### PR TITLE
Proxy upstream MCP servers (e.g. @playwright/mcp) through one endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,16 @@
 # ============ ADB binary override (default: 'adb' on PATH) ============
 # ADB_PATH=/usr/bin/adb
 
+# ============ Upstream MCP proxy — see README "Proxying upstream MCPs" ============
+# Two formats accepted:
+#   1. Shorthand: name=command [args...] ; name=command [args...]
+#   2. JSON array of { name, command, args, env }
+#
+# Default below adds Microsoft's @playwright/mcp as an upstream so all
+# 21 browser_* tools appear in this server's unified tool list. Comment
+# out to disable.
+# UPSTREAM_MCP=playwright=npx -y @playwright/mcp@latest --headless
+
 # ============ WiFi test fixtures (used by the wifi suite — not yet wired) ============
 # TEST_SSID_OPEN=
 # TEST_SSID_WPA2=

--- a/.github/workflows/test-proxy.yml
+++ b/.github/workflows/test-proxy.yml
@@ -1,0 +1,12 @@
+name: "Test: Proxy"
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  test:
+    uses: ./.github/workflows/test-run.yml
+    with:
+      tag: proxy
+    secrets: inherit

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ dist/
 # Test framework artifacts
 cicd/results/
 cicd/tests/dist/
+
+# @playwright/mcp scratch (when used as an upstream)
+.playwright-mcp/

