### PR TITLE
Add UI automation primitives (tap, type, screenshot, ui dump, …)

### DIFF
--- a/.github/workflows/test-ui.yml
+++ b/.github/workflows/test-ui.yml
@@ -1,0 +1,12 @@
+name: "Test: UI"
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  test:
+    uses: ./.github/workflows/test-run.yml
+    with:
+      tag: ui
+    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -193,6 +193,22 @@ Enterprise WiFi (802.1X/EAP) requires a companion Android app because the `cmd w
 | `network_check_captive` | Check for captive portal |
 | `network_interface_info` | Get IP, gateway, DNS info |
 
+### UI Automation
+
+OS-level primitives (pixel/UI-tree, not DOM). For browser-page DOM automation, see the planned `browser_*` tools tracked in #10.
+
+| Tool | Description |
+|------|-------------|
+| `device_launch_app` | Launch an app by package or `pkg/.Activity` component |
+| `device_open_url` | Open a URL in the default browser via VIEW intent |
+| `device_tap` | Tap at (x, y) screen coordinates |
+| `device_swipe` | Swipe between two coordinates with optional duration |
+| `device_type_text` | Type text into the focused field |
+| `device_keyevent` | Send a keyevent (e.g. `KEYCODE_HOME`, `KEYCODE_BACK`) |
+| `device_screenshot` | Capture a PNG (returns base64 or saves to a host path) |
+| `device_ui_dump` | Dump the on-screen UI hierarchy as XML |
+| `device_list_packages` | List installed app package names |
+
 ## Usage Examples
 
 ### List Connected Devices
@@ -242,6 +258,22 @@ This will use `wifi_connect_enterprise` with:
 ```
 > Check if my phone has internet access and detect any captive portal
 ```
+
+### Launch an App and Take a Screenshot
+
+```
+> Launch the Settings app on my phone, take a screenshot to /tmp/settings.png, then return to home
+```
+
+This chains `device_launch_app` (target: `com.android.settings`), `device_screenshot` (outputPath: `/tmp/settings.png`), and `device_keyevent` (keycode: `KEYCODE_HOME`).
+
+### Open a URL and Inspect the Page
+
+```
+> Open https://example.com on my phone and dump the on-screen UI hierarchy
+```
+
+Uses `device_open_url` then `device_ui_dump` for OS-level inspection. For DOM-level browser automation see #10.
 
 ## Reference
 
@@ -366,6 +398,7 @@ android-wifi-mcp/
 │   │   ├── adb-client.ts       # ADB command wrapper
 │   │   ├── device-manager.ts   # Multi-device handling
 │   │   ├── wifi-commands.ts    # cmd wifi wrapper
+│   │   ├── ui-commands.ts      # input / am start / screencap / uiautomator
 │   │   └── enterprise-wifi.ts  # 802.1X enterprise WiFi
 │   └── network/
 │       └── network-check.ts    # Network diagnostics

--- a/cicd/tests/testcases/ui/TC-UI-001.yml
+++ b/cicd/tests/testcases/ui/TC-UI-001.yml
@@ -1,0 +1,23 @@
+id: TC-UI-001
+name: device_list_packages returns installed apps
+suite: ui
+tags: [ui]
+priority: 1
+timeout: 30000
+dependencies: []
+
+steps:
+  - name: List packages filtered to com.android
+    command: npx tsx cicd/tests/src/mcp-client.ts device_list_packages '{"filter":"com.android"}'
+    expectPatterns:
+      - "packages"
+      - "count"
+      - "com.android"
+    rejectPatterns:
+      - "isError"
+
+criteria: |
+  Verify device_list_packages returns a non-empty package list.
+  - Tool returns successfully without errors
+  - Response contains the packages array and a count field
+  - At least one com.android.* package is reported (always true on stock Android)

--- a/cicd/tests/testcases/ui/TC-UI-002.yml
+++ b/cicd/tests/testcases/ui/TC-UI-002.yml
@@ -1,0 +1,22 @@
+id: TC-UI-002
+name: device_keyevent sends KEYCODE_WAKEUP
+suite: ui
+tags: [ui]
+priority: 2
+timeout: 30000
+dependencies: []
+
+steps:
+  - name: Wake the screen
+    command: npx tsx cicd/tests/src/mcp-client.ts device_keyevent '{"keycode":"KEYCODE_WAKEUP"}'
+    expectPatterns:
+      - "success.*true"
+      - "KEYCODE_WAKEUP"
+    rejectPatterns:
+      - "isError"
+
+criteria: |
+  Verify device_keyevent succeeds with a benign keycode.
+  - Tool returns success: true
+  - The dispatched keycode is echoed back
+  - KEYCODE_WAKEUP is harmless — it only wakes the display

--- a/cicd/tests/testcases/ui/TC-UI-003.yml
+++ b/cicd/tests/testcases/ui/TC-UI-003.yml
@@ -1,0 +1,24 @@
+id: TC-UI-003
+name: device_ui_dump returns the on-screen UI hierarchy as XML
+suite: ui
+tags: [ui]
+priority: 3
+timeout: 60000
+dependencies: []
+
+steps:
+  - name: Dump the UI hierarchy
+    command: npx tsx cicd/tests/src/mcp-client.ts device_ui_dump '{}'
+    expectPatterns:
+      - "success.*true"
+      - "<hierarchy"
+      - "<node"
+      - "bytes"
+    rejectPatterns:
+      - "isError"
+
+criteria: |
+  Verify device_ui_dump returns a parsed XML hierarchy.
+  - Tool returns success: true
+  - Response contains a `<hierarchy` root and at least one `<node` element
+  - The bytes field reports a non-trivial dump size

--- a/cicd/tests/testcases/ui/TC-UI-004.yml
+++ b/cicd/tests/testcases/ui/TC-UI-004.yml
@@ -1,0 +1,30 @@
+id: TC-UI-004
+name: device_screenshot saves a PNG to a host path
+suite: ui
+tags: [ui]
+priority: 4
+timeout: 60000
+dependencies: []
+
+steps:
+  - name: Capture a screenshot to /tmp/tc-ui-004.png
+    command: npx tsx cicd/tests/src/mcp-client.ts device_screenshot '{"outputPath":"/tmp/tc-ui-004.png"}'
+    expectPatterns:
+      - "success.*true"
+      - "outputPath.*tc-ui-004"
+      - "bytes"
+    rejectPatterns:
+      - "isError"
+
+  - name: Verify the file is a non-trivial PNG
+    command: test -s /tmp/tc-ui-004.png && file /tmp/tc-ui-004.png
+    expectPatterns:
+      - "PNG image"
+    rejectPatterns:
+      - "empty"
+
+criteria: |
+  Verify device_screenshot writes a PNG file to the host.
+  - Tool returns success: true with the requested outputPath
+  - The file exists, is non-empty, and `file(1)` recognizes it as a PNG
+  - Tests file-output path; base64 path is exercised by ad-hoc smoke

--- a/cicd/tests/testcases/ui/TC-UI-005.yml
+++ b/cicd/tests/testcases/ui/TC-UI-005.yml
@@ -1,0 +1,24 @@
+id: TC-UI-005
+name: device_tap dispatches a touch event at given coordinates
+suite: ui
+tags: [ui]
+priority: 5
+timeout: 30000
+dependencies: []
+
+steps:
+  - name: Tap at (100, 100)
+    command: npx tsx cicd/tests/src/mcp-client.ts device_tap '{"x":100,"y":100}'
+    expectPatterns:
+      - "success.*true"
+      - "x.*100"
+      - "y.*100"
+    rejectPatterns:
+      - "isError"
+
+criteria: |
+  Verify device_tap forwards the event to `input tap`.
+  - Tool returns success: true
+  - The dispatched coordinates are echoed back
+  - The actual UI consequence depends on what's on screen — this test only
+    verifies the tool succeeded, not what the device did with the tap

--- a/cicd/tests/testcases/ui/TC-UI-006.yml
+++ b/cicd/tests/testcases/ui/TC-UI-006.yml
@@ -1,0 +1,24 @@
+id: TC-UI-006
+name: device_swipe dispatches a swipe gesture
+suite: ui
+tags: [ui]
+priority: 6
+timeout: 30000
+dependencies: []
+
+steps:
+  - name: Swipe in place at (500, 500) over 100ms
+    command: npx tsx cicd/tests/src/mcp-client.ts device_swipe '{"x1":500,"y1":500,"x2":500,"y2":500,"durationMs":100}'
+    expectPatterns:
+      - "success.*true"
+      - "from"
+      - "to"
+      - "durationMs.*100"
+    rejectPatterns:
+      - "isError"
+
+criteria: |
+  Verify device_swipe forwards the event to `input swipe`.
+  - Tool returns success: true with from/to/durationMs echoed back
+  - Same-point swipe is intentionally a no-op gesture so the test does not
+    perturb whatever app is on screen

--- a/cicd/tests/testcases/ui/TC-UI-007.yml
+++ b/cicd/tests/testcases/ui/TC-UI-007.yml
@@ -1,0 +1,23 @@
+id: TC-UI-007
+name: device_type_text dispatches text input
+suite: ui
+tags: [ui]
+priority: 7
+timeout: 30000
+dependencies: []
+
+steps:
+  - name: Type a benign string
+    command: npx tsx cicd/tests/src/mcp-client.ts device_type_text '{"text":"hello world"}'
+    expectPatterns:
+      - "success.*true"
+      - "hello world"
+    rejectPatterns:
+      - "isError"
+
+criteria: |
+  Verify device_type_text forwards the event to `input text`.
+  - Tool returns success: true
+  - The text is echoed back unchanged
+  - If no field is focused on-device, `input text` is a no-op — the test only
+    verifies the tool dispatched successfully

--- a/cicd/tests/testcases/ui/TC-UI-008.yml
+++ b/cicd/tests/testcases/ui/TC-UI-008.yml
@@ -1,0 +1,30 @@
+id: TC-UI-008
+name: device_launch_app launches Settings and returns home
+suite: ui
+tags: [ui]
+priority: 8
+timeout: 30000
+dependencies: []
+
+steps:
+  - name: Launch the Settings app via package
+    command: npx tsx cicd/tests/src/mcp-client.ts device_launch_app '{"target":"com.android.settings"}'
+    expectPatterns:
+      - "success.*true"
+      - "method.*monkey"
+      - "com.android.settings"
+    rejectPatterns:
+      - "isError"
+
+  - name: Press HOME to return to launcher
+    command: npx tsx cicd/tests/src/mcp-client.ts device_keyevent '{"keycode":"KEYCODE_HOME"}'
+    expectPatterns:
+      - "success.*true"
+    rejectPatterns:
+      - "isError"
+
+criteria: |
+  Verify device_launch_app launches an app via the package-only path.
+  - Tool returns success: true with method=monkey
+  - HOME keyevent restores the launcher state at the end
+  - Component-form launches (com.pkg/.Activity) are exercised manually

--- a/cicd/tests/testcases/ui/TC-UI-009.yml
+++ b/cicd/tests/testcases/ui/TC-UI-009.yml
@@ -1,0 +1,30 @@
+id: TC-UI-009
+name: device_open_url opens example.com and returns home
+suite: ui
+tags: [ui]
+priority: 9
+timeout: 30000
+dependencies: []
+
+steps:
+  - name: Open https://example.com via VIEW intent
+    command: npx tsx cicd/tests/src/mcp-client.ts device_open_url '{"url":"https://example.com"}'
+    expectPatterns:
+      - "success.*true"
+      - "example.com"
+    rejectPatterns:
+      - "isError"
+
+  - name: Press HOME to return to launcher
+    command: npx tsx cicd/tests/src/mcp-client.ts device_keyevent '{"keycode":"KEYCODE_HOME"}'
+    expectPatterns:
+      - "success.*true"
+    rejectPatterns:
+      - "isError"
+
+criteria: |
+  Verify device_open_url launches the default browser with the URL.
+  - Tool returns success: true with the URL echoed back
+  - HOME keyevent restores the launcher state at the end
+  - The test does not assert the browser actually rendered the page —
+    that requires the browser tools planned in #10 (Playwright on Android)

--- a/src/adb/adb-client.ts
+++ b/src/adb/adb-client.ts
@@ -197,4 +197,40 @@ export class AdbClient {
       throw new Error(`Timeout waiting for device: ${result.stderr}`);
     }
   }
+
+  /**
+   * Execute an ADB command and capture stdout as a Buffer.
+   * Used for binary streams (e.g. `adb exec-out screencap -p`).
+   */
+  async execBinary(args: string[], timeout: number = 30000): Promise<Buffer> {
+    const deviceArgs = this.selectedDevice ? ['-s', this.selectedDevice] : [];
+    const fullArgs = [...deviceArgs, ...args];
+
+    return new Promise((resolve, reject) => {
+      const proc = spawn(this.adbPath, fullArgs);
+      const chunks: Buffer[] = [];
+      const errChunks: Buffer[] = [];
+
+      const timer = setTimeout(() => {
+        proc.kill('SIGKILL');
+        reject(new Error(`adb ${args.join(' ')} timed out after ${timeout}ms`));
+      }, timeout);
+
+      proc.stdout.on('data', (chunk: Buffer) => chunks.push(chunk));
+      proc.stderr.on('data', (chunk: Buffer) => errChunks.push(chunk));
+      proc.on('error', (err) => {
+        clearTimeout(timer);
+        reject(err);
+      });
+      proc.on('close', (code) => {
+        clearTimeout(timer);
+        if (code === 0) {
+          resolve(Buffer.concat(chunks));
+        } else {
+          const err = Buffer.concat(errChunks).toString().trim();
+          reject(new Error(`adb exited with code ${code}: ${err}`));
+        }
+      });
+    });
+  }
 }

--- a/src/adb/device-manager.ts
+++ b/src/adb/device-manager.ts
@@ -1,19 +1,22 @@
 import { AdbClient } from './adb-client.js';
 import { WifiCommands } from './wifi-commands.js';
+import { UICommands } from './ui-commands.js';
 import { Device, DeviceInfo } from '../types.js';
 
 /**
  * Manages connected Android devices and provides unified access
- * to ADB and WiFi commands.
+ * to ADB, WiFi, and UI commands.
  */
 export class DeviceManager {
   private adb: AdbClient;
   private wifi: WifiCommands;
+  private ui: UICommands;
   private devices: Map<string, DeviceInfo> = new Map();
 
   constructor(adbPath?: string) {
     this.adb = new AdbClient(adbPath);
     this.wifi = new WifiCommands(this.adb);
+    this.ui = new UICommands(this.adb);
   }
 
   /**
@@ -28,6 +31,13 @@ export class DeviceManager {
    */
   getWifiCommands(): WifiCommands {
     return this.wifi;
+  }
+
+  /**
+   * Get the UI commands instance
+   */
+  getUICommands(): UICommands {
+    return this.ui;
   }
 
   /**

--- a/src/adb/ui-commands.ts
+++ b/src/adb/ui-commands.ts
@@ -1,0 +1,190 @@
+import { writeFileSync } from 'fs';
+import { AdbClient } from './adb-client.js';
+
+/**
+ * Wraps Android UI-automation primitives via `adb shell input`, `am start`,
+ * `screencap`, `uiautomator dump`, and `pm list packages`. Lower-level than
+ * Playwright/Appium — operates at the OS pixel/UI-tree level, not the DOM.
+ */
+export class UICommands {
+  private adb: AdbClient;
+
+  constructor(adb: AdbClient) {
+    this.adb = adb;
+  }
+
+  /**
+   * Launch an app. Accepts either an explicit `pkg/.Activity` component or a
+   * bare package name (uses the monkey trick for the LAUNCHER intent).
+   */
+  async launchApp(target: string): Promise<{ success: boolean; target: string; method: string; output: string }> {
+    const isComponent = target.includes('/');
+    const command = isComponent
+      ? `am start -n ${shellQuote(target)}`
+      : `monkey -p ${shellQuote(target)} -c android.intent.category.LAUNCHER 1`;
+
+    const result = await this.adb.shell(command);
+    if (!result.success) {
+      throw new Error(`Failed to launch ${target}: ${result.stderr || result.stdout}`);
+    }
+
+    return {
+      success: true,
+      target,
+      method: isComponent ? 'am-start' : 'monkey',
+      output: result.stdout,
+    };
+  }
+
+  /**
+   * Open a URL in the default browser via VIEW intent.
+   */
+  async openUrl(url: string): Promise<{ success: boolean; url: string; output: string }> {
+    const command = `am start -a android.intent.action.VIEW -d ${shellQuote(url)}`;
+    const result = await this.adb.shell(command);
+    if (!result.success) {
+      throw new Error(`Failed to open URL: ${result.stderr || result.stdout}`);
+    }
+    return { success: true, url, output: result.stdout };
+  }
+
+  /**
+   * Tap at (x, y) screen coordinates.
+   */
+  async tap(x: number, y: number): Promise<{ success: boolean; x: number; y: number }> {
+    const result = await this.adb.shell(`input tap ${x} ${y}`);
+    if (!result.success) {
+      throw new Error(`Tap failed: ${result.stderr || result.stdout}`);
+    }
+    return { success: true, x, y };
+  }
+
+  /**
+   * Swipe from (x1, y1) to (x2, y2) over `durationMs`.
+   */
+  async swipe(
+    x1: number,
+    y1: number,
+    x2: number,
+    y2: number,
+    durationMs: number = 300
+  ): Promise<{ success: boolean; from: { x: number; y: number }; to: { x: number; y: number }; durationMs: number }> {
+    const result = await this.adb.shell(`input swipe ${x1} ${y1} ${x2} ${y2} ${durationMs}`);
+    if (!result.success) {
+      throw new Error(`Swipe failed: ${result.stderr || result.stdout}`);
+    }
+    return {
+      success: true,
+      from: { x: x1, y: y1 },
+      to: { x: x2, y: y2 },
+      durationMs,
+    };
+  }
+
+  /**
+   * Type text into the focused field. Spaces become %s; single quotes are
+   * escaped for shell wrapping. Some special characters may not survive
+   * `adb shell input text` — the caller should send those via keyevent
+   * codes if reliability matters.
+   */
+  async typeText(text: string): Promise<{ success: boolean; text: string }> {
+    const escaped = text.replace(/ /g, '%s');
+    const result = await this.adb.shell(`input text ${shellQuote(escaped)}`);
+    if (!result.success) {
+      throw new Error(`Type failed: ${result.stderr || result.stdout}`);
+    }
+    return { success: true, text };
+  }
+
+  /**
+   * Send a keyevent. Accepts a numeric code or a name like `KEYCODE_HOME`.
+   */
+  async keyevent(keycode: string | number): Promise<{ success: boolean; keycode: string | number }> {
+    const result = await this.adb.shell(`input keyevent ${keycode}`);
+    if (!result.success) {
+      throw new Error(`Keyevent failed: ${result.stderr || result.stdout}`);
+    }
+    return { success: true, keycode };
+  }
+
+  /**
+   * Capture a PNG screenshot. If `outputPath` is provided, save to that host
+   * path and return metadata. Otherwise return the PNG as base64.
+   */
+  async screenshot(outputPath?: string): Promise<
+    | { success: true; outputPath: string; bytes: number }
+    | { success: true; mimeType: 'image/png'; base64: string; bytes: number }
+  > {
+    const buf = await this.adb.execBinary(['exec-out', 'screencap', '-p'], 30000);
+
+    if (outputPath) {
+      writeFileSync(outputPath, buf);
+      return { success: true, outputPath, bytes: buf.length };
+    }
+
+    return {
+      success: true,
+      mimeType: 'image/png',
+      base64: buf.toString('base64'),
+      bytes: buf.length,
+    };
+  }
+
+  /**
+   * Dump the on-screen UI hierarchy as XML.
+   * Writes to a temp file on the device, cats it back, then cleans up.
+   */
+  async uiDump(): Promise<{ success: boolean; xml: string; bytes: number }> {
+    const devicePath = '/sdcard/window_dump.xml';
+
+    // uiautomator dump writes to the path we pass it.
+    const dumpResult = await this.adb.shell(`uiautomator dump ${devicePath}`);
+    if (!dumpResult.success || !dumpResult.stdout.includes('UI hierchary dumped')) {
+      // Note: Android historically misspells "hierarchy" as "hierchary" in this output.
+      // We don't fail just on the typo check — only on shell failure.
+      if (!dumpResult.success) {
+        throw new Error(`uiautomator dump failed: ${dumpResult.stderr || dumpResult.stdout}`);
+      }
+    }
+
+    const catResult = await this.adb.shell(`cat ${devicePath}`);
+    if (!catResult.success) {
+      throw new Error(`Failed to read dump file: ${catResult.stderr}`);
+    }
+
+    // Best-effort cleanup
+    await this.adb.shell(`rm -f ${devicePath}`);
+
+    return {
+      success: true,
+      xml: catResult.stdout,
+      bytes: catResult.stdout.length,
+    };
+  }
+
+  /**
+   * List installed app packages. Optional substring `filter` is passed to
+   * `pm list packages`.
+   */
+  async listPackages(filter?: string): Promise<{ count: number; packages: string[] }> {
+    const cmd = filter ? `pm list packages ${shellQuote(filter)}` : 'pm list packages';
+    const result = await this.adb.shell(cmd);
+    if (!result.success) {
+      throw new Error(`Failed to list packages: ${result.stderr || result.stdout}`);
+    }
+    const packages = result.stdout
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.startsWith('package:'))
+      .map((line) => line.slice('package:'.length));
+
+    return { count: packages.length, packages };
+  }
+}
+
+/**
+ * Wrap a string in single quotes for shell, escaping any embedded single quotes.
+ */
+function shellQuote(s: string): string {
+  return `'${s.replace(/'/g, "'\\''")}'`;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -612,5 +612,182 @@ export function createMcpServer(deviceManager: DeviceManager): McpServer {
     }
   );
 
