### PR TITLE
Add cicd/tests framework + smoke suite

### DIFF
--- a/.claude/skills/ci-run/SKILL.md
+++ b/.claude/skills/ci-run/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: ci-run
+description: |
+  Execute android-wifi-mcp test cases against the attached Android device.
+  Use when the user wants to run tests, execute test cases, or verify MCP tool behavior end-to-end.
+disable-model-invocation: true
+---
+
+# Run android-wifi-mcp Test Cases
+
+Execute YAML test cases against the attached Android device using the MCP stdio transport.
+
+{{input}}
+
+## PURPOSE
+
+Run YAML test cases by spawning the MCP server over stdio, calling tools, and evaluating results.
+
+---
+
+## AGENT WORKFLOW
+
+### Step 1: Identify the scope
+
+Input can be:
+- A test ID (e.g., `TC-SMK-003`) — run that specific test
+- A suite name (e.g., `smoke`, `wifi`) — run the whole suite
+- A tag (e.g., `device`, `network`) — run all tests tagged with it
+- Empty — run everything
+
+### Step 2: Pre-flight checks
+
+Before running:
+- `adb devices` lists at least one `device`-state entry
+- `dist/index.js` exists at the repo root (run `npm run build` if not)
+- `cicd/tests/node_modules` exists (run `cd cicd/tests && npm install` if not)
+
+If any of those is missing, fix it and report what you did.
+
+### Step 3: Execute
+
+From the repo root:
+
+```bash
+cd cicd/tests && npx tsx src/cli.ts run --suite <suite>
+# or
+cd cicd/tests && npx tsx src/cli.ts run --id <TC-XXX-NNN>
+# or
+cd cicd/tests && npx tsx src/cli.ts run --tag <tag>
+```
+
+The runner streams progress to stderr and writes JSON results to `cicd/results/<timestamp>_<suite>/`.
+
+Per-test, the executor snapshots WiFi state before and restores after — even on failure — so a flaky test doesn't poison subsequent ones.
+
+### Step 4: Interpret results
+
+A non-zero exit code from the runner means at least one test failed. The console reporter prints a summary table; per-test JSON reports are in the results directory for deeper inspection.
+
+For a failing test:
+- Open `cicd/results/<timestamp>/<test-id>.json` for the full step-by-step trace
+- Common causes:
+  - Tool error → check the `stdout` field for the actual MCP response
+  - Pattern miss → confirm you used **bare strings** (see ci-testcase skill for the gotcha)
+  - Device state drift → confirm restore actually ran (look for `Restored device state` in the log)
+
+### Step 5: Report
+
+Output:
+- Pass/fail count
+- For failures: test ID, the failing step, and the first diagnostic line
+- Path to the results directory
+
+---
+
+## OUTPUT
+
+Test results summary plus the path to the JSON results for the run.

--- a/.claude/skills/ci-testcase/SKILL.md
+++ b/.claude/skills/ci-testcase/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: ci-testcase
+description: |
+  Generate YAML test cases from an issue or feature request that test android-wifi-mcp tools against an attached Android device.
+  Use when the user wants to create tests, generate test cases, or add test coverage for a feature.
+disable-model-invocation: true
+---
+
+# Create Test Case for android-wifi-mcp
+
+Generate a YAML test case file that exercises one or more MCP tools against the attached Android device.
+
+{{input}}
+
+## PURPOSE
+
+Read an issue (or a description of what to test) and emit YAML test case(s) under `cicd/tests/testcases/<suite>/` that verify behavior end-to-end via the MCP server's stdio entry point.
+
+---
+
+## AGENT WORKFLOW
+
+### Step 1: Identify the suite
+
+Pick the right suite for the test:
+
+| Suite | When |
+|---|---|
+| `smoke` | Read-only, fast, no device side-effects (status, scan, info, list, ping). Always-safe to run. |
+| `wifi` | Connect/disconnect/forget against a known test SSID. Stateful — relies on per-test snapshot/restore. |
+| `enterprise` | 802.1X / EAP flows. Needs RADIUS test fixtures + the companion app installed. |
+| `ui` | UI-automation primitives (tap/type/screenshot). Lands with #1. |
+| `portal` | Captive portal interaction. Lands with #4. |
+
+### Step 2: Identify what to test
+
+From the issue acceptance criteria, determine:
+- Which MCP tool(s) to call
+- What output fields prove success (use bare strings — see gotcha below)
+- What output indicates failure (typically `isError`)
+- Any env-var fixtures the test needs (SSID, password, etc.)
+
+### Step 3: Generate the YAML
+
+Create the file as `cicd/tests/testcases/<suite>/TC-<SUITE>-<NNN>.yml`:
+
+```yaml
+id: TC-WIFI-001
+name: <descriptive name>
+suite: wifi
+tags: [wifi]
+priority: 1
+timeout: 30000
+dependencies: []
+
+steps:
+  - name: <step description>
+    command: npx tsx cicd/tests/src/mcp-client.ts <tool_name> '{"arg":"value"}'
+    expectPatterns:
+      - "<bare string or regex — see gotcha>"
+    rejectPatterns:
+      - "isError"
+
+criteria: |
+  <Plain-language description of what this test verifies.>
+```
+
+**ID conventions:**
+- `TC-SMK-NNN` (smoke) · `TC-WIFI-NNN` (wifi) · `TC-ENT-NNN` (enterprise) · `TC-UI-NNN` (ui) · `TC-PRT-NNN` (portal)
+
+**Priority:** lower = runs first within the suite. Use it to enforce a sane order when tests within a suite have an implicit ordering (e.g. enable WiFi before scanning).
+
+### Step 4: Pattern-matching gotcha
+
+`mcp-client.ts` returns double-encoded JSON — the tool's JSON is inside a `text` field whose value has escaped quotes. **Use bare strings**, not quoted forms:
+
+- ✅ `connected.*true`
+- ✅ `hasInternet.*true`
+- ❌ `'"connected": true'` — won't match the escaped output `\"connected\": true`
+
+For the same reason, the canonical failure signal is the bare string `isError` (not `'"isError"'`).
+
+### Step 5: Env-var fixtures
+
+If the test needs credentials or SSIDs, reference them with `${TEST_...}`:
+
+```yaml
+command: npx tsx cicd/tests/src/mcp-client.ts wifi_connect '{"ssid":"${TEST_SSID_WPA2}","security":"wpa2","password":"${TEST_SSID_WPA2_PASSWORD}"}'
+```
+
+The executor expands `${VAR}` from the environment before running the command. Document any new env vars in `.env.example`.
+
+### Step 6: Per-test state restore
+
+The executor automatically snapshots the device's WiFi state before each test and forgets any networks added during the test. You don't need to write cleanup steps for added networks — but if your test changes other state (e.g., installs a certificate), add a teardown step.
+
+### Step 7: Report
+
+Show the user:
+- The created file paths
+- What each test verifies
+- Suggest: `cd cicd/tests && npm test -- --suite <suite>` to run them
+
+---
+
+## OUTPUT
+
+Paths to created test case files.

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,23 @@
+# ============ Test runner — picks the device when multiple are attached ============
+# TEST_DEVICE_SERIAL=R5CR12ATMCB
+
+# ============ ADB binary override (default: 'adb' on PATH) ============
+# ADB_PATH=/usr/bin/adb
+
+# ============ WiFi test fixtures (used by the wifi suite — not yet wired) ============
+# TEST_SSID_OPEN=
+# TEST_SSID_WPA2=
+# TEST_SSID_WPA2_PASSWORD=
+# TEST_SSID_WPA3=
+# TEST_SSID_WPA3_PASSWORD=
+
+# ============ Enterprise WiFi fixtures (used by the enterprise suite — not yet wired) ============
+# TEST_SSID_ENTERPRISE=
+# TEST_EAP_USERNAME=
+# TEST_EAP_PASSWORD=
+# TEST_EAP_DOMAIN=
+
+# ============ Captive portal fixtures (used by the portal suite — not yet wired) ============
+# TEST_PORTAL_SSID=
+# TEST_PORTAL_USERNAME=
+# TEST_PORTAL_PASSWORD=

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,27 @@
+name: Build
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type check
+        run: npx tsc --noEmit
+
+      - name: Build
+        run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,13 @@
+name: CI
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+
+  test-smoke:
+    needs: build
+    uses: ./.github/workflows/test-smoke.yml
+    secrets: inherit