--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ The HTTP `/health` endpoint reports per-upstream state (`connected` / `disconnec
 
 ### Lifecycle
 
-Upstreams start eagerly at server boot. On `SIGINT` / `SIGTERM` the server closes all upstream subprocesses cleanly. Auto-restart on crash is **not** implemented in v1; if an upstream dies, restart the parent server.
+Upstreams start eagerly at server boot. On `SIGINT` / `SIGTERM` the server closes all upstream subprocesses cleanly.
 
 ### Verified composition
 

--- a/README.md
+++ b/README.md
@@ -347,6 +347,40 @@ where adb  # Windows
 - Check `wifi_check_companion_app` returns success
 - Verify the domain suffix match is correct for your RADIUS server
 
+## Proxying upstream MCPs
+
+This server can spawn other MCP servers as subprocesses and surface their tools through its own tool list, so Claude Code only needs **one MCP registration** to access device + WiFi + SMS + UI primitives + browser automation. The canonical example is composing with Microsoft's [`@playwright/mcp`](https://www.npmjs.com/package/@playwright/mcp) for DOM-level browser control.
+
+### How to enable
+
+Set the `UPSTREAM_MCP` environment variable. Two accepted formats:
+
+```bash
+# Shorthand: name=command [args...] ; ... (semicolon-separated for multiple)
+UPSTREAM_MCP="playwright=npx -y @playwright/mcp@latest --headless"
+
+# JSON: an array of { name, command, args?, env? }
+UPSTREAM_MCP='[{"name":"playwright","command":"npx","args":["-y","@playwright/mcp@latest"]}]'
+```
+
+On startup the server spawns each upstream over stdio, fetches its `tools/list`, and registers every tool on its own surface. A call to a proxied tool is forwarded transparently — the client sees one server.
+
+### Tool name collisions
+
+If an upstream's tool name clashes with a native tool or another upstream's tool, the proxy prefixes it with `<upstream-name>__`. Example: a hypothetical second `device_list` from an upstream named `playwright` becomes `playwright__device_list`.
+
+### Health observability
+
+The HTTP `/health` endpoint reports per-upstream state (`connected` / `disconnected` / `failed`, plus `toolCount` and the last error). Stdio mode logs the same to stderr at startup.
+
+### Lifecycle
+
+Upstreams start eagerly at server boot. On `SIGINT` / `SIGTERM` the server closes all upstream subprocesses cleanly. Auto-restart on crash is **not** implemented in v1; if an upstream dies, restart the parent server.
+
+### Verified composition
+
+The default `UPSTREAM_MCP` in `.env.example` is `@playwright/mcp` — running our server with that set yields **51 total tools** (30 native + 21 from `@playwright/mcp`), all reachable from one MCP endpoint. See `cicd/tests/testcases/proxy/TC-PROXY-002.yml` for the end-to-end smoke test.
+
 ## Testing
 
 YAML-driven test framework under `cicd/tests/` runs against an attached Android device using the stdio transport.
@@ -411,6 +445,8 @@ android-wifi-mcp/
 │   ├── index.ts                # Entry — picks transport (HTTP / stdio)
 │   ├── server.ts               # MCP server factory + tool registrations
 │   ├── types.ts                # TypeScript interfaces
+│   ├── mcp/
+│   │   └── upstream-proxy.ts   # Spawn + proxy other MCP servers (@playwright/mcp etc.)
 │   ├── adb/
 │   │   ├── adb-client.ts       # ADB command wrapper
 │   │   ├── device-manager.ts   # Multi-device handling

--- a/cicd/tests/fixtures/mock-mcp-upstream.mjs
+++ b/cicd/tests/fixtures/mock-mcp-upstream.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+/**
+ * Minimal stdio MCP server used by TC-PROXY-001 to verify the upstream
+ * proxy without depending on @playwright/mcp or the network.
+ *
+ * Exposes one tool: `mock_echo` that returns "MOCK_ECHO: <text>".
+ */
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import {
+  ListToolsRequestSchema,
+  CallToolRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+
+const server = new Server(
+  { name: 'mock-upstream', version: '1.0.0' },
+  { capabilities: { tools: {} } }
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: [
+    {
+      name: 'mock_echo',
+      description: 'Echo back the input text — used by TC-PROXY-001.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          text: { type: 'string', description: 'Text to echo' },
+        },
+        required: ['text'],
+      },
+    },
+  ],
+}));
+
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  const { name, arguments: args } = request.params;
+  if (name === 'mock_echo') {
+    return {
+      content: [{ type: 'text', text: `MOCK_ECHO: ${args.text}` }],
+    };
+  }
+  throw new Error(`Unknown tool: ${name}`);
+});
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/cicd/tests/src/config.ts
+++ b/cicd/tests/src/config.ts
@@ -2,7 +2,7 @@
  * Project configuration for the test framework.
  */
 
-export const SUITES = ['smoke', 'wifi', 'enterprise', 'ui', 'sms', 'portal'] as const;
+export const SUITES = ['smoke', 'wifi', 'enterprise', 'ui', 'sms', 'portal', 'proxy'] as const;
 export type Suite = typeof SUITES[number];
 
 export const CONFIG = {

--- a/cicd/tests/testcases/proxy/TC-PROXY-001.yml
+++ b/cicd/tests/testcases/proxy/TC-PROXY-001.yml
@@ -1,0 +1,25 @@
+id: TC-PROXY-001
+name: Proxy exposes a mock upstream's tool through the unified namespace
+suite: proxy
+tags: [proxy]
+priority: 1
+timeout: 60000
+dependencies: []
+
+steps:
+  - name: Call mock_echo through our server (proxied from mock upstream)
+    command: |
+      UPSTREAM_MCP='mock=node cicd/tests/fixtures/mock-mcp-upstream.mjs' \
+        npx tsx cicd/tests/src/mcp-client.ts mock_echo '{"text":"hello-from-test"}'
+    expectPatterns:
+      - "MOCK_ECHO: hello-from-test"
+    rejectPatterns:
+      - "isError"
+      - "Unknown tool"
+
+criteria: |
+  Verify the upstream proxy mechanism works end-to-end with no external deps.
+  - Our server spawns the mock upstream subprocess via UPSTREAM_MCP
+  - The mock's mock_echo tool is registered into our unified tools list
+  - tools/call routes the call to the mock subprocess and returns the result
+  - The text argument passes through the proxy unchanged

--- a/cicd/tests/testcases/proxy/TC-PROXY-002.yml
+++ b/cicd/tests/testcases/proxy/TC-PROXY-002.yml
@@ -1,0 +1,28 @@
+id: TC-PROXY-002
+name: Proxy exposes @playwright/mcp browser_navigate via host Chromium
+suite: proxy
+tags: [proxy, playwright]
+priority: 2
+timeout: 180000
+dependencies: []
+
+steps:
+  - name: browser_navigate to https://example.com via the proxied playwright server
+    command: |
+      UPSTREAM_MCP='playwright=npx -y @playwright/mcp@latest --headless' \
+        npx tsx cicd/tests/src/mcp-client.ts browser_navigate '{"url":"https://example.com"}'
+    timeout: 150000
+    expectPatterns:
+      - "Page URL"
+      - "example.com"
+      - "Example Domain"
+    rejectPatterns:
+      - "isError"
+      - "Unknown tool"
+
+criteria: |
+  Verify the proxy works with a real upstream MCP (@playwright/mcp).
+  - First run downloads @playwright/mcp + browsers if not cached (longer timeout)
+  - Our server spawns it as an upstream and registers all 21 browser_* tools
+  - browser_navigate to https://example.com returns Page URL and Page Title
+  - This validates the canonical use case: device + WiFi + browser via one MCP endpoint

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { DeviceManager } from './adb/device-manager.js';
 import { createMcpServer } from './server.js';
+import { UpstreamProxy, parseUpstreamConfig } from './mcp/upstream-proxy.js';
 
 const useStdio = process.argv.includes('--stdio');
 
@@ -11,10 +12,12 @@ if (useStdio) {
 }
 
 const deviceManager = new DeviceManager();
-const mcpServer = createMcpServer(deviceManager);
+const { server: mcpServer, nativeToolNames } = createMcpServer(deviceManager);
+const upstreamProxy = new UpstreamProxy();
 
 const shutdown = async () => {
   console.log('Shutting down...');
+  await upstreamProxy.closeAll().catch(() => {});
   process.exit(0);
 };
 
@@ -38,10 +41,19 @@ async function initDevice(): Promise<void> {
   }
 }
 
+async function initUpstreamProxy(): Promise<void> {
+  const configs = parseUpstreamConfig(process.env.UPSTREAM_MCP);
+  if (configs.length === 0) return;
+  console.log(`Connecting ${configs.length} upstream MCP server(s)...`);
+  await upstreamProxy.connectAll(configs, nativeToolNames);
+  upstreamProxy.attach(mcpServer);
+}
+
 async function startStdio(): Promise<void> {
   const { StdioServerTransport } = await import('@modelcontextprotocol/sdk/server/stdio.js');
 
   await initDevice();
+  await initUpstreamProxy();
 
   const transport = new StdioServerTransport();
   await mcpServer.connect(transport);
@@ -94,10 +106,12 @@ async function startHttp(): Promise<void> {
       version: '1.0.0',
       adb: adbAvailable,
       connectedDevices: deviceCount,
+      upstreams: upstreamProxy.getStatus(),
     });
   });
 
   await initDevice();
+  await initUpstreamProxy();
 
   const PORT = process.env.PORT || 3000;
   const HOST = process.env.HOST || '0.0.0.0';

--- a/src/mcp/upstream-proxy.ts
+++ b/src/mcp/upstream-proxy.ts
@@ -1,0 +1,255 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import {
+  ListToolsRequestSchema,
+  CallToolRequestSchema,
+  type Tool,
+} from '@modelcontextprotocol/sdk/types.js';
+
+export interface UpstreamConfig {
+  name: string;
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+}
+
+export interface UpstreamStatus {
+  name: string;
+  command: string;
+  args: string[];
+  state: 'connected' | 'disconnected' | 'failed';
+  toolCount: number;
+  lastError?: string;
+}
+
+interface UpstreamEntry {
+  config: UpstreamConfig;
+  client?: Client;
+  transport?: StdioClientTransport;
+  status: UpstreamStatus;
+  /** Map from final (possibly prefixed) tool name → original upstream tool name */
+  toolNameMap: Map<string, string>;
+}
+
+/**
+ * Manages a set of upstream MCP servers spawned as subprocesses over stdio.
+ * Their tools are surfaced through this server's tools/list and routed via
+ * tools/call, so callers see one unified namespace.
+ *
+ * Tool name collision strategy: prefer the upstream's original name; if a
+ * collision exists with a native tool or another upstream's tool, prefix
+ * with `<upstream-name>__`.
+ */
+export class UpstreamProxy {
+  private upstreams: Map<string, UpstreamEntry> = new Map();
+  private toolToUpstream: Map<string, string> = new Map();
+  private toolDefs: Map<string, Tool> = new Map();
+  /** Names of native tools (so we know what counts as a collision) */
+  private nativeToolNames: Set<string> = new Set();
+
+  /**
+   * Connect to all configured upstreams. Failures are recorded in status but
+   * do not throw — startup continues so a flaky upstream doesn't take the
+   * whole server down.
+   */
+  async connectAll(configs: UpstreamConfig[], nativeToolNames: string[]): Promise<void> {
+    this.nativeToolNames = new Set(nativeToolNames);
+
+    for (const config of configs) {
+      const entry: UpstreamEntry = {
+        config,
+        status: {
+          name: config.name,
+          command: config.command,
+          args: config.args ?? [],
+          state: 'disconnected',
+          toolCount: 0,
+        },
+        toolNameMap: new Map(),
+      };
+      this.upstreams.set(config.name, entry);
+
+      try {
+        await this.connectOne(entry);
+      } catch (e) {
+        entry.status.state = 'failed';
+        entry.status.lastError = (e as Error).message;
+        process.stderr.write(
+          `[upstream:${config.name}] connect failed: ${(e as Error).message}\n`
+        );
+      }
+    }
+  }
+
+  private async connectOne(entry: UpstreamEntry): Promise<void> {
+    const transport = new StdioClientTransport({
+      command: entry.config.command,
+      args: entry.config.args ?? [],
+      env: { ...process.env, ...entry.config.env } as Record<string, string>,
+    });
+    const client = new Client({
+      name: `android-wifi-mcp-proxy:${entry.config.name}`,
+      version: '1.0.0',
+    });
+
+    await client.connect(transport);
+    entry.transport = transport;
+    entry.client = client;
+
+    const tools = await client.listTools();
+    for (const tool of tools.tools) {
+      const finalName = this.resolveToolName(entry.config.name, tool.name);
+      entry.toolNameMap.set(finalName, tool.name);
+      this.toolToUpstream.set(finalName, entry.config.name);
+      this.toolDefs.set(finalName, { ...tool, name: finalName });
+    }
+
+    entry.status.state = 'connected';
+    entry.status.toolCount = tools.tools.length;
+    process.stderr.write(
+      `[upstream:${entry.config.name}] connected, ${tools.tools.length} tool(s)\n`
+    );
+  }
+
+  /**
+   * Decide the final tool name in our merged namespace.
+   * Prefer the upstream's name; on collision, prefix with `<upstream>__`.
+   */
+  private resolveToolName(upstreamName: string, toolName: string): string {
+    if (!this.nativeToolNames.has(toolName) && !this.toolToUpstream.has(toolName)) {
+      return toolName;
+    }
+    return `${upstreamName}__${toolName}`;
+  }
+
+  hasTool(name: string): boolean {
+    return this.toolToUpstream.has(name);
+  }
+
+  getTools(): Tool[] {
+    return Array.from(this.toolDefs.values());
+  }
+
+  getStatus(): UpstreamStatus[] {
+    return Array.from(this.upstreams.values()).map((e) => ({ ...e.status }));
+  }
+
+  async callTool(name: string, args: Record<string, unknown>): Promise<unknown> {
+    const upstreamName = this.toolToUpstream.get(name);
+    if (!upstreamName) {
+      throw new Error(`No upstream registered for tool '${name}'`);
+    }
+    const entry = this.upstreams.get(upstreamName);
+    if (!entry?.client) {
+      throw new Error(`Upstream '${upstreamName}' is not connected`);
+    }
+    const originalName = entry.toolNameMap.get(name) ?? name;
+    return await entry.client.callTool({
+      name: originalName,
+      arguments: args,
+    });
+  }
+
+  async closeAll(): Promise<void> {
+    for (const entry of this.upstreams.values()) {
+      try {
+        await entry.client?.close();
+      } catch {
+        // ignore
+      }
+    }
+    this.upstreams.clear();
+    this.toolToUpstream.clear();
+    this.toolDefs.clear();
+  }
+
+  /**
+   * Wire the proxy into an existing McpServer by replacing its tools/list and
+   * tools/call request handlers. The original handlers are preserved and
+   * called for native tools.
+   *
+   * This reaches into the SDK's private `_requestHandlers` Map. If the SDK
+   * changes that surface, this method needs an update.
+   */
+  attach(mcpServer: McpServer): void {
+    /* eslint-disable @typescript-eslint/no-explicit-any */
+    const server = mcpServer.server;
+    const handlers = (server as any)._requestHandlers as Map<
+      string,
+      (request: any, extra: any) => Promise<any>
+    >;
+
+    const originalList = handlers.get('tools/list');
+    const originalCall = handlers.get('tools/call');
+    if (!originalList || !originalCall) {
+      throw new Error(
+        'McpServer has not registered tools/list or tools/call yet — call attach() after native tools are registered'
+      );
+    }
+
+    server.setRequestHandler(ListToolsRequestSchema, async (request, extra) => {
+      const nativeResp = await originalList(request, extra);
+      return { tools: [...(nativeResp.tools ?? []), ...this.getTools()] };
+    });
+
+    server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
+      const name = request.params.name;
+      if (this.hasTool(name)) {
+        return (await this.callTool(
+          name,
+          (request.params.arguments as Record<string, unknown>) ?? {}
+        )) as any;
+      }
+      return await originalCall(request, extra);
+    });
+    /* eslint-enable @typescript-eslint/no-explicit-any */
+  }
+}
+
+/**
+ * Parse the `UPSTREAM_MCP` env variable into a list of upstream configs.
+ *
+ * Two accepted formats:
+ *   1. JSON array: `UPSTREAM_MCP='[{"name":"playwright","command":"npx","args":["-y","@playwright/mcp@latest"]}]'`
+ *   2. Semicolon-separated entries, each `name=command [arg1 arg2 ...]`:
+ *      `UPSTREAM_MCP="playwright=npx -y @playwright/mcp@latest"`
+ *
+ * Multiple entries in shorthand form are separated by `;`.
+ */
+export function parseUpstreamConfig(raw: string | undefined): UpstreamConfig[] {
+  if (!raw || !raw.trim()) return [];
+
+  const trimmed = raw.trim();
+  if (trimmed.startsWith('[')) {
+    try {
+      const parsed = JSON.parse(trimmed) as UpstreamConfig[];
+      return parsed.map((c) => ({
+        name: c.name,
+        command: c.command,
+        args: c.args ?? [],
+        env: c.env,
+      }));
+    } catch (e) {
+      throw new Error(`UPSTREAM_MCP JSON parse failed: ${(e as Error).message}`);
+    }
+  }
+
+  const out: UpstreamConfig[] = [];
+  for (const entry of trimmed.split(';').map((s) => s.trim()).filter(Boolean)) {
+    const eq = entry.indexOf('=');
+    if (eq < 0) {
+      throw new Error(`UPSTREAM_MCP entry missing '=': ${entry}`);
+    }
+    const name = entry.slice(0, eq).trim();
+    const rest = entry.slice(eq + 1).trim();
+    if (!name || !rest) {
+      throw new Error(`UPSTREAM_MCP entry malformed: ${entry}`);
+    }
+    const tokens = rest.match(/[^\s"']+|"[^"]*"|'[^']*'/g) ?? [];
+    const command = tokens[0]?.replace(/^["']|["']$/g, '') ?? '';
+    const args = tokens.slice(1).map((t) => t.replace(/^["']|["']$/g, ''));
+    out.push({ name, command, args });
+  }
+  return out;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,11 +5,26 @@ import { NetworkCheck } from './network/network-check.js';
 import { EnterpriseWifiCommands } from './adb/enterprise-wifi.js';
 import { SecurityType, EapMethod, Phase2Method } from './types.js';
 
-export function createMcpServer(deviceManager: DeviceManager): McpServer {
+export interface CreateServerResult {
+  server: McpServer;
+  nativeToolNames: string[];
+}
+
+export function createMcpServer(deviceManager: DeviceManager): CreateServerResult {
   const mcpServer = new McpServer({
     name: 'android-wifi-mcp',
     version: '1.0.0',
   });
+  const nativeToolNames: string[] = [];
+
+  // Wrap mcpServer.tool to also collect names so the upstream proxy can
+  // detect collisions without reaching into McpServer internals.
+  const originalTool = mcpServer.tool.bind(mcpServer);
+  mcpServer.tool = ((name: string, ...rest: unknown[]) => {
+    nativeToolNames.push(name);
+    // @ts-expect-error — pass-through to the wrapped overloaded method.
+    return originalTool(name, ...rest);
+  }) as typeof mcpServer.tool;
 
   async function ensureDevice(): Promise<void> {
     await deviceManager.ensureDeviceSelected();
@@ -830,5 +845,5 @@ export function createMcpServer(deviceManager: DeviceManager): McpServer {
     }
   );
 
-  return mcpServer;
+  return { server: mcpServer, nativeToolNames };
 }


### PR DESCRIPTION
## Summary

- This server now spawns other MCP servers as **stdio subprocesses** on startup and surfaces their tools through its own \`tools/list\` and \`tools/call\`. Claude Code only needs **one MCP registration** to access device + WiFi + SMS + UI primitives plus whatever the upstream(s) expose.
- Configured via the \`UPSTREAM_MCP\` env var. Two formats:
  - Shorthand: \`name=command [args...] ; ...\`
  - JSON array: \`[{ name, command, args, env }]\`
- New \`src/mcp/upstream-proxy.ts\` (\`UpstreamProxy\` class). \`attach()\` replaces the McpServer's \`tools/list\` and \`tools/call\` request handlers with merged versions — original handlers are preserved and called for native tools, proxied tools forward via the upstream \`Client\`. Tool name collisions get prefixed with \`<upstream-name>__\`.
- \`/health\` reports per-upstream state (\`connected\` / \`disconnected\` / \`failed\`, \`toolCount\`, \`lastError\`). Clean shutdown closes all upstreams on SIGINT / SIGTERM.
- \`createMcpServer()\` now returns \`{ server, nativeToolNames }\` so the proxy can detect collisions without reaching into McpServer's private \`_registeredTools\`.
- New \`proxy/\` test suite: TC-PROXY-001 (tiny mock upstream, no external deps) + TC-PROXY-002 (real \`@playwright/mcp\`, \`browser_navigate\` to example.com).
- README "Proxying upstream MCPs" section, \`.env.example\` documents the default, \`.gitignore\` excludes \`.playwright-mcp/\`.

Supersedes #10 (which was closed in favor of composition with \`@playwright/mcp\`).

Fixes #14

## Test plan

- [x] \`npm run build\` succeeds; \`tsc --noEmit\` clean for server *and* test framework
- [x] \`UPSTREAM_MCP=playwright=...\` exposes 51 tools (30 native + 21 from \`@playwright/mcp\`)
- [x] \`cicd/tests/src/cli.ts run --suite proxy\` — **2/2 pass** (mock + @playwright/mcp), 9.4s
- [x] \`run --suite smoke\` — **7/7 pass**, no regressions
- [x] \`run --suite ui\` — **9/9 pass**, no regressions
- [x] **End-to-end through Claude Code itself**: registered \`android-wifi\` as stdio + UPSTREAM_MCP via \`claude mcp add\`, reconnected, then in-session \`browser_navigate https://example.com\` returned the correct page title; \`browser_evaluate\` against the live HN front page returned the top 5 stories; navigation against amazon.com returned title + nav menu items
- [x] Clean shutdown: SIGINT / SIGTERM closes upstreams (verified via \`closeAll\` calls in \`UpstreamProxy\`)
- [ ] CI workflow (\`test-proxy.yml\`) green on a self-hosted runner — *manual once a runner is set up.*

## Implementation note

\`attach()\` reaches into the SDK's private \`_requestHandlers\` Map to wrap the existing handlers — this is the only practical way to merge native + proxied tools without re-implementing McpServer's tool-call dispatch. Flagged in the file with an upgrade-risk comment so future SDK changes don't silently break the proxy.

Generated with [Claude Code](https://claude.com/claude-code)