+  // ============ UI Automation Tools ============
+
+  mcpServer.tool(
+    'device_launch_app',
+    'Launch an Android app. Pass a package name (e.g. "com.android.chrome") to launch via the LAUNCHER intent, or an explicit "package/.Activity" component for precise launch.',
+    {
+      target: z
+        .string()
+        .describe('Package name (e.g. com.android.chrome) or component (e.g. com.android.chrome/com.google.android.apps.chrome.Main)'),
+    },
+    async ({ target }) => {
+      await ensureDevice();
+      const ui = deviceManager.getUICommands();
+      const result = await ui.launchApp(target);
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+      };
+    }
+  );
+
+  mcpServer.tool(
+    'device_open_url',
+    'Open a URL in the device default browser via VIEW intent',
+    {
+      url: z.string().describe('URL to open (e.g. https://example.com)'),
+    },
+    async ({ url }) => {
+      await ensureDevice();
+      const ui = deviceManager.getUICommands();
+      const result = await ui.openUrl(url);
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+      };
+    }
+  );
+
+  mcpServer.tool(
+    'device_tap',
+    'Tap at (x, y) screen coordinates',
+    {
+      x: z.number().describe('X coordinate in pixels'),
+      y: z.number().describe('Y coordinate in pixels'),
+    },
+    async ({ x, y }) => {
+      await ensureDevice();
+      const ui = deviceManager.getUICommands();
+      const result = await ui.tap(x, y);
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+      };
+    }
+  );
+
+  mcpServer.tool(
+    'device_swipe',
+    'Swipe from (x1, y1) to (x2, y2) over an optional duration in milliseconds',
+    {
+      x1: z.number().describe('Start X coordinate'),
+      y1: z.number().describe('Start Y coordinate'),
+      x2: z.number().describe('End X coordinate'),
+      y2: z.number().describe('End Y coordinate'),
+      durationMs: z.number().optional().default(300).describe('Swipe duration in milliseconds (default 300)'),
+    },
+    async ({ x1, y1, x2, y2, durationMs }) => {
+      await ensureDevice();
+      const ui = deviceManager.getUICommands();
+      const result = await ui.swipe(x1, y1, x2, y2, durationMs);
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+      };
+    }
+  );
+
+  mcpServer.tool(
+    'device_type_text',
+    'Type text into the currently focused field. Spaces are converted to %s; some special characters may not survive `input text` and should be sent via device_keyevent.',
+    {
+      text: z.string().describe('Text to type'),
+    },
+    async ({ text }) => {
+      await ensureDevice();
+      const ui = deviceManager.getUICommands();
+      const result = await ui.typeText(text);
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+      };
+    }
+  );
+
+  mcpServer.tool(
+    'device_keyevent',
+    'Send a keyevent. Accepts a numeric keycode or a name like KEYCODE_HOME, KEYCODE_BACK, KEYCODE_ENTER, KEYCODE_WAKEUP.',
+    {
+      keycode: z
+        .union([z.string(), z.number()])
+        .describe('Keycode name (e.g. KEYCODE_HOME) or numeric code (e.g. 3)'),
+    },
+    async ({ keycode }) => {
+      await ensureDevice();
+      const ui = deviceManager.getUICommands();
+      const result = await ui.keyevent(keycode);
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+      };
+    }
+  );
+
+  mcpServer.tool(
+    'device_screenshot',
+    'Capture a PNG screenshot. Returns image content with base64 data, or saves to a host path if `outputPath` is given.',
+    {
+      outputPath: z.string().optional().describe('Optional host filesystem path to save the PNG. If omitted, returns base64 image content.'),
+    },
+    async ({ outputPath }) => {
+      await ensureDevice();
+      const ui = deviceManager.getUICommands();
+      const result = await ui.screenshot(outputPath);
+
+      if ('outputPath' in result) {
+        return {
+          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+        };
+      }
+
+      // Inline image content + a small text summary so callers that only
+      // inspect text still see metadata.
+      return {
+        content: [
+          {
+            type: 'image',
+            data: result.base64,
+            mimeType: result.mimeType,
+          },
+          {
+            type: 'text',
+            text: JSON.stringify({ success: true, mimeType: result.mimeType, bytes: result.bytes }, null, 2),
+          },
+        ],
+      };
+    }
+  );
+
+  mcpServer.tool(
+    'device_ui_dump',
+    'Dump the current UI hierarchy as XML (uiautomator dump)',
+    {},
+    async () => {
+      await ensureDevice();
+      const ui = deviceManager.getUICommands();
+      const result = await ui.uiDump();
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({ success: result.success, bytes: result.bytes, xml: result.xml }, null, 2),
+          },
+        ],
+      };
+    }
+  );
+
+  mcpServer.tool(
+    'device_list_packages',
+    'List installed app package names. Optional substring filter narrows the list.',
+    {
+      filter: z.string().optional().describe('Substring to filter package names (passed to pm list packages)'),
+    },
+    async ({ filter }) => {
+      await ensureDevice();
+      const ui = deviceManager.getUICommands();
+      const result = await ui.listPackages(filter);
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+      };
+    }
+  );
+
   return mcpServer;
 }