--- a/.github/workflows/test-run.yml
+++ b/.github/workflows/test-run.yml
@@ -1,0 +1,33 @@
+name: Test Run (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Suite tag to filter tests (e.g. smoke)'
+        required: true
+        type: string
+
+jobs:
+  test:
+    runs-on: self-hosted
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install server dependencies
+        run: npm ci
+
+      - name: Build server
+        run: npm run build
+
+      - name: Install test dependencies
+        run: cd cicd/tests && npm install
+
+      - name: Run tests
+        run: |
+          cd cicd/tests
+          npx tsx src/cli.ts run --tag ${{ inputs.tag }} --format console
+        env:
+          TEST_DEVICE_SERIAL: ${{ secrets.TEST_DEVICE_SERIAL }}
+          ADB_PATH: ${{ secrets.ADB_PATH }}

--- a/.github/workflows/test-smoke.yml
+++ b/.github/workflows/test-smoke.yml
@@ -1,0 +1,12 @@
+name: "Test: Smoke"
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  test:
+    uses: ./.github/workflows/test-run.yml
+    with:
+      tag: smoke
+    secrets: inherit

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ dist/
 .env
 *.log
 .DS_Store
+
+# Test framework artifacts
+cicd/results/
+cicd/tests/dist/

--- a/README.md
+++ b/README.md
@@ -298,6 +298,55 @@ where adb  # Windows
 - Check `wifi_check_companion_app` returns success
 - Verify the domain suffix match is correct for your RADIUS server
 
+## Testing
+
+YAML-driven test framework under `cicd/tests/` runs against an attached Android device using the stdio transport.
+
+### Run smoke tests locally
+
+```bash
+# from repo root, one-time setup
+npm install && npm run build
+cd cicd/tests && npm install
+
+# run the smoke suite
+npm test                    # all tests
+npm run test:smoke          # smoke suite only
+npx tsx src/cli.ts list     # list available test cases
+npx tsx src/cli.ts run --id TC-SMK-001   # one specific test
+```
+
+Results land in `cicd/results/<timestamp>_<suite>/` (`summary.json` plus one `<test-id>.json` per test).
+
+### How the runner works
+
+- `mcp-client.ts` spawns `node dist/index.js --stdio`, calls one tool, prints the JSON result. Each test step is one such call.
+- `executor.ts` snapshots WiFi state (enabled flag, current SSID, saved-network IDs) before each test and restores it after — **per-test**, so a failing test cannot poison the next one. Snapshot/restore goes through `adb` directly so the framework doesn't depend on the very thing under test.
+- `simple-judge.ts` decides pass/fail from exit codes plus `expectPatterns`/`rejectPatterns`.
+
+### Test suites
+
+| Suite | What it covers |
+|---|---|
+| `smoke` | Read-only checks against existing tools — safe to run any time |
+| `wifi` | Connect/disconnect/forget against test SSIDs (env-driven) |
+| `enterprise` | 802.1X (PEAP/TTLS/TLS) — needs companion app + RADIUS test fixtures |
+| `ui` | UI-automation primitives — lands with the UI tools issue |
+| `portal` | Captive portal flows — lands with the portal tools issue |
+
+### Adding a new test case
+
+Use the `ci-testcase` skill (`.claude/skills/ci-testcase/SKILL.md`) — it generates a YAML in the right shape for the right suite. Pattern-matching gotcha: tool output is double-encoded JSON, so use **bare strings** in patterns (`connected.*true`, not `'"connected": true'`).
+
+### CI
+
+GitHub Actions workflows under `.github/workflows/`:
+
+- `build.yml` — runs on github-hosted runners, does `npm ci` + `tsc --noEmit` + `npm run build`. No device needed.
+- `test-run.yml` — reusable, `runs-on: self-hosted`, takes a `tag` input. Requires the runner to have `adb` installed and one Android device USB-attached.
+- `test-smoke.yml` — calls `test-run.yml` with `tag: smoke`.
+- `ci.yml` — orchestrator. **Manual trigger only** (`workflow_dispatch`) — chains build → test-smoke.
+
 ## Limitations
 
 - **Android 11+ Required**: The `cmd wifi` interface requires Android 11 (SDK 30) or higher
@@ -310,18 +359,33 @@ where adb  # Windows
 ```
 android-wifi-mcp/
 ├── src/
-│   ├── index.ts               # MCP server entry point
-│   ├── types.ts               # TypeScript interfaces
+│   ├── index.ts                # Entry — picks transport (HTTP / stdio)
+│   ├── server.ts               # MCP server factory + tool registrations
+│   ├── types.ts                # TypeScript interfaces
 │   ├── adb/
-│   │   ├── adb-client.ts      # ADB command wrapper
-│   │   ├── device-manager.ts  # Multi-device handling
-│   │   ├── wifi-commands.ts   # cmd wifi wrapper
-│   │   └── enterprise-wifi.ts # 802.1X enterprise WiFi
+│   │   ├── adb-client.ts       # ADB command wrapper
+│   │   ├── device-manager.ts   # Multi-device handling
+│   │   ├── wifi-commands.ts    # cmd wifi wrapper
+│   │   └── enterprise-wifi.ts  # 802.1X enterprise WiFi
 │   └── network/
-│       └── network-check.ts   # Network diagnostics
-├── companion-app/             # Android companion app for 802.1X
-│   ├── app/src/main/kotlin/   # Kotlin source files
-│   └── build.gradle.kts       # Gradle build config
+│       └── network-check.ts    # Network diagnostics
+├── companion-app/              # Android companion app for 802.1X
+│   ├── app/src/main/kotlin/    # Kotlin source files
+│   └── build.gradle.kts        # Gradle build config
+├── cicd/
+│   ├── tests/                  # YAML-driven test framework (see Testing)
+│   │   ├── src/
+│   │   │   ├── cli.ts
+│   │   │   ├── executor.ts     # per-test snapshot/restore of device state
+│   │   │   ├── device-state.ts # adb-direct snapshot/restore helpers
+│   │   │   ├── mcp-client.ts   # stdio MCP client
+│   │   │   ├── loader.ts, judge/, reporter/, types.ts, config.ts
+│   │   │   └── ...
+│   │   └── testcases/<suite>/  # smoke, wifi, enterprise, ui, portal
+│   └── results/                # JSON per-run results
+├── .github/workflows/          # build.yml, test-run.yml, test-smoke.yml, ci.yml
+├── .claude/skills/             # ci-testcase, ci-run
+├── .env.example
 ├── package.json
 ├── tsconfig.json
 └── README.md

--- a/cicd/tests/package-lock.json
+++ b/cicd/tests/package-lock.json
@@ -1,0 +1,2181 @@
+{
+  "name": "android-wifi-mcp-tests",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "android-wifi-mcp-tests",
+      "version": "1.0.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.12.0",
+        "chalk": "^5.3.0",
+        "commander": "^12.1.0",
+        "glob": "^10.3.10",
+        "js-yaml": "^4.1.0"
+      },
+      "devDependencies": {
+        "@types/js-yaml": "^4.0.9",
+        "@types/node": "^22.10.0",
+        "tsx": "^4.16.0",
+        "typescript": "^5.7.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "license": "MIT"
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
+      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.15",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
+      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/cicd/tests/package.json
+++ b/cicd/tests/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "android-wifi-mcp-tests",
+  "version": "1.0.0",
+  "description": "Test framework for android-wifi-mcp",
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "test": "tsx src/cli.ts run",
+    "test:smoke": "tsx src/cli.ts run --suite smoke",
+    "list": "tsx src/cli.ts list",
+    "dev": "tsx src/cli.ts"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.0",
+    "chalk": "^5.3.0",
+    "commander": "^12.1.0",
+    "glob": "^10.3.10",
+    "js-yaml": "^4.1.0"
+  },
+  "devDependencies": {
+    "@types/js-yaml": "^4.0.9",
+    "@types/node": "^22.10.0",
+    "tsx": "^4.16.0",
+    "typescript": "^5.7.0"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/cicd/tests/src/cli.ts
+++ b/cicd/tests/src/cli.ts
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+/**
+ * CLI for the test framework.
+ *
+ * Usage:
+ *   npx tsx src/cli.ts run [options]
+ *   npx tsx src/cli.ts list [options]
+ */
+
+import { Command } from 'commander';
+import path from 'path';
+import { mkdirSync, existsSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { TestLoader } from './loader.js';
+import { TestExecutor } from './executor.js';
+import { SimpleJudge } from './judge/index.js';
+import { JsonReporter, ConsoleReporter } from './reporter/index.js';
+import { RunConfig } from './types.js';
+
+const program = new Command();
+
+program
+  .name('android-wifi-mcp test-runner')
+  .description('Test framework for android-wifi-mcp')
+  .version('1.0.0');
+
+program
+  .command('run')
+  .description('Run test cases')
+  .option('-s, --suite <suite>', 'Run only tests from this suite')
+  .option('-t, --tag <tag>', 'Run only tests with this tag')
+  .option('-i, --id <id>', 'Run only the test with this ID')
+  .option('--dry-run', 'Show what would run without executing', false)
+  .option('-o, --output-dir <dir>', 'Output directory for results')
+  .option('-f, --format <format>', 'Output format (console, json)', 'console')
+  .action(async (options) => {
+    const startTime = new Date();
+
+    const here = path.dirname(fileURLToPath(import.meta.url));
+    const projectRoot = path.resolve(here, '..', '..', '..');
+    const testcasesDir = path.join(here, '..', 'testcases');
+
+    const timestamp = startTime.toISOString().replace(/[:.]/g, '-').substring(0, 19);
+    const suiteName = options.suite || options.tag || 'all';
+    const outputDir =
+      options.outputDir ||
+      path.join(here, '..', '..', 'results', `${timestamp}_${suiteName}`);
+
+    if (!existsSync(outputDir)) {
+      mkdirSync(outputDir, { recursive: true });
+    }
+
+    const config: RunConfig = {
+      suite: options.suite,
+      tag: options.tag,
+      testId: options.id,
+      dryRun: options.dryRun,
+      outputDir,
+      outputFormat: options.format as RunConfig['outputFormat'],
+      workingDir: projectRoot,
+    };
+
+    process.stderr.write(`\n[CONFIG] Project root: ${projectRoot}\n`);
+    process.stderr.write(`[CONFIG] Testcases: ${testcasesDir}\n`);
+    process.stderr.write(`[CONFIG] Output: ${outputDir}\n`);
+
+    const loader = new TestLoader(testcasesDir);
+    const allTestCases = await loader.loadAll();
+
+    if (allTestCases.length === 0) {
+      process.stderr.write('[ERROR] No test cases found\n');
+      process.exit(1);
+    }
+
+    let filteredTestCases = allTestCases;
+
+    if (config.suite) {
+      filteredTestCases = filteredTestCases.filter((tc) => tc.suite === config.suite);
+    }
+
+    if (config.tag) {
+      filteredTestCases = filteredTestCases.filter((tc) => tc.tags?.includes(config.tag!));
+    }
+
+    if (config.testId) {
+      filteredTestCases = filteredTestCases.filter((tc) => tc.id === config.testId);
+    }
+
+    if (filteredTestCases.length === 0) {
+      process.stderr.write('[ERROR] No matching test cases found\n');
+      process.exit(1);
+    }
+
+    const { tests: resolvedTestCases, autoIncluded } = loader.resolveDependencies(
+      filteredTestCases,
+      allTestCases
+    );
+
+    if (autoIncluded.length > 0) {
+      process.stderr.write(
+        `[INFO] Auto-included ${autoIncluded.length} dependency test(s): ${autoIncluded.join(', ')}\n`
+      );
+    }
+
+    const testCases = loader.sortByDependencies(resolvedTestCases);
+
+    process.stderr.write(`[INFO] Found ${testCases.length} test(s) to run\n`);
+
+    if (config.dryRun) {
+      process.stderr.write('\n[DRY RUN] Would execute:\n');
+      for (const tc of testCases) {
+        process.stderr.write(`  - ${tc.id}: ${tc.name} (${tc.suite})\n`);
+        for (const step of tc.steps) {
+          process.stderr.write(`      Step: ${step.name}\n`);
+        }
+      }
+      process.exit(0);
+    }
+
+    const executor = new TestExecutor(config);
+    const results = await executor.executeAll(testCases);
+
+    process.stderr.write('\n[JUDGE] Running simple judge...\n');
+    const simpleJudge = new SimpleJudge();
+    const judgments = simpleJudge.judgeAll(results);
+
+    const jsonReporter = new JsonReporter(outputDir);
+    const { summary, reports } = jsonReporter.generateReports(
+      results,
+      judgments,
+      startTime,
+      suiteName
+    );
+
+    jsonReporter.writeReports(summary, reports);
+
+    if (config.outputFormat === 'console') {
+      const consoleReporter = new ConsoleReporter();
+      consoleReporter.report(summary, reports);
+    } else if (config.outputFormat === 'json') {
+      jsonReporter.outputSummary(summary, reports);
+    }
+
+    process.exit(summary.failed > 0 ? 1 : 0);
+  });
+
+program
+  .command('list')
+  .description('List available test cases')
+  .option('-s, --suite <suite>', 'Filter by suite')
+  .action(async (options) => {
+    const here = path.dirname(fileURLToPath(import.meta.url));
+    const testcasesDir = path.join(here, '..', 'testcases');
+
+    const loader = new TestLoader(testcasesDir);
+    let testCases = await loader.loadAll();
+
+    if (options.suite) {
+      testCases = testCases.filter((tc) => tc.suite === options.suite);
+    }
+
+    testCases = loader.sortByDependencies(testCases);
+    const groups = loader.groupBySuite(testCases);
+
+    console.log('\nAvailable Test Cases:');
+    console.log('='.repeat(60));
+
+    for (const [suite, cases] of groups) {
+      console.log(`\n${suite.toUpperCase()} SUITE (${cases.length} tests):`);
+      for (const tc of cases) {
+        console.log(`  ${tc.id}: ${tc.name}`);
+        console.log(`    Priority: ${tc.priority}, Timeout: ${tc.timeout}ms`);
+        if (tc.dependencies.length > 0) {
+          console.log(`    Depends on: ${tc.dependencies.join(', ')}`);
+        }
+      }
+    }
+
+    console.log('\n' + '='.repeat(60));
+    console.log(`Total: ${testCases.length} test(s)`);
+  });
+
+program.parse();

--- a/cicd/tests/src/config.ts
+++ b/cicd/tests/src/config.ts
@@ -1,0 +1,30 @@
+/**
+ * Project configuration for the test framework.
+ */
+
+export const SUITES = ['smoke', 'wifi', 'enterprise', 'ui', 'portal'] as const;
+export type Suite = typeof SUITES[number];
+
+export const CONFIG = {
+  projectName: 'android-wifi-mcp',
+  defaultTimeout: 60000,
+  defaultStepTimeout: 30000,
+
+  logs: {
+    cleanupAge: 24 * 60 * 60 * 1000,
+    maxBuffer: 50 * 1024 * 1024,
+  },
+};
+
+export const ERROR_PATTERNS: RegExp[] = [
+  /\bError executing\b/i,
+  /\bUnknown tool\b/i,
+  /\bconnection refused\b/i,
+];
+
+export const ERROR_EXCLUSIONS: RegExp[] = [
+  /error.*handled/i,
+  /expected.*error/i,
+  /rejectPatterns/i,
+  /_idleTimeout/i,
+];

--- a/cicd/tests/src/device-state.ts
+++ b/cicd/tests/src/device-state.ts
@@ -1,0 +1,94 @@
+/**
+ * Device state snapshot/restore — runs adb directly (bypassing the MCP server)
+ * so test setup doesn't depend on the very thing under test.
+ *
+ * snapshot: WiFi enabled, currently-connected SSID (best-effort), saved-network IDs.
+ * restore:  match WiFi enabled state, forget any networks added during the test.
+ *
+ * We do NOT manually reconnect to the original SSID — Android auto-reconnects
+ * to known saved networks when WiFi comes up.
+ */
+
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
+
+export interface DeviceSnapshot {
+  wifiEnabled: boolean;
+  currentSsid: string | null;
+  savedNetworkIds: number[];
+}
+
+const ADB = process.env.ADB_PATH || 'adb';
+
+function adbArgs(): string {
+  const serial = process.env.TEST_DEVICE_SERIAL;
+  return serial ? `-s ${serial}` : '';
+}
+
+async function adbShell(cmd: string, timeout = 15000): Promise<string> {
+  const { stdout } = await execAsync(`${ADB} ${adbArgs()} shell ${cmd}`, { timeout });
+  return stdout;
+}
+
+export async function snapshotDeviceState(): Promise<DeviceSnapshot> {
+  const statusOut = await adbShell('cmd wifi status');
+  const wifiEnabled = /wifi is enabled/i.test(statusOut);
+
+  let currentSsid: string | null = null;
+  if (wifiEnabled) {
+    try {
+      const dumpsys = await adbShell('dumpsys wifi | grep -E "SSID:" | head -3');
+      const match = dumpsys.match(/SSID:\s*["']?([^"',\n]+)["']?/i);
+      if (match && match[1] && match[1] !== '<none>' && match[1].trim() !== '') {
+        currentSsid = match[1].trim();
+      }
+    } catch {
+      // Best-effort — leave null
+    }
+  }
+
+  const savedNetworkIds = await listSavedNetworkIds();
+
+  return { wifiEnabled, currentSsid, savedNetworkIds };
+}
+
+export async function restoreDeviceState(snapshot: DeviceSnapshot): Promise<void> {
+  // Match WiFi enabled state.
+  const currentStatus = await adbShell('cmd wifi status');
+  const isEnabled = /wifi is enabled/i.test(currentStatus);
+  if (snapshot.wifiEnabled && !isEnabled) {
+    await adbShell('cmd wifi set-wifi-enabled enabled');
+  } else if (!snapshot.wifiEnabled && isEnabled) {
+    await adbShell('cmd wifi set-wifi-enabled disabled');
+  }
+
+  // Forget any networks added during the test.
+  const currentIds = await listSavedNetworkIds();
+  const originalSet = new Set(snapshot.savedNetworkIds);
+  const added = currentIds.filter((id) => !originalSet.has(id));
+  for (const id of added) {
+    try {
+      await adbShell(`cmd wifi forget-network ${id}`);
+    } catch {
+      // Best-effort — a missing network ID is not fatal.
+    }
+  }
+}
+
+async function listSavedNetworkIds(): Promise<number[]> {
+  try {
+    const output = await adbShell('cmd wifi list-networks');
+    const ids = new Set<number>();
+    for (const line of output.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('Network Id')) continue;
+      const match = trimmed.match(/^(\d+)\s+/);
+      if (match) ids.add(parseInt(match[1], 10));
+    }
+    return Array.from(ids);
+  } catch {
+    return [];
+  }
+}

--- a/cicd/tests/src/executor.ts
+++ b/cicd/tests/src/executor.ts
@@ -1,0 +1,375 @@
+/**
+ * Test executor - orchestrates test execution with pattern matching.
+ *
+ * Adapted from ruckus1-mcp's executor.ts. Adds per-test snapshot/restore
+ * of Android device state so a failing test cannot poison subsequent tests.
+ */
+
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import { TestCase, TestResult, StepResult, PatternMatch, RunConfig } from './types.js';
+import { CONFIG } from './config.js';
+import {
+  snapshotDeviceState,
+  restoreDeviceState,
+  DeviceSnapshot,
+} from './device-state.js';
+
+const execAsync = promisify(exec);
+
+function stripAnsi(str: string): string {
+  return str.replace(
+    /\x1b\[[0-9;?]*[a-zA-Z]|\x1b\][^\x07]*\x07|\x1b[()][AB012]|\x1b[a-zA-Z]/g,
+    ''
+  );
+}
+
+export class TestExecutor {
+  private config: RunConfig;
+  private totalTests: number = 0;
+  private currentTest: number = 0;
+  private currentTestId: string | null = null;
+  private variables: Record<string, string> = {};
+  // Per-run unique suffix used by YAMLs to namespace resources where needed.
+  // Prefers GITHUB_RUN_ID in CI for traceability; falls back to TEST_RUN_ID
+  // override or a random 6-char string locally.
+  private readonly runId: string;
+
+  constructor(config: RunConfig) {
+    this.config = config;
+    const raw =
+      process.env.GITHUB_RUN_ID ||
+      process.env.TEST_RUN_ID ||
+      Math.random().toString(36).slice(2, 8);
+    this.runId = raw.slice(-6);
+  }
+
+  private substituteVariables(command: string): string {
+    return command.replace(/\{\{(\w+)\}\}/g, (_match, varName) => {
+      if (varName === 'TEST_RUN_ID') return this.runId;
+      const value = this.variables[varName] ?? process.env[varName];
+      if (value === undefined) {
+        throw new Error(
+          `Undefined variable {{${varName}}} — not set by any prior capture or environment`
+        );
+      }
+      return value;
+    });
+  }
+
+  /**
+   * Resolve a dot-notation path with optional array find syntax.
+   * Supports: "field", "nested.field", "data[name=foo].id"
+   */
+  private resolvePath(obj: any, fieldPath: string): any {
+    const segments = fieldPath.match(/[^.]+/g) || [];
+    let current = obj;
+
+    for (const segment of segments) {
+      if (current === undefined || current === null) return undefined;
+
+      const rootArrayMatch = segment.match(/^\$\[(\w+)=(.+)\]$/);
+      if (rootArrayMatch) {
+        const [, matchKey, matchValue] = rootArrayMatch;
+        if (!Array.isArray(current)) return undefined;
+        current = current.find((item: any) => String(item[matchKey]) === matchValue);
+        continue;
+      }
+
+      const arrayMatch = segment.match(/^(\w+)\[(\w+)=(.+)\]$/);
+      if (arrayMatch) {
+        const [, arrayField, matchKey, matchValue] = arrayMatch;
+        const arr = current[arrayField];
+        if (!Array.isArray(arr)) return undefined;
+        current = arr.find((item: any) => String(item[matchKey]) === matchValue);
+      } else {
+        current = current[segment];
+      }
+    }
+
+    return current;
+  }
+
+  private captureVariables(step: TestCase['steps'][0], result: StepResult): void {
+    if (!step.capture || result.exitCode !== 0) return;
+
+    try {
+      const mcpResponse = JSON.parse(result.stdout);
+      const innerText = mcpResponse?.content?.[0]?.text;
+      if (!innerText) return;
+
+      const toolResponse = JSON.parse(innerText);
+
+      for (const [varName, fieldPath] of Object.entries(step.capture)) {
+        const resolvedPath = this.substituteVariables(fieldPath);
+        const value = this.resolvePath(toolResponse, resolvedPath);
+        if (value !== undefined) {
+          this.variables[varName] = String(value);
+          this.progress(`    Captured: ${varName} = ${String(value).substring(0, 60)}`);
+        } else {
+          this.progress(`    [WARN] Capture field '${fieldPath}' not found in response`);
+        }
+      }
+    } catch (e) {
+      this.progress(`    [WARN] Failed to capture variables: ${e}`);
+    }
+  }
+
+  private progress(msg: string): void {
+    process.stderr.write(msg + '\n');
+  }
+
+  private async executeStep(
+    step: { name: string; command: string; timeout?: number },
+    defaultTimeout: number
+  ): Promise<StepResult> {
+    const startTime = Date.now();
+    let stdout = '';
+    let stderr = '';
+    let exitCode = 0;
+    let timedOut = false;
+
+    const timeout = step.timeout || defaultTimeout;
+
+    const env = { ...process.env };
+    if (this.currentTestId) {
+      env.TEST_ID = this.currentTestId;
+    }
+
+    try {
+      const result = await execAsync(step.command, {
+        cwd: this.config.workingDir,
+        timeout,
+        maxBuffer: CONFIG.logs.maxBuffer,
+        shell: '/bin/bash',
+        env,
+      });
+      stdout = result.stdout;
+      stderr = result.stderr;
+    } catch (error: unknown) {
+      const err = error as {
+        stdout?: string;
+        stderr?: string;
+        message?: string;
+        code?: number;
+        killed?: boolean;
+      };
+      stdout = err.stdout || '';
+      stderr = err.stderr || err.message || 'Unknown error';
+      exitCode = err.code || 1;
+      timedOut = err.killed === true;
+    }
+
+    const duration = Date.now() - startTime;
+
+    stdout = stripAnsi(stdout);
+    stderr = stripAnsi(stderr);
+
+    if (timedOut) {
+      stderr = `[TIMEOUT] Command killed after ${timeout / 1000}s\n\n${stderr}`;
+    }
+
+    return {
+      name: step.name,
+      command: step.command,
+      stdout,
+      stderr,
+      exitCode,
+      duration,
+    };
+  }
+
+  private checkPatterns(
+    result: StepResult,
+    expectPatterns?: string[],
+    rejectPatterns?: string[]
+  ): StepResult['patternMatches'] {
+    if (!expectPatterns && !rejectPatterns) {
+      return undefined;
+    }
+
+    const combined = result.stdout + '\n' + result.stderr;
+
+    const expected: PatternMatch[] = (expectPatterns || []).map((pattern) => {
+      try {
+        const resolved = this.substituteVariables(pattern);
+        return { pattern: resolved, found: new RegExp(resolved, 'i').test(combined) };
+      } catch (e) {
+        const msg = (e as Error).message;
+        return { pattern: `[UNDEFINED] ${pattern} — ${msg}`, found: false };
+      }
+    });
+
+    const rejected: PatternMatch[] = (rejectPatterns || []).map((pattern) => {
+      try {
+        const resolved = this.substituteVariables(pattern);
+        return { pattern: resolved, found: new RegExp(resolved, 'i').test(combined) };
+      } catch (e) {
+        const msg = (e as Error).message;
+        return { pattern: `[UNDEFINED] ${pattern} — ${msg}`, found: true };
+      }
+    });
+
+    return { expected, rejected };
+  }
+
+  async executeTestCase(testCase: TestCase): Promise<TestResult> {
+    const startTime = Date.now();
+    const stepResults: StepResult[] = [];
+    const timestamp = new Date().toISOString().substring(11, 19);
+
+    this.currentTest++;
+    this.currentTestId = testCase.id;
+    this.variables = {};
+    this.progress(
+      `[${timestamp}] [${this.currentTest}/${this.totalTests}] ${testCase.id}: ${testCase.name}`
+    );
+
+    // Snapshot device state before the test. Per-test, not per-suite —
+    // a failing test must not poison subsequent ones.
+    let snapshot: DeviceSnapshot | null = null;
+    try {
+      snapshot = await snapshotDeviceState();
+      this.progress(
+        `    Snapshot: wifiEnabled=${snapshot.wifiEnabled}, ssid=${snapshot.currentSsid ?? '<none>'}, savedNetworks=${snapshot.savedNetworkIds.length}`
+      );
+    } catch (e) {
+      this.progress(`    [WARN] Snapshot failed: ${(e as Error).message}`);
+    }
+
+    for (let i = 0; i < testCase.steps.length; i++) {
+      const step = testCase.steps[i];
+      const stepTimestamp = new Date().toISOString().substring(11, 19);
+
+      this.progress(
+        `  [${stepTimestamp}] Step ${i + 1}/${testCase.steps.length}: ${step.name}`
+      );
+
+      let resolvedCommand: string;
+      try {
+        resolvedCommand = this.substituteVariables(step.command);
+      } catch (e) {
+        const msg = (e as Error).message;
+        const synthetic: StepResult = {
+          name: step.name,
+          command: step.command,
+          stdout: '',
+          stderr: `[SUBSTITUTION FAILED] ${msg}`,
+          exitCode: 1,
+          duration: 0,
+        };
+        this.progress(`    [FAIL] Substitution: ${msg}`);
+        stepResults.push(synthetic);
+        continue;
+      }
+
+      const cmdPreview =
+        resolvedCommand.length > 80
+          ? resolvedCommand.substring(0, 80) + '...'
+          : resolvedCommand;
+      this.progress(`    Command: ${cmdPreview}`);
+
+      const resolvedStep = { ...step, command: resolvedCommand };
+      const result = await this.executeStep(resolvedStep, testCase.timeout);
+
+      result.patternMatches = this.checkPatterns(
+        result,
+        step.expectPatterns,
+        step.rejectPatterns
+      );
+
+      this.captureVariables(step, result);
+
+      stepResults.push(result);
+
+      const status = result.exitCode === 0 ? '[PASS]' : '[FAIL]';
+      const duration = `${(result.duration / 1000).toFixed(1)}s`;
+      this.progress(`    ${status} Exit: ${result.exitCode} (${duration})`);
+
+      if (result.patternMatches) {
+        const expectedMissing = result.patternMatches.expected.filter(
+          (p) => !p.found
+        );
+        const rejectedFound = result.patternMatches.rejected.filter(
+          (p) => p.found
+        );
+        if (expectedMissing.length > 0) {
+          this.progress(
+            `    Missing patterns: ${expectedMissing.map((p) => p.pattern).join(', ')}`
+          );
+        }
+        if (rejectedFound.length > 0) {
+          this.progress(
+            `    Rejected patterns found: ${rejectedFound.map((p) => p.pattern).join(', ')}`
+          );
+        }
+      }
+
+      if (result.exitCode !== 0 && result.stderr) {
+        const errorPreview = result.stderr.split('\n')[0].substring(0, 100);
+        this.progress(`    Error: ${errorPreview}`);
+      }
+    }
+
+    // Restore device state. Always attempt — even after failures.
+    if (snapshot) {
+      try {
+        await restoreDeviceState(snapshot);
+        this.progress(`    Restored device state`);
+      } catch (e) {
+        this.progress(`    [WARN] Restore failed: ${(e as Error).message}`);
+      }
+    }
+
+    const totalDuration = Date.now() - startTime;
+
+    const logs = stepResults
+      .map(
+        (r) =>
+          `=== Step: ${r.name} ===
+Command: ${r.command}
+Exit Code: ${r.exitCode}
+Duration: ${r.duration}ms
+
+STDOUT:
+${r.stdout || '(empty)'}
+
+STDERR:
+${r.stderr || '(empty)'}
+`
+      )
+      .join('\n' + '='.repeat(50) + '\n');
+
+    this.currentTestId = null;
+
+    return {
+      testCase,
+      steps: stepResults,
+      totalDuration,
+      logs,
+      logFile: '',
+    };
+  }
+
+  async executeAll(testCases: TestCase[]): Promise<TestResult[]> {
+    const results: TestResult[] = [];
+
+    this.totalTests = testCases.length;
+    this.currentTest = 0;
+
+    const startTimestamp = new Date().toISOString().substring(11, 19);
+    this.progress(`\n[${startTimestamp}] Starting ${this.totalTests} test(s)...`);
+    this.progress('-'.repeat(60));
+
+    for (const tc of testCases) {
+      const result = await this.executeTestCase(tc);
+      results.push(result);
+    }
+
+    const endTimestamp = new Date().toISOString().substring(11, 19);
+    this.progress('-'.repeat(60));
+    this.progress(`[${endTimestamp}] Execution complete: ${results.length} test(s)`);
+
+    return results;
+  }
+}

--- a/cicd/tests/src/judge/index.ts
+++ b/cicd/tests/src/judge/index.ts
@@ -1,0 +1,1 @@
+export { SimpleJudge } from './simple-judge.js';

--- a/cicd/tests/src/judge/simple-judge.ts
+++ b/cicd/tests/src/judge/simple-judge.ts
@@ -1,0 +1,69 @@
+/**
+ * Simple Judge — fast, deterministic verification based on:
+ * 1. Exit codes (all steps must return 0)
+ * 2. Pattern matching (expected patterns found, rejected patterns absent)
+ * 3. Error pattern detection in logs
+ */
+
+import { TestResult, Judgment } from '../types.js';
+import { ERROR_PATTERNS, ERROR_EXCLUSIONS } from '../config.js';
+
+export class SimpleJudge {
+  judge(result: TestResult): Judgment {
+    const reasons: string[] = [];
+    let pass = true;
+
+    const failedSteps = result.steps.filter((s) => s.exitCode !== 0);
+    if (failedSteps.length > 0) {
+      pass = false;
+      reasons.push(
+        `${failedSteps.length} step(s) failed with non-zero exit code: ${failedSteps.map((s) => `${s.name}(${s.exitCode})`).join(', ')}`
+      );
+    }
+
+    for (const step of result.steps) {
+      if (step.patternMatches) {
+        const missing = step.patternMatches.expected.filter((p) => !p.found);
+        if (missing.length > 0) {
+          pass = false;
+          reasons.push(
+            `Step "${step.name}" missing expected patterns: ${missing.map((p) => p.pattern).join(', ')}`
+          );
+        }
+
+        const found = step.patternMatches.rejected.filter((p) => p.found);
+        if (found.length > 0) {
+          pass = false;
+          reasons.push(
+            `Step "${step.name}" found rejected patterns: ${found.map((p) => p.pattern).join(', ')}`
+          );
+        }
+      }
+    }
+
+    const combinedLogs = result.logs + '\n' + result.steps.map((s) => s.stdout + s.stderr).join('\n');
+
+    for (const pattern of ERROR_PATTERNS) {
+      if (pattern.test(combinedLogs)) {
+        const isExcluded = ERROR_EXCLUSIONS.some((exc) => exc.test(combinedLogs));
+        if (!isExcluded) {
+          pass = false;
+          reasons.push(`Error pattern detected: ${pattern.source}`);
+          break;
+        }
+      }
+    }
+
+    return {
+      testId: result.testCase.id,
+      pass,
+      reason: pass
+        ? 'All steps passed with exit code 0, patterns matched, no errors'
+        : reasons.join('; '),
+    };
+  }
+
+  judgeAll(results: TestResult[]): Judgment[] {
+    return results.map((r) => this.judge(r));
+  }
+}

--- a/cicd/tests/src/loader.ts
+++ b/cicd/tests/src/loader.ts
@@ -1,0 +1,191 @@
+/**
+ * Test case loader - reads YAML test definitions and provides
+ * filtering, sorting, and grouping capabilities.
+ */
+
+import { readFileSync } from 'fs';
+import { glob } from 'glob';
+import yaml from 'js-yaml';
+import path from 'path';
+import { TestCase, TestStep } from './types.js';
+import { SUITES, CONFIG } from './config.js';
+
+export class TestLoader {
+  private testcasesDir: string;
+
+  constructor(testcasesDir: string) {
+    this.testcasesDir = testcasesDir;
+  }
+
+  async loadAll(): Promise<TestCase[]> {
+    const pattern = path.join(this.testcasesDir, '**/*.yml');
+    const files = await glob(pattern);
+
+    const testCases: TestCase[] = [];
+
+    for (const file of files) {
+      try {
+        const content = readFileSync(file, 'utf-8');
+        const raw = yaml.load(content) as Record<string, unknown>;
+        const testCase = this.validateAndNormalize(raw, file);
+        if (testCase) {
+          testCases.push(testCase);
+        }
+      } catch (error) {
+        console.error(`Failed to load ${file}:`, error);
+      }
+    }
+
+    return testCases;
+  }
+
+  async loadBySuite(suite: string): Promise<TestCase[]> {
+    const all = await this.loadAll();
+    return all.filter((tc) => tc.suite === suite);
+  }
+
+  async loadById(id: string): Promise<TestCase | undefined> {
+    const all = await this.loadAll();
+    return all.find((tc) => tc.id === id);
+  }
+
+  sortByDependencies(testCases: TestCase[]): TestCase[] {
+    const sorted: TestCase[] = [];
+    const visited = new Set<string>();
+    const idMap = new Map(testCases.map((tc) => [tc.id, tc]));
+
+    const visit = (tc: TestCase) => {
+      if (visited.has(tc.id)) return;
+      visited.add(tc.id);
+
+      for (const depId of tc.dependencies) {
+        const dep = idMap.get(depId);
+        if (dep) visit(dep);
+      }
+
+      sorted.push(tc);
+    };
+
+    const byPriority = [...testCases].sort((a, b) => a.priority - b.priority);
+    for (const tc of byPriority) {
+      visit(tc);
+    }
+
+    return sorted;
+  }
+
+  resolveDependencies(
+    filteredTests: TestCase[],
+    allTests: TestCase[]
+  ): { tests: TestCase[]; autoIncluded: string[] } {
+    const filteredIds = new Set(filteredTests.map((tc) => tc.id));
+    const allTestsMap = new Map(allTests.map((tc) => [tc.id, tc]));
+    const result = new Map<string, TestCase>();
+    const autoIncluded: string[] = [];
+
+    const collectWithDeps = (testId: string) => {
+      if (result.has(testId)) return;
+
+      const test = allTestsMap.get(testId);
+      if (!test) {
+        process.stderr.write(`[WARN] Dependency ${testId} not found\n`);
+        return;
+      }
+
+      for (const depId of test.dependencies) {
+        collectWithDeps(depId);
+      }
+
+      result.set(testId, test);
+
+      if (!filteredIds.has(testId)) {
+        autoIncluded.push(testId);
+      }
+    };
+
+    for (const test of filteredTests) {
+      collectWithDeps(test.id);
+    }
+
+    return { tests: Array.from(result.values()), autoIncluded };
+  }
+
+  groupBySuite(testCases: TestCase[]): Map<string, TestCase[]> {
+    const groups = new Map<string, TestCase[]>();
+
+    for (const suite of SUITES) {
+      groups.set(suite, []);
+    }
+
+    for (const tc of testCases) {
+      const suite = tc.suite;
+      if (!groups.has(suite)) {
+        groups.set(suite, []);
+      }
+      groups.get(suite)!.push(tc);
+    }
+
+    for (const [suite, cases] of groups) {
+      if (cases.length === 0) {
+        groups.delete(suite);
+      }
+    }
+
+    return groups;
+  }
+
+  private validateAndNormalize(
+    raw: Record<string, unknown>,
+    filePath: string
+  ): TestCase | null {
+    if (!raw.id || typeof raw.id !== 'string') {
+      console.error(`${filePath}: missing or invalid 'id' field`);
+      return null;
+    }
+    if (!raw.name || typeof raw.name !== 'string') {
+      console.error(`${filePath}: missing or invalid 'name' field`);
+      return null;
+    }
+    if (!raw.suite || typeof raw.suite !== 'string') {
+      console.error(`${filePath}: missing or invalid 'suite' field`);
+      return null;
+    }
+    if (!raw.steps || !Array.isArray(raw.steps) || raw.steps.length === 0) {
+      console.error(`${filePath}: missing or empty 'steps' array`);
+      return null;
+    }
+
+    const steps: TestStep[] = [];
+    for (const step of raw.steps) {
+      if (!step.name || typeof step.name !== 'string') {
+        console.error(`${filePath}: step missing 'name' field`);
+        return null;
+      }
+      if (!step.command || typeof step.command !== 'string') {
+        console.error(`${filePath}: step '${step.name}' missing 'command' field`);
+        return null;
+      }
+
+      steps.push({
+        name: step.name,
+        command: step.command,
+        timeout: typeof step.timeout === 'number' ? step.timeout : undefined,
+        expectPatterns: Array.isArray(step.expectPatterns) ? step.expectPatterns : undefined,
+        rejectPatterns: Array.isArray(step.rejectPatterns) ? step.rejectPatterns : undefined,
+        capture: typeof step.capture === 'object' && step.capture !== null ? step.capture : undefined,
+      });
+    }
+
+    return {
+      id: raw.id as string,
+      name: raw.name as string,
+      suite: raw.suite as string,
+      tags: Array.isArray(raw.tags) ? raw.tags : undefined,
+      priority: typeof raw.priority === 'number' ? raw.priority : 1,
+      timeout: typeof raw.timeout === 'number' ? raw.timeout : CONFIG.defaultTimeout,
+      dependencies: Array.isArray(raw.dependencies) ? raw.dependencies : [],
+      steps,
+      criteria: typeof raw.criteria === 'string' ? raw.criteria : '',
+    };
+  }
+}

--- a/cicd/tests/src/mcp-client.ts
+++ b/cicd/tests/src/mcp-client.ts
@@ -1,0 +1,38 @@
+#!/usr/bin/env npx tsx
+/**
+ * Lightweight MCP client CLI for integration testing.
+ * Spawns the MCP server over stdio, calls a tool, prints the result as JSON.
+ *
+ * Usage: npx tsx cicd/tests/src/mcp-client.ts <tool_name> '<json_args>'
+ */
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const [toolName, argsJson] = process.argv.slice(2);
+if (!toolName) {
+  console.error('Usage: mcp-client.ts <tool_name> [json_args]');
+  process.exit(1);
+}
+
+const args = argsJson ? JSON.parse(argsJson) : {};
+
+// Resolve dist/index.js relative to this file so the client works from any CWD.
+const here = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(here, '..', '..', '..');
+const serverEntry = path.join(projectRoot, 'dist', 'index.js');
+
+const transport = new StdioClientTransport({
+  command: 'node',
+  args: [serverEntry, '--stdio'],
+  env: { ...process.env } as Record<string, string>,
+});
+
+const client = new Client({ name: 'android-wifi-mcp-test-client', version: '1.0.0' });
+await client.connect(transport);
+
+const result = await client.callTool({ name: toolName, arguments: args });
+console.log(JSON.stringify(result, null, 2));
+
+await client.close();

--- a/cicd/tests/src/reporter/console.ts
+++ b/cicd/tests/src/reporter/console.ts
@@ -1,0 +1,60 @@
+/**
+ * Console Reporter — outputs test results to terminal with formatting.
+ */
+
+import chalk from 'chalk';
+import { TestReport, TestSummary } from '../types.js';
+
+export class ConsoleReporter {
+  private formatDuration(ms: number): string {
+    if (ms < 1000) return `${ms}ms`;
+    if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`;
+    return `${(ms / 60000).toFixed(1)}min`;
+  }
+
+  report(summary: TestSummary, reports: TestReport[]): void {
+    console.log('\n' + '='.repeat(60));
+    console.log(chalk.bold('Test Results'));
+    console.log('='.repeat(60));
+
+    for (const report of reports) {
+      const status = report.pass
+        ? chalk.green.bold('[PASS]')
+        : chalk.red.bold('[FAIL]');
+
+      console.log(`\n${status} ${report.testId}: ${report.name}`);
+      console.log(`  Suite: ${report.suite}`);
+      console.log(`  Duration: ${this.formatDuration(report.duration)}`);
+      console.log(`  Reason: ${report.reason}`);
+
+      if (report.logFile) {
+        console.log(`  Log file: ${report.logFile}`);
+      }
+    }
+
+    console.log('\n' + '='.repeat(60));
+    console.log(chalk.bold('Summary'));
+    console.log('='.repeat(60));
+
+    const passColor = summary.passed === summary.total ? chalk.green : chalk.yellow;
+    console.log(
+      `Total: ${summary.total} | ` +
+        passColor(`Passed: ${summary.passed}`) +
+        ` | ` +
+        chalk.red(`Failed: ${summary.failed}`)
+    );
+
+    console.log(`Duration: ${this.formatDuration(summary.duration)}`);
+    console.log(`Output: ${summary.runId}`);
+
+    console.log('\n' + '='.repeat(60));
+    if (summary.failed === 0) {
+      console.log(chalk.green.bold('All tests passed!'));
+    } else {
+      console.log(
+        chalk.red.bold(`${summary.failed} test(s) failed.`)
+      );
+    }
+    console.log('='.repeat(60) + '\n');
+  }
+}

