### PR TITLE
Fix wrong issue ref in README; require branch+PR for all changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,8 @@ The unified namespace is the design goal: Claude Code sees one server, gets one 
 - **Add a test:** see `ci-testcase` skill.
 - **Run tests locally:** `cd cicd/tests && npm test` (smoke + everything tagged); add `--suite <s>` to scope.
 - **Issue → PR:** `dw-implement` → `dw-create-pr` → `dw-review-pr` → `dw-merge` (home-level skills, see `~/.claude/CLAUDE.md`).
-- **Direct-push exceptions:** docs-only or this CLAUDE.md update can go straight to `main` per home rules. **Verify every factual claim in the change *before* `git push`** — counts, file paths, anchor links, command names. Post-push review is a backstop, not the gate.
+- **Always branch + PR.** Even for docs / README / CLAUDE.md / config-only changes. The home-level "direct-push for docs" exception does **not** apply in this repo — a wrong-issue-number bug shipped through a docs-only direct-push (commit `1829746`) and the PR self-review would have caught it. Branch as `fix/<slug>` or `feature/<slug>` for non-issue-tracked work.
+- **Verify factual claims before push** regardless of branch — counts, file paths, anchor links, command names, issue numbers. Run `npm run tools:count` for tool count claims. Post-push / post-merge review is a backstop, not the gate.
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This server enables Claude and other MCP clients to remotely control WiFi connec
 
 ### For Enterprise WiFi or Notification Capture (Optional)
 
-The companion Android app is needed for 802.1X enterprise WiFi (#5) and for capturing OTPs that don't arrive via SMS (#3 — notification listener for WhatsApp / email / banking). Skip this section if you only need WPA2/WPA3 personal WiFi + SMS-based OTPs.
+The companion Android app is needed for 802.1X enterprise WiFi and for capturing OTPs that don't arrive via SMS (#3 — notification listener for WhatsApp / email / banking). Skip this section if you only need WPA2/WPA3 personal WiFi + SMS-based OTPs.
 
 **One-time host setup (Linux example, Fedora/RHEL):**
 


### PR DESCRIPTION
## Summary

- **README:** drop \`(#5)\` from the enterprise WiFi line in the companion-app setup section. Issue #5 was the stdio transport — enterprise WiFi has no issue (it's in the initial commit \`05a2264\`). \`(#3)\` for the notification listener stays; verified correct.
- **CLAUDE.md:** remove the docs-only direct-push exception. All changes (including docs / CLAUDE.md / config) now go through branch + PR. Reason: the bug above shipped through a docs-only direct push (\`1829746\`) where the verification step happened *after* push. Self-review on a PR would have caught it.
- The verify-claims rule now applies to every change regardless of branch, with an explicit "issue numbers" item added to the list to verify.

## Test plan

- [x] \`grep -nE '\\(#[0-9]+\\)' README.md\` returns nothing — no stale issue refs left
- [x] Remaining \`#3\` mention verified via \`gh issue view 3\` — title matches notification listener
- [x] \`npm run tools:count\` returns 32, README count line matches
- [x] Commit \`1829746\` referenced in the new CLAUDE.md note resolves via \`git rev-parse\`
- [x] CLAUDE.md mentions \`tools:count\` twice (in the Tool count discipline rule and the new Verify factual claims rule)

Generated with [Claude Code](https://claude.com/claude-code)