### PR DESCRIPTION
## Summary

- 9 new MCP tools wrapping `adb shell input` / `am start` / `screencap` / `uiautomator` / `pm`: \`device_launch_app\`, \`device_open_url\`, \`device_tap\`, \`device_swipe\`, \`device_type_text\`, \`device_keyevent\`, \`device_screenshot\`, \`device_ui_dump\`, \`device_list_packages\`.
- New \`src/adb/ui-commands.ts\` mirrors \`wifi-commands.ts\`. \`AdbClient\` gains \`execBinary()\` (spawn-based, returns Buffer) so \`screencap\` PNG can stream over stdout.
- \`device_screenshot\` returns image content (base64) by default, or saves to a host \`outputPath\`. \`device_ui_dump\` writes \`/sdcard/window_dump.xml\`, cats it back, and removes the temp file.
- Test coverage: 9 YAMLs under \`cicd/tests/testcases/ui/\`. Stateful tests (\`launch_app\`, \`open_url\`) include a KEYCODE_HOME teardown.
- New \`.github/workflows/test-ui.yml\` calls \`test-run.yml\` with \`tag: ui\`.
- README: UI Automation tools table, two usage examples, updated Project Structure tree, pointer to #10 for DOM-level browser automation.

Fixes #1

## Test plan

- [x] \`npm run build\` succeeds
- [x] \`npx tsc --noEmit\` clean for server *and* test framework
- [x] Spawn server via stdio + list tools — **28 total** (19 prior + 9 new)
- [x] Ad-hoc end-to-end smoke for keyevent / list_packages / screenshot / ui_dump — all return expected content
- [x] \`npm run test:smoke\` — **7/7 pass** (no regressions)
- [x] UI suite via \`npx tsx src/cli.ts run --suite ui\` — **9/9 pass in 25.5s**
- [x] \`device_screenshot\` to \`/tmp/tc-ui-004.png\` produces a 2.7 MB valid PNG (verified via \`file(1)\`)
- [ ] CI workflow (\`test-ui.yml\`) green on a self-hosted runner — *manual once a runner is set up.*

Generated with [Claude Code](https://claude.com/claude-code)