--- a/cicd/tests/src/reporter/index.ts
+++ b/cicd/tests/src/reporter/index.ts
@@ -1,0 +1,2 @@
+export { JsonReporter } from './json.js';
+export { ConsoleReporter } from './console.js';

--- a/cicd/tests/src/reporter/json.ts
+++ b/cicd/tests/src/reporter/json.ts
@@ -1,0 +1,109 @@
+/**
+ * JSON Reporter — outputs test results as JSON files.
+ */
+
+import { writeFileSync, mkdirSync, existsSync } from 'fs';
+import { hostname } from 'os';
+import path from 'path';
+import { TestResult, TestReport, TestSummary, Judgment, StepReportEntry } from '../types.js';
+
+export class JsonReporter {
+  private outputDir: string;
+
+  constructor(outputDir: string) {
+    this.outputDir = outputDir;
+    if (!existsSync(outputDir)) {
+      mkdirSync(outputDir, { recursive: true });
+    }
+  }
+
+  generateReports(
+    results: TestResult[],
+    judgments: Judgment[],
+    startTime: Date,
+    suite: string
+  ): { summary: TestSummary; reports: TestReport[] } {
+    const endTime = new Date();
+    const duration = endTime.getTime() - startTime.getTime();
+
+    const judgmentMap = new Map(judgments.map((j) => [j.testId, j]));
+
+    const reports: TestReport[] = results.map((result) => {
+      const judgment = judgmentMap.get(result.testCase.id) || {
+        testId: result.testCase.id,
+        pass: false,
+        reason: 'No judgment',
+      };
+
+      const steps: StepReportEntry[] = result.steps.map((step) => ({
+        name: step.name,
+        command: step.command,
+        exitCode: step.exitCode,
+        duration: step.duration,
+        stdout: step.stdout,
+        stderr: step.stderr,
+        pass: step.exitCode === 0,
+      }));
+
+      return {
+        testId: result.testCase.id,
+        name: result.testCase.name,
+        suite: result.testCase.suite,
+        pass: judgment.pass,
+        reason: judgment.reason,
+        duration: result.totalDuration,
+        steps,
+        logFile: result.logFile,
+        judgment,
+      };
+    });
+
+    const passed = reports.filter((r) => r.pass).length;
+
+    const summary: TestSummary = {
+      runId: startTime.toISOString(),
+      suite,
+      timestamp: startTime.toISOString(),
+      duration,
+      total: results.length,
+      passed,
+      failed: results.length - passed,
+      environment: {
+        hostname: hostname(),
+        nodeVersion: process.version,
+      },
+      tests: results.map((r) => r.testCase.id),
+    };
+
+    return { summary, reports };
+  }
+
+  writeReports(summary: TestSummary, reports: TestReport[]): void {
+    const summaryPath = path.join(this.outputDir, 'summary.json');
+    writeFileSync(summaryPath, JSON.stringify(summary, null, 2));
+
+    for (const report of reports) {
+      const reportPath = path.join(this.outputDir, `${report.testId}.json`);
+      writeFileSync(reportPath, JSON.stringify(report, null, 2));
+    }
+
+    process.stderr.write(`\n[JSON] Results written to ${this.outputDir}/\n`);
+  }
+
+  outputSummary(summary: TestSummary, reports: TestReport[]): void {
+    const output = {
+      summary,
+      results: reports.map((r) => ({
+        testId: r.testId,
+        name: r.name,
+        suite: r.suite,
+        pass: r.pass,
+        reason: r.reason,
+        duration: r.duration,
+        steps: r.steps,
+        judgment: r.judgment,
+      })),
+    };
+    console.log(JSON.stringify(output, null, 2));
+  }
+}

