### PR TITLE
Add SMS read + OTP-wait tools

### DIFF
--- a/.github/workflows/test-sms.yml
+++ b/.github/workflows/test-sms.yml
@@ -1,0 +1,12 @@
+name: "Test: SMS"
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  test:
+    uses: ./.github/workflows/test-run.yml
+    with:
+      tag: sms
+    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -209,6 +209,15 @@ OS-level primitives (pixel/UI-tree, not DOM). For browser-page DOM automation, s
 | `device_ui_dump` | Dump the on-screen UI hierarchy as XML |
 | `device_list_packages` | List installed app package names |
 
+### SMS / OTP
+
+Reads SMS messages from `content://sms/inbox` via adb shell — no root, no companion app. **Limitation:** some Samsung/OEM devices restrict the SMS content provider even from adb; the tools return an empty list with a `warning` field on those devices, and the recommended fallback is the notification listener planned in #3.
+
+| Tool | Description |
+|------|-------------|
+| `sms_read_recent` | Read recent SMS, optionally filtered by sender, body regex, or recency |
+| `sms_wait_for_otp` | Poll the inbox until a matching OTP arrives or timeout elapses |
+
 ## Usage Examples
 
 ### List Connected Devices
@@ -274,6 +283,14 @@ This chains `device_launch_app` (target: `com.android.settings`), `device_screen
 ```
 
 Uses `device_open_url` then `device_ui_dump` for OS-level inspection. For DOM-level browser automation see #10.
+
+### Wait for a Login OTP via SMS
+
+```
+> Wait up to 60 seconds for an SMS OTP from "VERIFY" — give me the code as soon as it arrives
+```
+
+Calls `sms_wait_for_otp` with `senderFilter: "VERIFY"` and a 60s timeout. The tool returns the extracted OTP string when a matching message arrives. On devices that restrict the SMS content provider (some Samsung models), see #3 for the notification-listener fallback.
 
 ## Reference
 
@@ -399,6 +416,7 @@ android-wifi-mcp/
 │   │   ├── device-manager.ts   # Multi-device handling
 │   │   ├── wifi-commands.ts    # cmd wifi wrapper
 │   │   ├── ui-commands.ts      # input / am start / screencap / uiautomator
+│   │   ├── sms-commands.ts     # SMS read / OTP polling via content provider
 │   │   └── enterprise-wifi.ts  # 802.1X enterprise WiFi
 │   └── network/
 │       └── network-check.ts    # Network diagnostics

--- a/cicd/tests/src/config.ts
+++ b/cicd/tests/src/config.ts
@@ -2,7 +2,7 @@
  * Project configuration for the test framework.
  */
 
