### PR TITLE
Clear result file before broadcast in enterprise-wifi (#21)

### DIFF
--- a/src/adb/enterprise-wifi.ts
+++ b/src/adb/enterprise-wifi.ts
@@ -68,6 +68,10 @@ export class EnterpriseWifiCommands {
 
     await this.writeCommandFile(commandPayload);
 
+    // Clear stale result BEFORE broadcasting; the receiver runs synchronously
+    // and a post-broadcast rm would delete the live result.
+    await this.adb.shell(`rm -f ${RESULT_FILE}`);
+
     // Send broadcast to companion app
     const broadcastResult = await this.adb.shell(
       `am broadcast -a ${COMPANION_PACKAGE}.CONNECT_ENTERPRISE ` +
@@ -124,6 +128,10 @@ export class EnterpriseWifiCommands {
 
     await this.writeCommandFile(commandPayload);
 
+    // Clear stale result BEFORE broadcasting; the receiver runs synchronously
+    // and a post-broadcast rm would delete the live result.
+    await this.adb.shell(`rm -f ${RESULT_FILE}`);
+
     // Send broadcast to companion app
     const broadcastResult = await this.adb.shell(
       `am broadcast -a ${COMPANION_PACKAGE}.INSTALL_CERTIFICATE ` +
@@ -167,9 +175,6 @@ export class EnterpriseWifiCommands {
     const startTime = Date.now();
     const pollInterval = 500; // 500ms
 
-    // Clear any existing result file
-    await this.adb.shell(`rm -f ${RESULT_FILE}`);
-
     while (Date.now() - startTime < RESULT_TIMEOUT) {
       await new Promise(resolve => setTimeout(resolve, pollInterval));
 
@@ -205,6 +210,10 @@ export class EnterpriseWifiCommands {
     };
 
     await this.writeCommandFile(commandPayload);
+
+    // Clear stale result BEFORE broadcasting; the receiver runs synchronously
+    // and a post-broadcast rm would delete the live result.
+    await this.adb.shell(`rm -f ${RESULT_FILE}`);
 
     await this.adb.shell(
       `am broadcast -a ${COMPANION_PACKAGE}.LIST_CERTIFICATES ` +

--- a/src/adb/enterprise-wifi.ts
+++ b/src/adb/enterprise-wifi.ts
@@ -67,9 +67,6 @@ export class EnterpriseWifiCommands {
     };
 
     await this.writeCommandFile(commandPayload);
-
-    // Clear stale result BEFORE broadcasting; the receiver runs synchronously
-    // and a post-broadcast rm would delete the live result.
     await this.adb.shell(`rm -f ${RESULT_FILE}`);
 
     // Send broadcast to companion app
@@ -127,9 +124,6 @@ export class EnterpriseWifiCommands {
     };
 
     await this.writeCommandFile(commandPayload);
-
-    // Clear stale result BEFORE broadcasting; the receiver runs synchronously
-    // and a post-broadcast rm would delete the live result.
     await this.adb.shell(`rm -f ${RESULT_FILE}`);
 
     // Send broadcast to companion app
@@ -169,7 +163,12 @@ export class EnterpriseWifiCommands {
   }
 
   /**
-   * Wait for result from companion app
+   * Poll for the result file the companion app writes after handling a broadcast.
+   *
+   * Caller must `rm -f ${RESULT_FILE}` between writing the command file and
+   * sending the broadcast. The receiver runs synchronously (~50 ms) so a
+   * post-broadcast cleanup would race the app's write and produce spurious
+   * timeouts.
    */
   private async waitForResult<T>(identifier: string): Promise<T | null> {
     const startTime = Date.now();
@@ -210,9 +209,6 @@ export class EnterpriseWifiCommands {
     };
 
     await this.writeCommandFile(commandPayload);
-
-    // Clear stale result BEFORE broadcasting; the receiver runs synchronously
-    // and a post-broadcast rm would delete the live result.
     await this.adb.shell(`rm -f ${RESULT_FILE}`);
 
     await this.adb.shell(


### PR DESCRIPTION
## Summary

- Fix the result-file race that caused every `wifi_connect_enterprise`, `wifi_install_certificate`, and `wifi_list_certificates` call to time out at 30s.
- Move `rm -f ${RESULT_FILE}` from inside `waitForResult()` to **before** each `am broadcast` in the three caller paths. Mirrors the working pattern in `notifications-commands.ts:getStatus`.
- Net diff: +12 / −3.

## Why this works

The companion app's `BroadcastReceiver.onReceive` runs synchronously (~50 ms in our measurements) and writes the result file before the host can resume. The previous order — broadcast first, then `rm` inside `waitForResult` — deleted the live result, leaving the poll loop to wait the full 30 s for nothing.

`getStatus()` already cleared *before* broadcasting and never had this bug. This PR aligns the enterprise-wifi paths with that pattern.

## Test plan

- [x] `npm run build` clean
- [x] `npm run test:unit` — 26/26 pass
- [x] End-to-end on Pixel 8 / Android 14: `wifi_connect_enterprise` with deliberately bogus PEAP args returns in **3.7 s** (was 30 s flat). Logcat confirms the companion app received the broadcast, processed it, and wrote the result file — and the host now reads it instead of overwriting it.

## Follow-ups (not in this PR)

- #22 — companion app's `EACCES` reading shell-written command files on Android 11+. With the race fix in, this is now the next visible failure layer (the tool returns `Failed to read config file` instead of timing out — but on the host side the message is silently dropped because of a field-name mismatch between companion-app's `message` and the host type's `error`. Will file as its own issue).

Fixes #21.