--- a/cicd/tests/src/types.ts
+++ b/cicd/tests/src/types.ts
@@ -1,0 +1,110 @@
+/**
+ * TypeScript interfaces for the test framework.
+ */
+
+export interface TestStep {
+  name: string;
+  command: string;
+  timeout?: number;
+  expectPatterns?: string[];
+  rejectPatterns?: string[];
+  capture?: Record<string, string>;
+}
+
+export interface TestCase {
+  id: string;
+  name: string;
+  suite: string;
+  tags?: string[];
+  priority: number;
+  timeout: number;
+  dependencies: string[];
+  steps: TestStep[];
+  criteria: string;
+  goal?: string;
+}
+
+export interface PatternMatch {
+  pattern: string;
+  found: boolean;
+}
+
+export interface StepResult {
+  name: string;
+  command: string;
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+  duration: number;
+  patternMatches?: {
+    expected: PatternMatch[];
+    rejected: PatternMatch[];
+  };
+}
+
+export interface TestResult {
+  testCase: TestCase;
+  steps: StepResult[];
+  totalDuration: number;
+  logs: string;
+  logFile: string;
+}
+
+export interface Judgment {
+  testId: string;
+  pass: boolean;
+  reason: string;
+  evidence?: string;
+}
+
+export interface StepReportEntry {
+  name: string;
+  command: string;
+  exitCode: number;
+  duration: number;
+  stdout: string;
+  stderr: string;
+  pass: boolean;
+}
+
+export interface TestReport {
+  testId: string;
+  name: string;
+  suite: string;
+  pass: boolean;
+  reason: string;
+  duration: number;
+  steps: StepReportEntry[];
+  logFile: string;
+  judgment: Judgment;
+}
+
+export interface TestSummary {
+  runId: string;
+  suite: string;
+  timestamp: string;
+  duration: number;
+  total: number;
+  passed: number;
+  failed: number;
+  environment: {
+    hostname: string;
+    nodeVersion: string;
+  };
+  tests: string[];
+}
+
+export interface RunConfig {
+  suite?: string;
+  tag?: string;
+  testId?: string;
+  dryRun: boolean;
+  outputDir: string;
+  outputFormat: 'console' | 'json';
+  workingDir: string;
+}
+
+export const DEFAULT_CONFIG: Partial<RunConfig> = {
+  dryRun: false,
+  outputFormat: 'console',
+};