-export const SUITES = ['smoke', 'wifi', 'enterprise', 'ui', 'portal'] as const;
+export const SUITES = ['smoke', 'wifi', 'enterprise', 'ui', 'sms', 'portal'] as const;
 export type Suite = typeof SUITES[number];
 
 export const CONFIG = {

--- a/cicd/tests/testcases/sms/TC-SMS-001.yml
+++ b/cicd/tests/testcases/sms/TC-SMS-001.yml
@@ -1,0 +1,24 @@
+id: TC-SMS-001
+name: sms_read_recent returns the messages/count shape
+suite: sms
+tags: [sms]
+priority: 1
+timeout: 30000
+dependencies: []
+
+steps:
+  - name: Read recent SMS with default options
+    command: npx tsx cicd/tests/src/mcp-client.ts sms_read_recent '{}'
+    expectPatterns:
+      - "messages"
+      - "count"
+    rejectPatterns:
+      - "isError"
+
+criteria: |
+  Verify sms_read_recent returns the standard response shape.
+  - Tool returns successfully without errors
+  - Response always contains messages and count fields
+  - On Samsung/OEM devices that restrict content://sms/inbox the response
+    is { messages: [], count: 0, warning: "..." } — still passes shape check
+  - On stock Android the messages array carries the real inbox rows

--- a/cicd/tests/testcases/sms/TC-SMS-002.yml
+++ b/cicd/tests/testcases/sms/TC-SMS-002.yml
@@ -1,0 +1,24 @@
+id: TC-SMS-002
+name: sms_read_recent accepts sender + body regex filters
+suite: sms
+tags: [sms]
+priority: 2
+timeout: 30000
+dependencies: []
+
+steps:
+  - name: Read recent SMS filtered to a sender substring + 4-8 digit body
+    command: npx tsx cicd/tests/src/mcp-client.ts sms_read_recent '{"senderFilter":"verify","bodyRegex":"\\d{4,8}","limit":5}'
+    expectPatterns:
+      - "messages"
+      - "count"
+    rejectPatterns:
+      - "isError"
+
+criteria: |
+  Verify sms_read_recent honors filter parameters without erroring.
+  - Tool accepts senderFilter, bodyRegex, and limit
+  - Filtered response still has messages and count fields
+  - Result will be empty on devices with no matching messages or with
+    OEM-restricted SMS access — that is expected and still passes the
+    shape check

--- a/cicd/tests/testcases/sms/TC-SMS-003.yml
+++ b/cicd/tests/testcases/sms/TC-SMS-003.yml
@@ -1,0 +1,24 @@
+id: TC-SMS-003
+name: sms_wait_for_otp times out cleanly when no message arrives
+suite: sms
+tags: [sms]
+priority: 3
+timeout: 30000
+dependencies: []
+
+steps:
+  - name: Wait briefly for an OTP that will not arrive in CI
+    command: npx tsx cicd/tests/src/mcp-client.ts sms_wait_for_otp '{"timeoutMs":3000,"pollIntervalMs":500,"bodyRegex":"\\d{6}"}'
+    expectPatterns:
+      - "found"
+      - "waitedMs"
+    rejectPatterns:
+      - "isError"
+
+criteria: |
+  Verify sms_wait_for_otp returns cleanly on timeout (not an error).
+  - Tool accepts timeoutMs and pollIntervalMs
+  - Response always contains found and waitedMs fields
+  - In CI / smoke contexts where no live OTP arrives, found will be false —
+    that is correct behavior and still a pass
+  - When an OTP does arrive, the response carries otp + sender + body

--- a/src/adb/device-manager.ts
+++ b/src/adb/device-manager.ts
@@ -1,22 +1,25 @@
 import { AdbClient } from './adb-client.js';
 import { WifiCommands } from './wifi-commands.js';
 import { UICommands } from './ui-commands.js';
+import { SmsCommands } from './sms-commands.js';
 import { Device, DeviceInfo } from '../types.js';
 
 /**
  * Manages connected Android devices and provides unified access
- * to ADB, WiFi, and UI commands.
+ * to ADB, WiFi, UI, and SMS commands.
  */
 export class DeviceManager {
   private adb: AdbClient;
   private wifi: WifiCommands;
   private ui: UICommands;
+  private sms: SmsCommands;
   private devices: Map<string, DeviceInfo> = new Map();
 
   constructor(adbPath?: string) {
     this.adb = new AdbClient(adbPath);
     this.wifi = new WifiCommands(this.adb);
     this.ui = new UICommands(this.adb);
+    this.sms = new SmsCommands(this.adb);
   }
 
   /**
@@ -38,6 +41,13 @@ export class DeviceManager {
    */
   getUICommands(): UICommands {
     return this.ui;
+  }
+
+  /**
+   * Get the SMS commands instance
+   */
+  getSmsCommands(): SmsCommands {
+    return this.sms;
   }
 
   /**

--- a/src/adb/sms-commands.ts
+++ b/src/adb/sms-commands.ts
@@ -1,0 +1,201 @@
+import { AdbClient } from './adb-client.js';
+
+/**
+ * Reads SMS messages from the device's content provider for OTP capture.
+ *
+ * Works without root and without a companion app. Some Samsung/OEM devices
+ * restrict `content://sms/inbox` even via adb shell — when that happens the
+ * tool returns an empty list with a `warning` rather than failing, and the
+ * caller can fall back to the notification listener (see #3).
+ */
+export class SmsCommands {
+  private adb: AdbClient;
+
+  constructor(adb: AdbClient) {
+    this.adb = adb;
+  }
+
+  async readRecent(opts: SmsReadRecentOptions = {}): Promise<SmsReadRecentResult> {
+    const limit = opts.limit ?? 10;
+    const result = await this.adb.shell(
+      `content query --uri content://sms/inbox --projection address,body,date`
+    );
+
+    if (!result.success) {
+      return {
+        messages: [],
+        count: 0,
+        warning: `content query failed: ${result.stderr || result.stdout}`,
+      };
+    }
+
+    const stdout = result.stdout.trim();
+    if (!stdout || /no result found/i.test(stdout)) {
+      return {
+        messages: [],
+        count: 0,
+        warning:
+          'No SMS rows returned. On Samsung/OEM devices, content://sms/inbox is often restricted even via adb shell. Use the companion app notification listener (see #3) for those devices.',
+      };
+    }
+
+    let messages = parseContentQuery(stdout);
+
+    // Apply filters
+    if (opts.senderFilter) {
+      const re = new RegExp(opts.senderFilter, 'i');
+      messages = messages.filter((m) => re.test(m.sender));
+    }
+
+    if (opts.bodyRegex) {
+      const re = new RegExp(opts.bodyRegex);
+      const out: SmsMessage[] = [];
+      for (const m of messages) {
+        const match = m.body.match(re);
+        if (!match) continue;
+        // Use a capture group if present; else fall back to the digits heuristic.
+        m.otp = match[1] ?? extractOtp(m.body);
+        out.push(m);
+      }
+      messages = out;
+    } else {
+      for (const m of messages) {
+        m.otp = extractOtp(m.body);
+      }
+    }
+
+    if (opts.sinceSeconds !== undefined) {
+      const cutoff = Date.now() - opts.sinceSeconds * 1000;
+      messages = messages.filter((m) => m.timestamp >= cutoff);
+    }
+
+    messages.sort((a, b) => b.timestamp - a.timestamp);
+    messages = messages.slice(0, limit);
+
+    return { messages, count: messages.length };
+  }
+
+  async waitForOtp(opts: SmsWaitForOtpOptions = {}): Promise<SmsWaitForOtpResult> {
+    const timeoutMs = opts.timeoutMs ?? 60000;
+    const pollIntervalMs = opts.pollIntervalMs ?? 2000;
+    const sinceSeconds = opts.sinceSeconds ?? 60;
+    const start = Date.now();
+
+    let lastWarning: string | undefined;
+
+    while (Date.now() - start < timeoutMs) {
+      const r = await this.readRecent({
+        senderFilter: opts.senderFilter,
+        bodyRegex: opts.bodyRegex,
+        sinceSeconds,
+        limit: 5,
+      });
+      lastWarning = r.warning;
+
+      const hit = r.messages.find((m) => m.otp);
+      if (hit && hit.otp) {
+        return {
+          found: true,
+          otp: hit.otp,
+          sender: hit.sender,
+          body: hit.body,
+          timestamp: hit.timestamp,
+          waitedMs: Date.now() - start,
+          warning: r.warning,
+        };
+      }
+
+      await new Promise((res) => setTimeout(res, pollIntervalMs));
+    }
+
+    return {
+      found: false,
+      waitedMs: Date.now() - start,
+      warning: lastWarning,
+    };
+  }
+}
+
+export interface SmsMessage {
+  sender: string;
+  body: string;
+  timestamp: number; // ms since epoch
+  otp?: string;
+}
+
+export interface SmsReadRecentOptions {
+  limit?: number;
+  senderFilter?: string;
+  bodyRegex?: string;
+  sinceSeconds?: number;
+}
+
+export interface SmsReadRecentResult {
+  messages: SmsMessage[];
+  count: number;
+  warning?: string;
+}
+
+export interface SmsWaitForOtpOptions {
+  senderFilter?: string;
+  bodyRegex?: string;
+  sinceSeconds?: number;
+  timeoutMs?: number;
+  pollIntervalMs?: number;
+}
+
+export type SmsWaitForOtpResult =
+  | {
+      found: true;
+      otp: string;
+      sender: string;
+      body: string;
+      timestamp: number;
+      waitedMs: number;
+      warning?: string;
+    }
+  | {
+      found: false;
+      waitedMs: number;
+      warning?: string;
+    };
+
+/**
+ * Parse `content query --projection address,body,date` output.
+ *
+ * Each row looks like:
+ *   Row: 0 address=AlertBank, body=Your code is 123456, date=1633000000000
+ *
+ * Bodies can legitimately contain commas, so we anchor on the known column
+ * names instead of splitting on `, `. Assumes the projection order
+ * address,body,date — the same order our query passes.
+ */
+function parseContentQuery(stdout: string): SmsMessage[] {
+  const messages: SmsMessage[] = [];
+  for (const line of stdout.split('\n')) {
+    if (!line.trimStart().startsWith('Row:')) continue;
+
+    const addressIdx = line.indexOf('address=');
+    const bodyIdx = line.indexOf(', body=');
+    const dateIdx = line.indexOf(', date=');
+    if (addressIdx === -1 || bodyIdx === -1 || dateIdx === -1) continue;
+    if (!(addressIdx < bodyIdx && bodyIdx < dateIdx)) continue;
+
+    const sender = line.slice(addressIdx + 'address='.length, bodyIdx).trim();
+    const body = line.slice(bodyIdx + ', body='.length, dateIdx);
+    const dateStr = line.slice(dateIdx + ', date='.length).split(/[,\s]/)[0];
+    const timestamp = parseInt(dateStr, 10);
+
+    if (!sender || isNaN(timestamp)) continue;
+    messages.push({ sender, body, timestamp });
+  }
+  return messages;
+}
+
+/**
+ * Heuristic OTP extraction: first standalone 4-8 digit run in the body.
+ */
+function extractOtp(body: string): string | undefined {
+  const match = body.match(/\b(\d{4,8})\b/);
+  return match ? match[1] : undefined;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -789,5 +789,46 @@ export function createMcpServer(deviceManager: DeviceManager): McpServer {
     }
   );
 
+  // ============ SMS / OTP Tools ============
+
+  mcpServer.tool(
+    'sms_read_recent',
+    'Read recent SMS messages from the device inbox. Optionally filter by sender substring/regex, body regex (with capture group for OTP), or recency. Note: some Samsung/OEM devices restrict content://sms/inbox even via adb shell — the response includes a warning when no rows are returned. Use the companion app notification listener (#3) for those devices.',
+    {
+      limit: z.number().optional().default(10).describe('Max messages to return (default 10)'),
+      senderFilter: z.string().optional().describe('Regex/substring match against the sender (case-insensitive)'),
+      bodyRegex: z.string().optional().describe('Regex match against body. If it has a capture group, the captured text becomes the OTP'),
+      sinceSeconds: z.number().optional().describe('Only return messages received within the last N seconds'),
+    },
+    async ({ limit, senderFilter, bodyRegex, sinceSeconds }) => {
+      await ensureDevice();
+      const sms = deviceManager.getSmsCommands();
+      const result = await sms.readRecent({ limit, senderFilter, bodyRegex, sinceSeconds });
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+      };
+    }
+  );
+
+  mcpServer.tool(
+    'sms_wait_for_otp',
+    'Poll the SMS inbox until a matching message arrives or timeout elapses. Returns the extracted OTP string when found. Default timeout 60s, default poll 2s.',
+    {
+      senderFilter: z.string().optional().describe('Regex/substring to match against the sender'),
+      bodyRegex: z.string().optional().describe('Regex against body. If it has a capture group, that becomes the OTP; else first 4-8 digit run is used'),
+      sinceSeconds: z.number().optional().default(60).describe('Initial look-back window for matching messages (default 60s)'),
+      timeoutMs: z.number().optional().default(60000).describe('Max time to wait in milliseconds (default 60000)'),
+      pollIntervalMs: z.number().optional().default(2000).describe('Poll interval in milliseconds (default 2000)'),
+    },
+    async ({ senderFilter, bodyRegex, sinceSeconds, timeoutMs, pollIntervalMs }) => {
+      await ensureDevice();
+      const sms = deviceManager.getSmsCommands();
+      const result = await sms.waitForOtp({ senderFilter, bodyRegex, sinceSeconds, timeoutMs, pollIntervalMs });
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+      };
+    }
+  );
+
   return mcpServer;
 }


