### PR TITLE
Add PLAYWRIGHT_HEADED env toggle for proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,11 @@
 # out to disable.
 # UPSTREAM_MCP=playwright=npx -y @playwright/mcp@latest --headless
 
+# When set to 1/true, strips `--headless` from the playwright upstream's args
+# at startup so Chromium runs visible. Lets you toggle headed/headless without
+# re-running `claude mcp add`.
+# PLAYWRIGHT_HEADED=1
+
 # ============ WiFi test fixtures (used by the wifi suite — not yet wired) ============
 # TEST_SSID_OPEN=
 # TEST_SSID_WPA2=

--- a/README.md
+++ b/README.md
@@ -379,6 +379,14 @@ If an upstream's tool name clashes with a native tool or another upstream's tool
 
 The HTTP `/health` endpoint reports per-upstream state (`connected` / `disconnected` / `failed`, plus `toolCount` and the last error). Stdio mode logs the same to stderr at startup.
 
+### Per-upstream env overrides
+
+Recognized today:
+
+| Env var | Effect |
+|---|---|
+| `PLAYWRIGHT_HEADED=1` | Strips `--headless` from the args of an upstream named `playwright` at startup so Chromium runs visible. Saves having to rewrite `UPSTREAM_MCP` and re-register the server. |
+
 ### Lifecycle
 
 Upstreams start eagerly at server boot. On `SIGINT` / `SIGTERM` the server closes all upstream subprocesses cleanly.

--- a/src/mcp/upstream-proxy.ts
+++ b/src/mcp/upstream-proxy.ts
@@ -55,8 +55,9 @@ export class UpstreamProxy {
    */
   async connectAll(configs: UpstreamConfig[], nativeToolNames: string[]): Promise<void> {
     this.nativeToolNames = new Set(nativeToolNames);
+    const adjusted = configs.map((c) => applyEnvOverrides(c));
 
-    for (const config of configs) {
+    for (const config of adjusted) {
       const entry: UpstreamEntry = {
         config,
         status: {
@@ -205,6 +206,20 @@ export class UpstreamProxy {
     });
     /* eslint-enable @typescript-eslint/no-explicit-any */
   }
+}
+
+/**
+ * Apply per-upstream env-var overrides. Today only one is recognized:
+ * `PLAYWRIGHT_HEADED=1` — when set, strips `--headless` from the args of any
+ * upstream named `playwright`. Lets users flip @playwright/mcp's window
+ * visibility without re-running `claude mcp add`.
+ */
+function applyEnvOverrides(config: UpstreamConfig): UpstreamConfig {
+  if (config.name !== 'playwright') return config;
+  const flag = process.env.PLAYWRIGHT_HEADED;
+  if (!flag || flag === '0' || flag.toLowerCase() === 'false') return config;
+  if (!config.args?.includes('--headless')) return config;
+  return { ...config, args: config.args.filter((a) => a !== '--headless') };
 }
 
 /**


### PR DESCRIPTION
## Summary

- Set \`PLAYWRIGHT_HEADED=1\` to strip \`--headless\` from the args of any upstream named \`playwright\` at startup.
- Lets users flip @playwright/mcp's window visibility without rewriting \`UPSTREAM_MCP\` and re-running \`claude mcp add\` — edit ~/.claude.json's env block, /mcp reconnect, done.
- Opt-in. Default (unset) is the exact same behavior as before — args pass through verbatim.
- Implemented as a 5-line \`applyEnvOverrides\` helper in \`src/mcp/upstream-proxy.ts\` called once at \`connectAll()\` start.
- README "Per-upstream env overrides" subsection added; \`.env.example\` documents the new var.

## Test plan

- [x] \`npm run build\` succeeds; \`tsc --noEmit\` clean
- [x] Proxy suite still passes (2/2) with \`PLAYWRIGHT_HEADED\` unset — regression-clean
- [x] Code inspection: \`applyEnvOverrides\` only mutates when \`name === 'playwright'\` AND \`PLAYWRIGHT_HEADED\` is truthy AND \`--headless\` is in args
- [ ] Manual verification of headed mode would require visible Chromium — out of scope for this self-contained CI loop. The 5-line helper is small enough to verify by inspection.
- [ ] Dedicated unit test deferred to task #6 (parser + collision + this toggle covered together)

Generated with [Claude Code](https://claude.com/claude-code)