--- a/cicd/tests/testcases/smoke/TC-SMK-001.yml
+++ b/cicd/tests/testcases/smoke/TC-SMK-001.yml
@@ -1,0 +1,23 @@
+id: TC-SMK-001
+name: device_list returns the attached Android device
+suite: smoke
+tags: [smoke, device]
+priority: 1
+timeout: 30000
+dependencies: []
+
+steps:
+  - name: List connected Android devices
+    command: npx tsx cicd/tests/src/mcp-client.ts device_list '{}'
+    expectPatterns:
+      - "devices"
+      - "serial"
+      - "selectedDevice"
+    rejectPatterns:
+      - "isError"
+
+criteria: |
+  Verify device_list returns a non-empty list of devices and a selected device.
+  - Tool returns successfully without errors
+  - Response contains the devices array and a selectedDevice field
+  - Confirms ADB is reachable and at least one device is attached

--- a/cicd/tests/testcases/smoke/TC-SMK-002.yml
+++ b/cicd/tests/testcases/smoke/TC-SMK-002.yml
@@ -1,0 +1,24 @@
+id: TC-SMK-002
+name: device_info reports a supported Android version (SDK >= 30)
+suite: smoke
+tags: [smoke, device]
+priority: 2
+timeout: 30000
+dependencies: []
+
+steps:
+  - name: Get device info
+    command: npx tsx cicd/tests/src/mcp-client.ts device_info '{}'
+    expectPatterns:
+      - "sdkVersion"
+      - "androidVersion"
+      - "supported.*true"
+    rejectPatterns:
+      - "isError"
+      - "supported.*false"
+
+criteria: |
+  Verify device_info returns a device with SDK >= 30 (Android 11+).
+  - Tool returns successfully without errors
+  - Response contains sdkVersion and androidVersion fields
+  - The compatibility.supported flag is true (deviceManager checks SDK >= 30)

