### PR TITLE
Add notification listener in companion app for OTP capture

### DIFF
--- a/.github/workflows/test-notifications.yml
+++ b/.github/workflows/test-notifications.yml
@@ -1,0 +1,12 @@
+name: "Test: Notifications"
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  test:
+    uses: ./.github/workflows/test-run.yml
+    with:
+      tag: notifications
+    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Enterprise WiFi (802.1X/EAP) requires a companion Android app because the `cmd w
 
 ## Available Tools
 
-**30 native tools** in 6 categories below. With the optional `@playwright/mcp` upstream enabled (see [Proxying upstream MCPs](#proxying-upstream-mcps)), an additional **21 `browser_*` tools** are surfaced through the same endpoint for **51 total**.
+**32 native tools** in 7 categories below. With the optional `@playwright/mcp` upstream enabled (see [Proxying upstream MCPs](#proxying-upstream-mcps)), an additional **21 `browser_*` tools** are surfaced through the same endpoint for **53 total**.
 
 ### Device Management
 
@@ -219,6 +219,15 @@ Reads SMS messages from `content://sms/inbox` via adb shell — no root, no comp
 |------|-------------|
 | `sms_read_recent` | Read recent SMS, optionally filtered by sender, body regex, or recency |
 | `sms_wait_for_otp` | Poll the inbox until a matching OTP arrives or timeout elapses |