### PR DESCRIPTION
## Summary

- Two new MCP tools for OTP capture flows: \`sms_read_recent\` (filters: \`limit\`, \`senderFilter\`, \`bodyRegex\`, \`sinceSeconds\`) and \`sms_wait_for_otp\` (polling with \`timeoutMs\` / \`pollIntervalMs\`, default 60s).
- Auto-OTP extraction: a capture group in \`bodyRegex\` wins, otherwise the first standalone 4-8 digit run.
- Backed by \`adb shell content query --uri content://sms/inbox\` — no root, no companion app. Some Samsung/OEM devices restrict that provider; tools return \`{ messages: [], count: 0, warning: ... }\` instead of failing, and point at the notification-listener fallback in #3.
- New \`src/adb/sms-commands.ts\` mirrors the wifi/ui module shape. Body parsing anchors on known column names because SMS bodies can contain commas.
- 3 YAMLs under \`cicd/tests/testcases/sms/\`, new \`test-sms.yml\` workflow, \`sms\` added to \`SUITES\` in the framework config.
- README: SMS / OTP tools table, OTP-wait usage example, updated project tree.

Fixes #2

## Test plan

- [x] \`npm run build\` succeeds
- [x] \`tsc --noEmit\` clean for server *and* test framework
- [x] Spawn server via stdio + list tools — **30 total** (28 prior + 2 new)
- [x] Ad-hoc smoke against Samsung SM-G9980: tools respond with the empty + warning shape (OEM restriction working as designed)
- [x] \`sms_wait_for_otp\` with 3-second timeout returns \`{ found: false, waitedMs: ~3100 }\` cleanly (no error)
- [x] \`npx tsx src/cli.ts run --suite sms\` — **3/3 pass in 11.9s**
- [x] \`npx tsx src/cli.ts run --suite smoke\` — **7/7 pass** (no regressions)
- [ ] CI workflow (\`test-sms.yml\`) green on a self-hosted runner — *manual once a runner is set up.*
- [ ] Verify SMS path on a stock-Android (non-Samsung) device returns real rows — *requires hardware not in this loop; tests are tolerant of either case.*

Generated with [Claude Code](https://claude.com/claude-code)