--- a/cicd/tests/testcases/smoke/TC-SMK-003.yml
+++ b/cicd/tests/testcases/smoke/TC-SMK-003.yml
@@ -1,0 +1,24 @@
+id: TC-SMK-003
+name: wifi_status returns enabled and connected
+suite: smoke
+tags: [smoke, wifi]
+priority: 3
+timeout: 30000
+dependencies: []
+
+steps:
+  - name: Get current WiFi status
+    command: npx tsx cicd/tests/src/mcp-client.ts wifi_status '{}'
+    expectPatterns:
+      - "enabled.*true"
+      - "connected.*true"
+      - "ssid"
+    rejectPatterns:
+      - "isError"
+
+criteria: |
+  Verify wifi_status reports the device is on WiFi.
+  - Tool returns successfully without errors
+  - enabled is true and connected is true
+  - An ssid field is present
+  - Smoke runner expects the test device to already be on a WiFi network

--- a/cicd/tests/testcases/smoke/TC-SMK-004.yml
+++ b/cicd/tests/testcases/smoke/TC-SMK-004.yml
@@ -1,0 +1,24 @@
+id: TC-SMK-004
+name: wifi_scan returns at least one network
+suite: smoke
+tags: [smoke, wifi]
+priority: 4
+timeout: 60000
+dependencies: []
+
+steps:
+  - name: Scan for WiFi networks
+    command: npx tsx cicd/tests/src/mcp-client.ts wifi_scan '{}'
+    expectPatterns:
+      - "networks"
+      - "count"
+      - "bssid"
+    rejectPatterns:
+      - "isError"
+
+criteria: |
+  Verify wifi_scan returns scan results.
+  - Tool returns successfully without errors
+  - Response contains a networks array and a count field
+  - The bssid pattern confirms at least one parsed network entry exists
+    (an empty count would not produce any bssid lines)