+
+### Notification capture (companion app)
+
+For OTPs that don't come via SMS — WhatsApp, banking apps, email clients, etc. The companion app's `NotificationListenerService` captures every notification system-wide, then the host MCP server reads them through the same broadcast bridge used for enterprise WiFi. **Requires** the user to grant **Notification access** to the companion app once via Settings → Notifications → Notification access (the app's main screen has a one-tap shortcut). Granted state is reported by `wifi_check_companion_app`.
+
+| Tool | Description |
+|------|-------------|
+| `notifications_list_recent` | List recent captured notifications, optionally filtered by package or body regex |
+| `notifications_wait_for_otp` | Poll captured notifications until a matching OTP arrives or timeout elapses |
 
 ### Proxied (optional)
 
@@ -428,6 +437,7 @@ Results land in `cicd/results/<timestamp>_<suite>/` (`summary.json` plus one `<t
 | `smoke` | Read-only checks against existing tools — safe to run any time | 7 tests |
 | `ui` | UI-automation primitives (`device_*` from #1) | 9 tests |
 | `sms` | SMS / OTP shape checks (tolerates Samsung-restricted inboxes) | 3 tests |
+| `notifications` | Notification capture via companion app (OTPs from any package) | 3 tests |
 | `proxy` | Upstream MCP proxying — mock + `@playwright/mcp` end-to-end | 2 tests |
 | `wifi` | Connect/disconnect/forget against test SSIDs (env-driven) | not yet |
 | `enterprise` | 802.1X (PEAP/TTLS/TLS) — needs companion app + RADIUS fixtures | not yet |
@@ -469,6 +479,7 @@ android-wifi-mcp/
 │   │   ├── wifi-commands.ts    # cmd wifi wrapper
 │   │   ├── ui-commands.ts      # input / am start / screencap / uiautomator
 │   │   ├── sms-commands.ts     # SMS read / OTP polling via content provider
+│   │   ├── notifications-commands.ts # Notification capture via companion app
 │   │   └── enterprise-wifi.ts  # 802.1X enterprise WiFi
 │   └── network/
 │       └── network-check.ts    # Network diagnostics
@@ -484,10 +495,10 @@ android-wifi-mcp/
 │   │   │   ├── mcp-client.ts   # stdio MCP client
 │   │   │   ├── loader.ts, judge/, reporter/, types.ts, config.ts
 │   │   │   └── ...
-│   │   ├── testcases/<suite>/  # smoke, ui, sms, proxy (wifi/enterprise/portal pending)
+│   │   ├── testcases/<suite>/  # smoke, ui, sms, notifications, proxy (wifi/enterprise/portal pending)
 │   │   └── fixtures/           # mock-mcp-upstream.mjs (used by TC-PROXY-001)
 │   └── results/                # JSON per-run results
-├── .github/workflows/          # build.yml, test-run.yml, test-{smoke,ui,sms,proxy}.yml, ci.yml
+├── .github/workflows/          # build.yml, test-run.yml, test-{smoke,ui,sms,notifications,proxy}.yml, ci.yml
 ├── .claude/skills/             # ci-testcase, ci-run
 ├── .env.example
 ├── package.json

--- a/cicd/tests/src/config.ts
+++ b/cicd/tests/src/config.ts
@@ -2,7 +2,7 @@
  * Project configuration for the test framework.
  */
 
-export const SUITES = ['smoke', 'wifi', 'enterprise', 'ui', 'sms', 'portal', 'proxy'] as const;
+export const SUITES = ['smoke', 'wifi', 'enterprise', 'ui', 'sms', 'notifications', 'portal', 'proxy'] as const;
 export type Suite = typeof SUITES[number];
 
 export const CONFIG = {

--- a/cicd/tests/testcases/notifications/TC-NOTIF-001.yml
+++ b/cicd/tests/testcases/notifications/TC-NOTIF-001.yml
@@ -1,0 +1,24 @@
+id: TC-NOTIF-001
+name: notifications_list_recent returns the standard shape
+suite: notifications
+tags: [notifications]
+priority: 1
+timeout: 30000
+dependencies: []
+
+steps:
+  - name: List recent notifications via the companion app
+    command: npx tsx cicd/tests/src/mcp-client.ts notifications_list_recent '{"limit":5}'
+    expectPatterns:
+      - "notifications"
+      - "count"
+    rejectPatterns:
+      - "isError"
+
+criteria: |
+  Verify notifications_list_recent returns the expected response shape.
+  - Tool returns successfully without errors
+  - Response contains notifications array and count field
+  - Result may be empty if no notifications were posted recently or if
+    notification access has not been granted yet — both are valid states
+    for the shape check (warning field surfaces the diagnostic)

--- a/cicd/tests/testcases/notifications/TC-NOTIF-002.yml
+++ b/cicd/tests/testcases/notifications/TC-NOTIF-002.yml
@@ -1,0 +1,25 @@
+id: TC-NOTIF-002
+name: notifications_wait_for_otp returns cleanly on short timeout
+suite: notifications
+tags: [notifications]
+priority: 2
+timeout: 30000
+dependencies: []
+
+steps:
+  - name: Wait briefly for an OTP that may not arrive
+    command: npx tsx cicd/tests/src/mcp-client.ts notifications_wait_for_otp '{"timeoutMs":3000,"pollIntervalMs":500,"packageFilter":"unlikely-test-only-package"}'
+    expectPatterns:
+      - "found"
+      - "waitedMs"
+    rejectPatterns:
+      - "isError"
+
+criteria: |
+  Verify notifications_wait_for_otp returns cleanly on timeout.
+  - Tool accepts timeoutMs, pollIntervalMs, packageFilter
+  - Response always contains found and waitedMs fields
+  - The unlikely package filter ensures the timeout path is exercised
+    without depending on the absence of any captured notifications
+  - When a real OTP does arrive, the response carries otp + packageName
+    + title + text

--- a/cicd/tests/testcases/notifications/TC-NOTIF-003.yml
+++ b/cicd/tests/testcases/notifications/TC-NOTIF-003.yml
@@ -1,0 +1,25 @@
+id: TC-NOTIF-003
+name: wifi_check_companion_app reports notification access state
+suite: notifications
+tags: [notifications]
+priority: 3
+timeout: 15000
+dependencies: []
+
+steps:
+  - name: Check companion app status
+    command: npx tsx cicd/tests/src/mcp-client.ts wifi_check_companion_app '{}'
+    expectPatterns:
+      - "companionAppInstalled"
+      - "notificationAccessGranted"
+      - "capturedNotifications"
+    rejectPatterns:
+      - "isError"
+
+criteria: |
+  Verify wifi_check_companion_app surfaces the notification listener state.
+  - Tool returns successfully without errors
+  - Response now includes notificationAccessGranted and capturedNotifications
+    fields in addition to the original companionAppInstalled
+  - Values may be true/false depending on the runner's setup; the test
+    only verifies the fields are present (shape check)

--- a/companion-app/app/src/main/AndroidManifest.xml
+++ b/companion-app/app/src/main/AndroidManifest.xml
@@ -20,6 +20,10 @@
     <!-- Foreground service for long-running operations -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
+    <!-- Notification listener for OTP capture (granted manually via Notification access) -->
+    <uses-permission android:name="android.permission.BIND_NOTIFICATION_LISTENER_SERVICE"
+        tools:ignore="ProtectedPermissions" />
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
@@ -50,8 +54,21 @@
                 <action android:name="com.example.wifimcpcompanion.INSTALL_CERTIFICATE" />
                 <action android:name="com.example.wifimcpcompanion.LIST_CERTIFICATES" />
                 <action android:name="com.example.wifimcpcompanion.DISCONNECT" />
+                <action android:name="com.example.wifimcpcompanion.LIST_NOTIFICATIONS" />
+                <action android:name="com.example.wifimcpcompanion.NOTIFICATION_STATUS" />
             </intent-filter>
         </receiver>
+
+        <!-- System-wide notification capture for OTPs (WhatsApp / email / banking) -->
+        <service
+            android:name=".NotificationCaptureService"
+            android:exported="true"
+            android:label="@string/notification_listener_label"
+            android:permission="android.permission.BIND_NOTIFICATION_LISTENER_SERVICE">
+            <intent-filter>
+                <action android:name="android.service.notification.NotificationListenerService" />
+            </intent-filter>
+        </service>
 
     </application>
 

--- a/companion-app/app/src/main/kotlin/com/example/wifimcpcompanion/AdbBridgeReceiver.kt
+++ b/companion-app/app/src/main/kotlin/com/example/wifimcpcompanion/AdbBridgeReceiver.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Environment
 import android.util.Log
+import org.json.JSONArray
 import org.json.JSONObject
 import java.io.File
 
@@ -20,6 +21,8 @@ class AdbBridgeReceiver : BroadcastReceiver() {
         const val ACTION_INSTALL_CERTIFICATE = "com.example.wifimcpcompanion.INSTALL_CERTIFICATE"
         const val ACTION_LIST_CERTIFICATES = "com.example.wifimcpcompanion.LIST_CERTIFICATES"
         const val ACTION_DISCONNECT = "com.example.wifimcpcompanion.DISCONNECT"
+        const val ACTION_LIST_NOTIFICATIONS = "com.example.wifimcpcompanion.LIST_NOTIFICATIONS"
+        const val ACTION_NOTIFICATION_STATUS = "com.example.wifimcpcompanion.NOTIFICATION_STATUS"
 
         const val EXTRA_CONFIG_FILE = "config_file"
 
@@ -42,6 +45,8 @@ class AdbBridgeReceiver : BroadcastReceiver() {
                 ACTION_INSTALL_CERTIFICATE -> handleInstallCertificate(context, intent)
                 ACTION_LIST_CERTIFICATES -> handleListCertificates(context)
                 ACTION_DISCONNECT -> handleDisconnect(context, intent)
+                ACTION_LIST_NOTIFICATIONS -> handleListNotifications(intent)
+                ACTION_NOTIFICATION_STATUS -> handleNotificationStatus()
                 else -> {
                     Log.w(TAG, "Unknown action: ${intent.action}")
                     writeResult(false, "Unknown action", mapOf("action" to (intent.action ?: "null")))
@@ -184,6 +189,62 @@ class AdbBridgeReceiver : BroadcastReceiver() {
         )
     }
 
+    private fun handleListNotifications(intent: Intent) {
+        // Optional filter params from the command file (sinceMs, packageFilter, limit).
+        val configFile = intent.getStringExtra(EXTRA_CONFIG_FILE)
+        val cfg = configFile?.let { readConfigFile(it) }
+        val sinceMs = cfg?.optLong("sinceMs", 0L) ?: 0L
+        val packageFilter = cfg?.optString("packageFilter", null)
+        val limit = cfg?.optInt("limit", 50) ?: 50
+
+        if (!NotificationCaptureService.listenerConnected) {
+            writeResult(
+                false,
+                "NotificationCaptureService is not connected. Has notification access been granted? See Settings → Notifications → Notification access.",
+                mapOf("action" to "list_notifications")
+            )
+            return
+        }
+
+        val packageRegex = packageFilter?.let { Regex(it, RegexOption.IGNORE_CASE) }
+        val matches = NotificationCaptureService.captured
+            .asSequence()
+            .filter { it.timestamp >= sinceMs }
+            .filter { packageRegex == null || packageRegex.containsMatchIn(it.packageName) }
+            .take(limit)
+            .map { n ->
+                mapOf(
+                    "packageName" to n.packageName,
+                    "title" to n.title,
+                    "text" to n.text,
+                    "timestamp" to n.timestamp
+                )
+            }
+            .toList()
+
+        writeResult(
+            true,
+            "Returned ${matches.size} notification(s)",
+            mapOf(
+                "action" to "list_notifications",
+                "count" to matches.size,
+                "notifications" to matches
+            )
+        )
+    }
+
+    private fun handleNotificationStatus() {
+        writeResult(
+            true,
+            if (NotificationCaptureService.listenerConnected) "Notification listener connected" else "Notification access not granted",
+            mapOf(
+                "action" to "notification_status",
+                "listenerConnected" to NotificationCaptureService.listenerConnected,
+                "capturedCount" to NotificationCaptureService.captured.size
+            )
+        )
+    }
+
     private fun handleListCertificates(context: Context) {
         val certManager = CertificateManager(context)
         val certificates = certManager.listCertificates()
@@ -240,7 +301,7 @@ class AdbBridgeReceiver : BroadcastReceiver() {
                 put("message", message)
                 put("timestamp", System.currentTimeMillis())
                 extra.forEach { (key, value) ->
-                    put(key, value)
+                    put(key, toJson(value))
                 }
             }
 
@@ -249,6 +310,20 @@ class AdbBridgeReceiver : BroadcastReceiver() {
             Log.i(TAG, "Result written to ${RESULT_FILE.absolutePath}")
         } catch (e: Exception) {
             Log.e(TAG, "Failed to write result file", e)
+        }
+    }
+
+    /** Recursively wrap nested Map / Collection in JSONObject / JSONArray so they serialize properly. */
+    private fun toJson(value: Any?): Any? {
+        return when (value) {
+            null -> JSONObject.NULL
+            is Map<*, *> -> JSONObject().apply {
+                value.forEach { (k, v) -> if (k != null) put(k.toString(), toJson(v)) }
+            }
+            is Collection<*> -> JSONArray().apply {
+                value.forEach { put(toJson(it)) }
+            }
+            else -> value
         }
     }
 }

--- a/companion-app/app/src/main/kotlin/com/example/wifimcpcompanion/MainActivity.kt
+++ b/companion-app/app/src/main/kotlin/com/example/wifimcpcompanion/MainActivity.kt
@@ -1,9 +1,11 @@
 package com.example.wifimcpcompanion
 
 import android.Manifest
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
+import android.provider.Settings
 import android.widget.Button
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
@@ -22,6 +24,8 @@ class MainActivity : AppCompatActivity() {
 
     private lateinit var statusText: TextView
     private lateinit var permissionButton: Button
+    private lateinit var notificationStatusText: TextView
+    private lateinit var notificationAccessButton: Button
 
     private val requiredPermissions = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
         arrayOf(
@@ -46,17 +50,38 @@ class MainActivity : AppCompatActivity() {
 
         statusText = findViewById(R.id.statusText)
         permissionButton = findViewById(R.id.permissionButton)
+        notificationStatusText = findViewById(R.id.notificationStatusText)
+        notificationAccessButton = findViewById(R.id.notificationAccessButton)
 
         permissionButton.setOnClickListener {
             requestPermissions()
         }
 
+        notificationAccessButton.setOnClickListener {
+            startActivity(Intent(Settings.ACTION_NOTIFICATION_LISTENER_SETTINGS))
+        }
+
         checkPermissions()
+        updateNotificationAccessStatus()
     }
 
     override fun onResume() {
         super.onResume()
         checkPermissions()
+        updateNotificationAccessStatus()
+    }
+
+    private fun updateNotificationAccessStatus() {
+        val enabledListeners =
+            Settings.Secure.getString(contentResolver, "enabled_notification_listeners") ?: ""
+        val granted = enabledListeners.contains(packageName)
+        if (granted) {
+            notificationStatusText.text = getString(R.string.notification_access_status_on)
+            notificationAccessButton.visibility = android.view.View.GONE
+        } else {
+            notificationStatusText.text = getString(R.string.notification_access_status_off)
+            notificationAccessButton.visibility = android.view.View.VISIBLE
+        }
     }
 
     private fun checkPermissions() {

--- a/companion-app/app/src/main/kotlin/com/example/wifimcpcompanion/NotificationCaptureService.kt
+++ b/companion-app/app/src/main/kotlin/com/example/wifimcpcompanion/NotificationCaptureService.kt
@@ -1,0 +1,81 @@
+package com.example.wifimcpcompanion
+
+import android.service.notification.NotificationListenerService
+import android.service.notification.StatusBarNotification
+import android.util.Log
+import java.util.concurrent.ConcurrentLinkedDeque
+
+/**
+ * Captures system-wide notifications so the host MCP server can read them
+ * (e.g. for OTPs delivered via WhatsApp, banking apps, email clients —
+ * anywhere SMS-based capture from #2 doesn't reach).
+ *
+ * Requires the user to grant notification access once via
+ * Settings → Notifications → Notification access. The MainActivity exposes
+ * a button that opens that page directly.
+ */
+class NotificationCaptureService : NotificationListenerService() {
+
+    companion object {
+        private const val TAG = "NotificationCapture"
+
+        /** Max notifications retained in memory. */
+        const val MAX_RETAINED = 100
+
+        /**
+         * Ring buffer of recent notifications, newest-first.
+         * Static so the AdbBridgeReceiver can read it without binding the service.
+         * ConcurrentLinkedDeque is safe for the listener thread + receiver thread.
+         */
+        val captured: ConcurrentLinkedDeque<CapturedNotification> = ConcurrentLinkedDeque()
+
+        /** True once onListenerConnected has fired — implies notification access is granted. */
+        @Volatile
+        var listenerConnected: Boolean = false
+            private set
+    }
+
+    data class CapturedNotification(
+        val packageName: String,
+        val title: String,
+        val text: String,
+        val timestamp: Long,
+        val notificationId: Int,
+        val tag: String?
+    )
+
+    override fun onListenerConnected() {
+        super.onListenerConnected()
+        listenerConnected = true
+        Log.i(TAG, "Notification listener connected")
+    }
+
+    override fun onListenerDisconnected() {
+        super.onListenerDisconnected()
+        listenerConnected = false
+        Log.i(TAG, "Notification listener disconnected")
+    }
+
+    override fun onNotificationPosted(sbn: StatusBarNotification) {
+        val extras = sbn.notification.extras
+        val title = extras.getCharSequence("android.title")?.toString() ?: ""
+        val text = extras.getCharSequence("android.text")?.toString()
+            ?: extras.getCharSequence("android.bigText")?.toString()
+            ?: ""
+
+        val captured = CapturedNotification(
+            packageName = sbn.packageName,
+            title = title,
+            text = text,
+            timestamp = sbn.postTime,
+            notificationId = sbn.id,
+            tag = sbn.tag
+        )
+
+        // Newest first; trim to MAX_RETAINED.
+        Companion.captured.addFirst(captured)
+        while (Companion.captured.size > MAX_RETAINED) {
+            Companion.captured.pollLast()
+        }
+    }
+}

--- a/companion-app/app/src/main/res/layout/activity_main.xml
+++ b/companion-app/app/src/main/res/layout/activity_main.xml
@@ -31,6 +31,20 @@
         android:visibility="gone" />
 
     <TextView
+        android:id="@+id/notificationStatusText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:textSize="14sp" />
+
+    <Button
+        android:id="@+id/notificationAccessButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:text="@string/grant_notification_access" />
+
+    <TextView
         android:id="@+id/infoText"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/companion-app/app/src/main/res/values/strings.xml
+++ b/companion-app/app/src/main/res/values/strings.xml
@@ -7,4 +7,8 @@
     <string name="status_error">Error: %1$s</string>
     <string name="permissions_required">Location permission is required for WiFi operations</string>
     <string name="grant_permission">Grant Permission</string>
+    <string name="notification_listener_label">WiFi MCP Notification Capture</string>
+    <string name="grant_notification_access">Grant Notification Access</string>
+    <string name="notification_access_status_on">Notification access granted</string>
+    <string name="notification_access_status_off">Notification access NOT granted — needed for non-SMS OTP capture</string>
 </resources>

--- a/companion-app/gradle/wrapper/gradle-wrapper.properties
+++ b/companion-app/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/companion-app/gradlew
+++ b/companion-app/gradlew
@@ -83,7 +83,8 @@ done
 # This is normally unused
 # shellcheck disable=SC2034
 APP_BASE_NAME=${0##*/}
-APP_HOME=$( cd "${APP_HOME:-./}" && pwd -P ) || exit
+# Discard cd standard output in case $CDPATH is set (https://github.com/gradle/gradle/issues/25036)
+APP_HOME=$( cd "${APP_HOME:-./}" > /dev/null && pwd -P ) || exit
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD=maximum
@@ -144,7 +145,7 @@ if ! "$cygwin" && ! "$darwin" && ! "$nonstop" ; then
     case $MAX_FD in #(
       max*)
         # In POSIX sh, ulimit -H is undefined. That's why the result is checked to see if it worked.
-        # shellcheck disable=SC3045
+        # shellcheck disable=SC2039,SC3045
         MAX_FD=$( ulimit -H -n ) ||
             warn "Could not query maximum file descriptor limit"
     esac
@@ -152,7 +153,7 @@ if ! "$cygwin" && ! "$darwin" && ! "$nonstop" ; then
       '' | soft) :;; #(
       *)
         # In POSIX sh, ulimit -n is undefined. That's why the result is checked to see if it worked.
-        # shellcheck disable=SC3045
+        # shellcheck disable=SC2039,SC3045
         ulimit -n "$MAX_FD" ||
             warn "Could not set maximum file descriptor limit to $MAX_FD"
     esac
@@ -201,11 +202,11 @@ fi
 # Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
 DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
 
-# Collect all arguments for the java command;
-#   * $DEFAULT_JVM_OPTS, $JAVA_OPTS, and $GRADLE_OPTS can contain fragments of
-#     shell script including quotes and variable substitutions, so put them in
-#     double quotes to make sure that they get re-expanded; and
-#   * put everything else in single quotes, so that it's not re-expanded.
+# Collect all arguments for the java command:
+#   * DEFAULT_JVM_OPTS, JAVA_OPTS, JAVA_OPTS, and optsEnvironmentVar are not allowed to contain shell fragments,
+#     and any embedded shellness will be escaped.
+#   * For example: A user cannot expect ${Hostname} to be expanded, as it is an environment variable and will be
+#     treated as '${Hostname}' itself on the command line.
 
 set -- \
         "-Dorg.gradle.appname=$APP_BASE_NAME" \

--- a/src/adb/device-manager.ts
+++ b/src/adb/device-manager.ts
@@ -2,17 +2,19 @@ import { AdbClient } from './adb-client.js';
 import { WifiCommands } from './wifi-commands.js';
 import { UICommands } from './ui-commands.js';
 import { SmsCommands } from './sms-commands.js';
+import { NotificationCommands } from './notifications-commands.js';
 import { Device, DeviceInfo } from '../types.js';
 
 /**
  * Manages connected Android devices and provides unified access
- * to ADB, WiFi, UI, and SMS commands.
+ * to ADB, WiFi, UI, SMS, and notification commands.
  */
 export class DeviceManager {
   private adb: AdbClient;
   private wifi: WifiCommands;
   private ui: UICommands;
   private sms: SmsCommands;
+  private notifications: NotificationCommands;
   private devices: Map<string, DeviceInfo> = new Map();
 
   constructor(adbPath?: string) {
@@ -20,6 +22,7 @@ export class DeviceManager {
     this.wifi = new WifiCommands(this.adb);
     this.ui = new UICommands(this.adb);
     this.sms = new SmsCommands(this.adb);
+    this.notifications = new NotificationCommands(this.adb);
   }
 
   /**
@@ -48,6 +51,13 @@ export class DeviceManager {
    */
   getSmsCommands(): SmsCommands {
     return this.sms;
+  }
+
+  /**
+   * Get the notification commands instance
+   */
+  getNotificationCommands(): NotificationCommands {
+    return this.notifications;
   }
 
   /**

--- a/src/adb/notifications-commands.ts
+++ b/src/adb/notifications-commands.ts
@@ -1,0 +1,218 @@
+import { AdbClient } from './adb-client.js';
+
+const COMPANION_PACKAGE = 'com.example.wifimcpcompanion';
+const COMMAND_FILE = '/sdcard/Download/wifi_mcp_command.json';
+const RESULT_FILE = '/sdcard/Download/wifi_mcp_result.json';
+const RESULT_TIMEOUT = 10000; // 10s for a single broadcast round-trip
+
+/**
+ * Talks to the companion app's NotificationCaptureService over the same
+ * file-IPC bridge the enterprise-wifi flow uses.
+ *
+ * The service captures every notification posted system-wide (WhatsApp,
+ * email, banking apps, etc.) so we can extract OTPs that don't come via
+ * SMS. Requires the user to have granted notification access once via
+ * Settings → Notifications → Notification access.
+ */
+export class NotificationCommands {
+  private adb: AdbClient;
+
+  constructor(adb: AdbClient) {
+    this.adb = adb;
+  }
+
+  async getStatus(): Promise<NotificationStatus> {
+    await this.adb.shell(`rm -f ${RESULT_FILE}`);
+    await this.adb.shell(
+      `am broadcast -a ${COMPANION_PACKAGE}.NOTIFICATION_STATUS -n ${COMPANION_PACKAGE}/.AdbBridgeReceiver`
+    );
+    const result = await this.waitForResult();
+    if (!result) {
+      return {
+        listenerConnected: false,
+        capturedCount: 0,
+        warning:
+          'No response from companion app. Is it installed? See wifi_check_companion_app.',
+      };
+    }
+    return {
+      listenerConnected: !!result.listenerConnected,
+      capturedCount: typeof result.capturedCount === 'number' ? result.capturedCount : 0,
+      warning: result.success
+        ? undefined
+        : typeof result.message === 'string'
+        ? result.message
+        : 'Unknown error',
+    };
+  }
+
+  async listRecent(opts: NotificationListOptions = {}): Promise<NotificationListResult> {
+    const config: Record<string, unknown> = {};
+    if (opts.sinceSeconds !== undefined) {
+      config.sinceMs = Date.now() - opts.sinceSeconds * 1000;
+    }
+    if (opts.packageFilter !== undefined) {
+      config.packageFilter = opts.packageFilter;
+    }
+    if (opts.limit !== undefined) {
+      config.limit = opts.limit;
+    }
+    await this.writeCommandFile(config);
+    await this.adb.shell(`rm -f ${RESULT_FILE}`);
+    await this.adb.shell(
+      `am broadcast -a ${COMPANION_PACKAGE}.LIST_NOTIFICATIONS -n ${COMPANION_PACKAGE}/.AdbBridgeReceiver --es config_file "${COMMAND_FILE}"`
+    );
+    const result = await this.waitForResult();
+    if (!result) {
+      return {
+        notifications: [],
+        count: 0,
+        warning: 'No response from companion app. Is it installed and is notification access granted?',
+      };
+    }
+    if (!result.success) {
+      return {
+        notifications: [],
+        count: 0,
+        warning: typeof result.message === 'string' ? result.message : 'Unknown error',
+      };
+    }
+    const raw = Array.isArray(result.notifications) ? (result.notifications as unknown[]) : [];
+    const notifications: CapturedNotification[] = raw.map((n) => {
+      const o = n as Record<string, unknown>;
+      const cap: CapturedNotification = {
+        packageName: typeof o.packageName === 'string' ? o.packageName : '',
+        title: typeof o.title === 'string' ? o.title : '',
+        text: typeof o.text === 'string' ? o.text : '',
+        timestamp: typeof o.timestamp === 'number' ? o.timestamp : 0,
+      };
+      if (opts.bodyRegex) {
+        const re = new RegExp(opts.bodyRegex);
+        const haystack = `${cap.title}\n${cap.text}`;
+        const match = haystack.match(re);
+        if (!match) return null as unknown as CapturedNotification;
+        cap.otp = match[1] ?? extractOtp(haystack);
+      } else {
+        cap.otp = extractOtp(`${cap.title}\n${cap.text}`);
+      }
+      return cap;
+    }).filter(Boolean) as CapturedNotification[];
+
+    return { notifications, count: notifications.length };
+  }
+
+  async waitForOtp(opts: WaitForOtpOptions = {}): Promise<WaitForOtpResult> {
+    const timeoutMs = opts.timeoutMs ?? 60000;
+    const pollIntervalMs = opts.pollIntervalMs ?? 2000;
+    const sinceSeconds = opts.sinceSeconds ?? 60;
+    const start = Date.now();
+
+    let lastWarning: string | undefined;
+    while (Date.now() - start < timeoutMs) {
+      const r = await this.listRecent({
+        packageFilter: opts.packageFilter,
+        bodyRegex: opts.bodyRegex,
+        sinceSeconds,
+        limit: 10,
+      });
+      lastWarning = r.warning;
+      const hit = r.notifications.find((n) => n.otp);
+      if (hit?.otp) {
+        return {
+          found: true,
+          otp: hit.otp,
+          packageName: hit.packageName,
+          title: hit.title,
+          text: hit.text,
+          timestamp: hit.timestamp,
+          waitedMs: Date.now() - start,
+          warning: r.warning,
+        };
+      }
+      await new Promise((res) => setTimeout(res, pollIntervalMs));
+    }
+    return { found: false, waitedMs: Date.now() - start, warning: lastWarning };
+  }
+
+  private async writeCommandFile(payload: object): Promise<void> {
+    const json = JSON.stringify(payload);
+    const escaped = json.replace(/'/g, "'\\''");
+    await this.adb.shell(`echo '${escaped}' > ${COMMAND_FILE}`);
+  }
+
+  private async waitForResult(): Promise<Record<string, unknown> | null> {
+    const start = Date.now();
+    const pollInterval = 300;
+    while (Date.now() - start < RESULT_TIMEOUT) {
+      await new Promise((res) => setTimeout(res, pollInterval));
+      const cat = await this.adb.shell(`cat ${RESULT_FILE} 2>/dev/null`);
+      if (cat.success && cat.stdout.trim()) {
+        try {
+          const parsed = JSON.parse(cat.stdout) as Record<string, unknown>;
+          await this.adb.shell(`rm -f ${RESULT_FILE}`);
+          return parsed;
+        } catch {
+          // partial write — keep polling
+        }
+      }
+    }
+    return null;
+  }
+}
+
+export interface NotificationStatus {
+  listenerConnected: boolean;
+  capturedCount: number;
+  warning?: string;
+}
+
+export interface CapturedNotification {
+  packageName: string;
+  title: string;
+  text: string;
+  timestamp: number;
+  otp?: string;
+}
+
+export interface NotificationListOptions {
+  packageFilter?: string;
+  bodyRegex?: string;
+  sinceSeconds?: number;
+  limit?: number;
+}
+
+export interface NotificationListResult {
+  notifications: CapturedNotification[];
+  count: number;
+  warning?: string;
+}
+
+export interface WaitForOtpOptions {
+  packageFilter?: string;
+  bodyRegex?: string;
+  sinceSeconds?: number;
+  timeoutMs?: number;
+  pollIntervalMs?: number;
+}
+
+export type WaitForOtpResult =
+  | {
+      found: true;
+      otp: string;
+      packageName: string;
+      title: string;
+      text: string;
+      timestamp: number;
+      waitedMs: number;
+      warning?: string;
+    }
+  | {
+      found: false;
+      waitedMs: number;
+      warning?: string;
+    };
+
+function extractOtp(haystack: string): string | undefined {
+  const m = haystack.match(/\b(\d{4,8})\b/);
+  return m ? m[1] : undefined;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -499,6 +499,10 @@ export function createMcpServer(deviceManager: DeviceManager): CreateServerResul
       const enterpriseWifi = new EnterpriseWifiCommands(deviceManager.getAdbClient());
       const installed = await enterpriseWifi.isCompanionAppInstalled();
 
+      const notifStatus = installed
+        ? await deviceManager.getNotificationCommands().getStatus().catch(() => null)
+        : null;
+
       return {
         content: [
           {
@@ -507,9 +511,13 @@ export function createMcpServer(deviceManager: DeviceManager): CreateServerResul
               {
                 companionAppInstalled: installed,
                 packageName: 'com.example.wifimcpcompanion',
+                notificationAccessGranted: notifStatus?.listenerConnected ?? false,
+                capturedNotifications: notifStatus?.capturedCount ?? 0,
                 message: installed
-                  ? 'Companion app is installed and ready for enterprise WiFi'
-                  : 'Companion app not installed. Please install it to use enterprise WiFi features.',
+                  ? notifStatus?.listenerConnected
+                    ? 'Companion app installed; notification access granted'
+                    : 'Companion app installed, but notification access not granted. Open the app and tap Grant Notification Access.'
+                  : 'Companion app not installed. Build + install companion-app/ to use enterprise WiFi or notification-based OTP capture.',
               },
               null,
               2
@@ -839,6 +847,47 @@ export function createMcpServer(deviceManager: DeviceManager): CreateServerResul
       await ensureDevice();
       const sms = deviceManager.getSmsCommands();
       const result = await sms.waitForOtp({ senderFilter, bodyRegex, sinceSeconds, timeoutMs, pollIntervalMs });
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+      };
+    }
+  );
+
+  // ============ Notification / OTP Tools (companion app) ============
+
+  mcpServer.tool(
+    'notifications_list_recent',
+    'List recent notifications captured by the companion app (WhatsApp, email, banking apps, etc). Useful for OTPs that do not arrive via SMS. Requires the companion app installed and notification access granted (see wifi_check_companion_app).',
+    {
+      packageFilter: z.string().optional().describe('Regex match against package name, e.g. "com.whatsapp" or "bank"'),
+      bodyRegex: z.string().optional().describe('Regex against title+text. If it has a capture group, that becomes the OTP; else first 4-8 digit run is used'),
+      sinceSeconds: z.number().optional().describe('Only return notifications received within the last N seconds'),
+      limit: z.number().optional().default(50).describe('Max notifications to return (default 50)'),
+    },
+    async ({ packageFilter, bodyRegex, sinceSeconds, limit }) => {
+      await ensureDevice();
+      const notif = deviceManager.getNotificationCommands();
+      const result = await notif.listRecent({ packageFilter, bodyRegex, sinceSeconds, limit });
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+      };
+    }
+  );
+
+  mcpServer.tool(
+    'notifications_wait_for_otp',
+    'Poll captured notifications until a matching OTP arrives or timeout elapses. Default timeout 60s, default poll 2s. Use packageFilter (e.g. "com.whatsapp") to scope.',
+    {
+      packageFilter: z.string().optional().describe('Regex against package name'),
+      bodyRegex: z.string().optional().describe('Regex against title+text. Capture group becomes the OTP if present'),
+      sinceSeconds: z.number().optional().default(60).describe('Initial look-back window (default 60s)'),
+      timeoutMs: z.number().optional().default(60000).describe('Max time to wait in milliseconds (default 60000)'),
+      pollIntervalMs: z.number().optional().default(2000).describe('Poll interval in milliseconds (default 2000)'),
+    },
+    async ({ packageFilter, bodyRegex, sinceSeconds, timeoutMs, pollIntervalMs }) => {
+      await ensureDevice();
+      const notif = deviceManager.getNotificationCommands();
+      const result = await notif.waitForOtp({ packageFilter, bodyRegex, sinceSeconds, timeoutMs, pollIntervalMs });
       return {
         content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
       };


### PR DESCRIPTION
## Summary

- **Companion app (Kotlin):** new \`NotificationCaptureService\` (extends \`NotificationListenerService\`) keeps the last 100 posted notifications in a thread-safe ring buffer. \`AdbBridgeReceiver\` gains \`LIST_NOTIFICATIONS\` + \`NOTIFICATION_STATUS\` broadcast actions over the same file-IPC bridge enterprise WiFi already uses. \`MainActivity\` exposes a "Grant Notification Access" button that deep-links into Settings → Notifications → Notification access.
- **MCP server (TypeScript):** new \`src/adb/notifications-commands.ts\` (\`NotificationCommands\` class). Two new tools: \`notifications_list_recent\` (filters: \`packageFilter\` regex, \`bodyRegex\`, \`sinceSeconds\`, \`limit\`) and \`notifications_wait_for_otp\` (timeout + poll, default 60s/2s). Same \`\\b(\\d{4,8})\\b\` OTP heuristic as SMS; capture-group in \`bodyRegex\` overrides.
- \`wifi_check_companion_app\` now also reports \`notificationAccessGranted\` and \`capturedNotifications\` so callers can detect the missing-permission state.
- 3 YAMLs in new \`notifications/\` suite, new \`test-notifications.yml\` workflow, \`notifications\` added to \`SUITES\`.
- README: 32 native / 53 total tool counts, new "Notification capture (companion app)" subsection in Available Tools, suite table gets a \`notifications\` row, project tree includes \`notifications-commands.ts\` and the new Kotlin file.
- Side note: bumped Gradle wrapper 8.2 → 8.5 incidentally when regenerating the wrapper jar (the repo doesn't track \`gradle-wrapper.jar\` per its existing \`.gitignore\`). Build verified before and after.

Fixes #3

## Test plan

- [x] \`./gradlew assembleDebug\` succeeds (companion-app)
- [x] APK installs on SM-G9980 (uninstall first — debug build signature differs from previously installed release-style APK)
- [x] Manual: tapped "Grant Notification Access" → toggled WiFi MCP Notification Capture → status text flips to "Notification access granted"
- [x] \`adb shell cmd notification post -t "Test OTP" "tag" "Your code is 654321"\` → captured by the service
- [x] \`notifications_list_recent\` via stdio MCP returns the captured notification with \`otp: "654321"\` auto-extracted
- [x] \`notifications_wait_for_otp\` finds it inside the 60s look-back window
- [x] \`wifi_check_companion_app\` returns \`{ companionAppInstalled: true, notificationAccessGranted: true, capturedNotifications: 1 }\`
- [x] \`tsc --noEmit\` clean for server *and* test framework
- [x] \`cd cicd/tests && npx tsx src/cli.ts run --suite notifications\` — **3/3 pass in 8.3s**
- [x] Regression: smoke **7/7**, proxy **2/2** — both green
- [ ] \`test-notifications.yml\` workflow green on a self-hosted runner — *manual once a runner is set up.*

Generated with [Claude Code](https://claude.com/claude-code)