--- a/cicd/tests/testcases/smoke/TC-SMK-005.yml
+++ b/cicd/tests/testcases/smoke/TC-SMK-005.yml
@@ -1,0 +1,22 @@
+id: TC-SMK-005
+name: wifi_list_networks returns the saved-networks array
+suite: smoke
+tags: [smoke, wifi]
+priority: 5
+timeout: 30000
+dependencies: []
+
+steps:
+  - name: List saved WiFi networks
+    command: npx tsx cicd/tests/src/mcp-client.ts wifi_list_networks '{}'
+    expectPatterns:
+      - "networks"
+      - "count"
+    rejectPatterns:
+      - "isError"
+
+criteria: |
+  Verify wifi_list_networks returns a structured saved-networks payload.
+  - Tool returns successfully without errors
+  - Response contains a networks array and a count field
+  - Empty networks array is acceptable; the test only verifies the shape

--- a/cicd/tests/testcases/smoke/TC-SMK-006.yml
+++ b/cicd/tests/testcases/smoke/TC-SMK-006.yml
@@ -1,0 +1,22 @@
+id: TC-SMK-006
+name: network_check_internet reports hasInternet true
+suite: smoke
+tags: [smoke, network]
+priority: 6
+timeout: 60000
+dependencies: []
+
+steps:
+  - name: Check internet connectivity
+    command: npx tsx cicd/tests/src/mcp-client.ts network_check_internet '{}'
+    expectPatterns:
+      - "hasInternet.*true"
+    rejectPatterns:
+      - "isError"
+      - "hasInternet.*false"
+
+criteria: |
+  Verify network_check_internet confirms the device can reach the internet.
+  - Tool returns successfully without errors
+  - hasInternet is true
+  - Smoke runner expects the test device to have working internet

--- a/cicd/tests/testcases/smoke/TC-SMK-007.yml
+++ b/cicd/tests/testcases/smoke/TC-SMK-007.yml
@@ -1,0 +1,23 @@
+id: TC-SMK-007
+name: network_interface_info returns an IP address
+suite: smoke
+tags: [smoke, network]
+priority: 7
+timeout: 30000
+dependencies: []
+
+steps:
+  - name: Get WiFi interface info
+    command: npx tsx cicd/tests/src/mcp-client.ts network_interface_info '{}'
+    expectPatterns:
+      - "interface"
+      - "ipAddress"
+      - "\\d+\\.\\d+\\.\\d+\\.\\d+"
+    rejectPatterns:
+      - "isError"
+
+criteria: |
+  Verify network_interface_info returns the wlan0 interface and its IP.
+  - Tool returns successfully without errors
+  - Response contains the interface and ipAddress fields
+  - ipAddress matches an IPv4 dotted-quad pattern

--- a/cicd/tests/tsconfig.json
+++ b/cicd/tests/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

- Port the YAML-driven test framework from `ruckus1-mcp` under `cicd/tests/` — `cli.ts`, `loader.ts`, `executor.ts`, `judge/`, `reporter/`, plus a small stdio `mcp-client.ts` that spawns `node dist/index.js --stdio`.
- Add per-test snapshot/restore of Android device state (WiFi enabled flag, current SSID, saved-network IDs) via `device-state.ts`. Uses `adb` directly so the framework doesn't depend on the very server under test. Restore runs even after a failing test so it can't poison the next one.
- Smoke suite: 7 YAMLs covering every read-only tool (`device_list`, `device_info`, `wifi_status`, `wifi_scan`, `wifi_list_networks`, `network_check_internet`, `network_interface_info`).
- GitHub Actions: `build.yml` (github-hosted, `npm ci` + `tsc --noEmit` + build), `test-run.yml` (reusable, self-hosted, `tag` input), `test-smoke.yml`, `ci.yml` orchestrator. `workflow_dispatch` only — no auto-runs.
- Project-level skills under `.claude/skills/` for `ci-testcase` and `ci-run`.
- README "Testing" section, `.env.example`, `.gitignore` excludes `cicd/results/` and `cicd/tests/dist/`.

Fixes #6

## Test plan

- [x] `cd cicd/tests && npm install` succeeds
- [x] `npx tsx src/cli.ts list` discovers all 7 smoke YAMLs
- [x] `npm test` runs the smoke suite end-to-end against an attached device — **7/7 passing in 18.7s** (SM-G9980 on `Wednesday`)
- [x] Per-test snapshot+restore log lines visible (`Snapshot: wifiEnabled=true, ssid=Wednesday, savedNetworks=5` ... `Restored device state`)
- [x] `tsc --noEmit` passes for both the server and the test framework
- [x] JSON results land under `cicd/results/<timestamp>_<suite>/` with `summary.json` + per-test reports
- [ ] CI workflows actually green on a self-hosted runner — *manual once a runner is set up; not gating this PR.*

### Notable bug caught during verification

Original TC-SMK-004 had a reject pattern `count.*:\s*0` to fail on empty scans. `\s*` allows zero whitespace, so the regex matched `:0` substrings inside BSSIDs like `46:ed:00:0c:26:b3` and reported a false positive. Removed the reject — the existing `bssid` expect pattern already proves scan returned ≥1 network.

Generated with [Claude Code](https://claude.com/claude-code)