### PR TITLE
Move companion-app IPC to filesDir via run-as (#22)

### DIFF
--- a/companion-app/app/src/main/kotlin/com/example/wifimcpcompanion/AdbBridgeReceiver.kt
+++ b/companion-app/app/src/main/kotlin/com/example/wifimcpcompanion/AdbBridgeReceiver.kt
@@ -3,14 +3,18 @@ package com.example.wifimcpcompanion
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import android.os.Environment
 import android.util.Log
 import org.json.JSONArray
 import org.json.JSONObject
 import java.io.File
 
 /**
- * Receives broadcast intents from ADB and processes enterprise WiFi commands
+ * Receives broadcast intents from ADB and processes enterprise WiFi commands.
+ *
+ * IPC files live in the app's private filesDir (`/data/data/<pkg>/files/`)
+ * and are accessed from the host via `adb shell run-as <pkg> ...`. The
+ * previous location `/sdcard/Download/` is unreadable to the app on
+ * Android 11+ when written by adb shell (scoped storage / EACCES).
  */
 class AdbBridgeReceiver : BroadcastReceiver() {
 
@@ -24,46 +28,40 @@ class AdbBridgeReceiver : BroadcastReceiver() {
         const val ACTION_LIST_NOTIFICATIONS = "com.example.wifimcpcompanion.LIST_NOTIFICATIONS"
         const val ACTION_NOTIFICATION_STATUS = "com.example.wifimcpcompanion.NOTIFICATION_STATUS"
 
-        const val EXTRA_CONFIG_FILE = "config_file"
-
-        private val COMMAND_FILE = File(
-            Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS),
-            "wifi_mcp_command.json"
-        )
-        private val RESULT_FILE = File(
-            Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS),
-            "wifi_mcp_result.json"
-        )
+        private const val COMMAND_FILE_NAME = "wifi_mcp_command.json"
+        private const val RESULT_FILE_NAME = "wifi_mcp_result.json"
     }
+
+    private fun commandFile(context: Context) = File(context.filesDir, COMMAND_FILE_NAME)
+    private fun resultFile(context: Context) = File(context.filesDir, RESULT_FILE_NAME)
 
     override fun onReceive(context: Context, intent: Intent) {
         Log.i(TAG, "Received broadcast: ${intent.action}")
 
         try {
             when (intent.action) {
-                ACTION_CONNECT_ENTERPRISE -> handleConnectEnterprise(context, intent)
-                ACTION_INSTALL_CERTIFICATE -> handleInstallCertificate(context, intent)
+                ACTION_CONNECT_ENTERPRISE -> handleConnectEnterprise(context)
+                ACTION_INSTALL_CERTIFICATE -> handleInstallCertificate(context)
                 ACTION_LIST_CERTIFICATES -> handleListCertificates(context)
-                ACTION_DISCONNECT -> handleDisconnect(context, intent)
-                ACTION_LIST_NOTIFICATIONS -> handleListNotifications(intent)
-                ACTION_NOTIFICATION_STATUS -> handleNotificationStatus()
+                ACTION_DISCONNECT -> handleDisconnect(context)
+                ACTION_LIST_NOTIFICATIONS -> handleListNotifications(context)
+                ACTION_NOTIFICATION_STATUS -> handleNotificationStatus(context)
                 else -> {
                     Log.w(TAG, "Unknown action: ${intent.action}")
-                    writeResult(false, "Unknown action", mapOf("action" to (intent.action ?: "null")))
+                    writeResult(context, false, "Unknown action", mapOf("action" to (intent.action ?: "null")))
                 }
             }
         } catch (e: Exception) {
             Log.e(TAG, "Error processing broadcast", e)
-            writeResult(false, e.message ?: "Unknown error", mapOf("action" to (intent.action ?: "null")))
+            writeResult(context, false, e.message ?: "Unknown error", mapOf("action" to (intent.action ?: "null")))
         }
     }
 
-    private fun handleConnectEnterprise(context: Context, intent: Intent) {
-        val configFile = intent.getStringExtra(EXTRA_CONFIG_FILE) ?: COMMAND_FILE.absolutePath
-        val config = readConfigFile(configFile)
+    private fun handleConnectEnterprise(context: Context) {
+        val config = readConfigFile(commandFile(context))
 
         if (config == null) {
-            writeResult(false, "Failed to read config file", mapOf("action" to "connect_enterprise"))
+            writeResult(context, false, "Failed to read config file", mapOf("action" to "connect_enterprise"))
             return
         }
 
@@ -103,6 +101,7 @@ class AdbBridgeReceiver : BroadcastReceiver() {
             "tls" -> {
                 if (clientCertificate == null || privateKey == null) {
                     writeResult(
+                        context,
                         false,
                         "Client certificate and private key are required for EAP-TLS",
                         mapOf("action" to "connect_enterprise", "ssid" to ssid, "eapMethod" to eapMethod)
@@ -121,6 +120,7 @@ class AdbBridgeReceiver : BroadcastReceiver() {
             }
             else -> {
                 writeResult(
+                    context,
                     false,
                     "Unknown EAP method: $eapMethod",
                     mapOf("action" to "connect_enterprise", "ssid" to ssid)
@@ -130,6 +130,7 @@ class AdbBridgeReceiver : BroadcastReceiver() {
         }
 
         writeResult(
+            context,
             result.success,
             result.message ?: result.error ?: "Unknown",
             mapOf(
@@ -140,12 +141,11 @@ class AdbBridgeReceiver : BroadcastReceiver() {
         )
     }
 
-    private fun handleInstallCertificate(context: Context, intent: Intent) {
-        val configFile = intent.getStringExtra(EXTRA_CONFIG_FILE) ?: COMMAND_FILE.absolutePath
-        val config = readConfigFile(configFile)
+    private fun handleInstallCertificate(context: Context) {
+        val config = readConfigFile(commandFile(context))
 
         if (config == null) {
-            writeResult(false, "Failed to read config file", mapOf("action" to "install_certificate"))
+            writeResult(context, false, "Failed to read config file", mapOf("action" to "install_certificate"))
             return
         }
 
@@ -179,6 +179,7 @@ class AdbBridgeReceiver : BroadcastReceiver() {
         }
 
         writeResult(
+            context,
             result.success,
             result.message ?: result.error ?: "Unknown",
             mapOf(
@@ -189,16 +190,16 @@ class AdbBridgeReceiver : BroadcastReceiver() {
         )
     }
 
-    private fun handleListNotifications(intent: Intent) {
+    private fun handleListNotifications(context: Context) {
         // Optional filter params from the command file (sinceMs, packageFilter, limit).
-        val configFile = intent.getStringExtra(EXTRA_CONFIG_FILE)
-        val cfg = configFile?.let { readConfigFile(it) }
+        val cfg = readConfigFile(commandFile(context))
         val sinceMs = cfg?.optLong("sinceMs", 0L) ?: 0L
         val packageFilter = cfg?.optString("packageFilter", null)
         val limit = cfg?.optInt("limit", 50) ?: 50
 
         if (!NotificationCaptureService.listenerConnected) {
             writeResult(
+                context,
                 false,
                 "NotificationCaptureService is not connected. Has notification access been granted? See Settings → Notifications → Notification access.",
                 mapOf("action" to "list_notifications")
@@ -223,6 +224,7 @@ class AdbBridgeReceiver : BroadcastReceiver() {
             .toList()
 
         writeResult(
+            context,
             true,
             "Returned ${matches.size} notification(s)",
             mapOf(
@@ -233,8 +235,9 @@ class AdbBridgeReceiver : BroadcastReceiver() {
         )
     }
 
-    private fun handleNotificationStatus() {
+    private fun handleNotificationStatus(context: Context) {
         writeResult(
+            context,
             true,
             if (NotificationCaptureService.listenerConnected) "Notification listener connected" else "Notification access not granted",
             mapOf(
@@ -250,6 +253,7 @@ class AdbBridgeReceiver : BroadcastReceiver() {
         val certificates = certManager.listCertificates()
 
         writeResult(
+            context,
             true,
             "Found ${certificates.size} certificates",
             mapOf(
@@ -259,9 +263,8 @@ class AdbBridgeReceiver : BroadcastReceiver() {
         )
     }
 
-    private fun handleDisconnect(context: Context, intent: Intent) {
-        val configFile = intent.getStringExtra(EXTRA_CONFIG_FILE) ?: COMMAND_FILE.absolutePath
-        val config = readConfigFile(configFile)
+    private fun handleDisconnect(context: Context) {
+        val config = readConfigFile(commandFile(context))
 
         val ssid = config?.optString("ssid", null)
 
@@ -270,31 +273,30 @@ class AdbBridgeReceiver : BroadcastReceiver() {
             val removed = wifiManager.removeNetworkSuggestion(ssid)
 
             writeResult(
+                context,
                 removed,
                 if (removed) "Network suggestion removed" else "Failed to remove network suggestion",
                 mapOf("action" to "disconnect", "ssid" to ssid)
             )
         } else {
-            writeResult(false, "SSID is required for disconnect", mapOf("action" to "disconnect"))
+            writeResult(context, false, "SSID is required for disconnect", mapOf("action" to "disconnect"))
         }
     }
 
-    private fun readConfigFile(path: String): JSONObject? {
+    private fun readConfigFile(file: File): JSONObject? {
         return try {
-            val file = File(path)
             if (!file.exists()) {
-                Log.e(TAG, "Config file not found: $path")
+                Log.e(TAG, "Config file not found: ${file.absolutePath}")
                 return null
             }
-            val content = file.readText()
-            JSONObject(content)
+            JSONObject(file.readText())
         } catch (e: Exception) {
-            Log.e(TAG, "Failed to read config file: $path", e)
+            Log.e(TAG, "Failed to read config file: ${file.absolutePath}", e)
             null
         }
     }
 
-    private fun writeResult(success: Boolean, message: String, extra: Map<String, Any> = emptyMap()) {
+    private fun writeResult(context: Context, success: Boolean, message: String, extra: Map<String, Any> = emptyMap()) {
         try {
             val result = JSONObject().apply {
                 put("success", success)
@@ -305,9 +307,10 @@ class AdbBridgeReceiver : BroadcastReceiver() {
                 }
             }
 
-            RESULT_FILE.parentFile?.mkdirs()
-            RESULT_FILE.writeText(result.toString(2))
-            Log.i(TAG, "Result written to ${RESULT_FILE.absolutePath}")
+            val outFile = resultFile(context)
+            outFile.parentFile?.mkdirs()
+            outFile.writeText(result.toString(2))
+            Log.i(TAG, "Result written to ${outFile.absolutePath}")
         } catch (e: Exception) {
             Log.e(TAG, "Failed to write result file", e)
         }

--- a/src/adb/adb-client.ts
+++ b/src/adb/adb-client.ts
@@ -1,8 +1,10 @@
-import { exec, spawn } from 'child_process';
+import { execFile, spawn } from 'child_process';
 import { promisify } from 'util';
 import { Device, DeviceInfo, AdbResult } from '../types.js';
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
+
+const MAX_OUTPUT_BUFFER = 1024 * 1024 * 8; // 8 MB; covers ui_dump and wifi_scan with headroom
 
 export class AdbClient {
   private adbPath: string;
@@ -13,15 +15,22 @@ export class AdbClient {
   }
 
   /**
-   * Execute an ADB command
+   * Execute an ADB command.
+   *
+   * Uses `execFile` so adb is invoked directly with an args array — no host
+   * /bin/sh layer between us and adb. That keeps shell metacharacters in
+   * shell-command args (`|`, `>`, single quotes around `sh -c '...'`)
+   * intact when adb forwards them to the device shell.
    */
   async exec(args: string[], timeout: number = 30000): Promise<AdbResult> {
     const deviceArgs = this.selectedDevice ? ['-s', this.selectedDevice] : [];
     const fullArgs = [...deviceArgs, ...args];
-    const command = `${this.adbPath} ${fullArgs.join(' ')}`;
 
     try {
-      const { stdout, stderr } = await execAsync(command, { timeout });
+      const { stdout, stderr } = await execFileAsync(this.adbPath, fullArgs, {
+        timeout,
+        maxBuffer: MAX_OUTPUT_BUFFER,
+      });
       return {
         success: true,
         stdout: stdout.trim(),

--- a/src/adb/enterprise-wifi.ts
+++ b/src/adb/enterprise-wifi.ts
@@ -6,8 +6,13 @@ import {
 } from '../types.js';
 
 const COMPANION_PACKAGE = 'com.example.wifimcpcompanion';
-const COMMAND_FILE = '/sdcard/Download/wifi_mcp_command.json';
-const RESULT_FILE = '/sdcard/Download/wifi_mcp_result.json';
+// IPC files live in the companion app's private filesDir, accessed via
+// `run-as`. /sdcard/Download/ was the previous location but Android 11+
+// scoped storage blocks the app from reading shell-written files there.
+const COMMAND_FILE_NAME = 'wifi_mcp_command.json';
+const RESULT_FILE_NAME = 'wifi_mcp_result.json';
+const RESULT_FILE_REL = `files/${RESULT_FILE_NAME}`;
+const COMMAND_FILE_REL = `files/${COMMAND_FILE_NAME}`;
 const RESULT_TIMEOUT = 30000; // 30 seconds
 
 export class EnterpriseWifiCommands {
@@ -67,13 +72,12 @@ export class EnterpriseWifiCommands {
     };
 
     await this.writeCommandFile(commandPayload);
-    await this.adb.shell(`rm -f ${RESULT_FILE}`);
+    await this.clearResultFile();
 
     // Send broadcast to companion app
     const broadcastResult = await this.adb.shell(
       `am broadcast -a ${COMPANION_PACKAGE}.CONNECT_ENTERPRISE ` +
-      `-n ${COMPANION_PACKAGE}/.AdbBridgeReceiver ` +
-      `--es config_file "${COMMAND_FILE}"`
+      `-n ${COMPANION_PACKAGE}/.AdbBridgeReceiver`
     );
 
     if (!broadcastResult.success) {
@@ -124,13 +128,12 @@ export class EnterpriseWifiCommands {
     };
 
     await this.writeCommandFile(commandPayload);
-    await this.adb.shell(`rm -f ${RESULT_FILE}`);
+    await this.clearResultFile();
 
     // Send broadcast to companion app
     const broadcastResult = await this.adb.shell(
       `am broadcast -a ${COMPANION_PACKAGE}.INSTALL_CERTIFICATE ` +
-      `-n ${COMPANION_PACKAGE}/.AdbBridgeReceiver ` +
-      `--es config_file "${COMMAND_FILE}"`
+      `-n ${COMPANION_PACKAGE}/.AdbBridgeReceiver`
     );
 
     if (!broadcastResult.success) {
@@ -153,19 +156,26 @@ export class EnterpriseWifiCommands {
   }
 
   /**
-   * Write command payload to file on device
+   * Write command payload into the companion app's private filesDir via run-as.
+   * Payload is base64-encoded so embedded JSON quotes / cert hyphens cannot
+   * break shell escaping.
    */
   private async writeCommandFile(payload: object): Promise<void> {
     const json = JSON.stringify(payload);
-    // Escape for shell and write to file
-    const escaped = json.replace(/'/g, "'\\''");
-    await this.adb.shell(`echo '${escaped}' > ${COMMAND_FILE}`);
+    const b64 = Buffer.from(json, 'utf-8').toString('base64');
+    await this.adb.shell(
+      `run-as ${COMPANION_PACKAGE} sh -c 'echo ${b64} | base64 -d > ${COMMAND_FILE_REL}'`
+    );
+  }
+
+  private async clearResultFile(): Promise<void> {
+    await this.adb.shell(`run-as ${COMPANION_PACKAGE} rm -f ${RESULT_FILE_REL}`);
   }
 
   /**
    * Poll for the result file the companion app writes after handling a broadcast.
    *
-   * Caller must `rm -f ${RESULT_FILE}` between writing the command file and
+   * Caller must call `clearResultFile()` between writing the command file and
    * sending the broadcast. The receiver runs synchronously (~50 ms) so a
    * post-broadcast cleanup would race the app's write and produce spurious
    * timeouts.
@@ -177,13 +187,13 @@ export class EnterpriseWifiCommands {
     while (Date.now() - startTime < RESULT_TIMEOUT) {
       await new Promise(resolve => setTimeout(resolve, pollInterval));
 
-      // Check if result file exists
-      const checkResult = await this.adb.shell(`cat ${RESULT_FILE} 2>/dev/null`);
+      const checkResult = await this.adb.shell(
+        `run-as ${COMPANION_PACKAGE} cat ${RESULT_FILE_REL} 2>/dev/null`
+      );
       if (checkResult.success && checkResult.stdout.trim()) {
         try {
           const result = JSON.parse(checkResult.stdout) as T;
-          // Clean up
-          await this.adb.shell(`rm -f ${RESULT_FILE}`);
+          await this.clearResultFile();
           return result;
         } catch {
           // JSON not ready yet, continue waiting
@@ -209,12 +219,11 @@ export class EnterpriseWifiCommands {
     };
 
     await this.writeCommandFile(commandPayload);
-    await this.adb.shell(`rm -f ${RESULT_FILE}`);
+    await this.clearResultFile();
 
     await this.adb.shell(
       `am broadcast -a ${COMPANION_PACKAGE}.LIST_CERTIFICATES ` +
-      `-n ${COMPANION_PACKAGE}/.AdbBridgeReceiver ` +
-      `--es config_file "${COMMAND_FILE}"`
+      `-n ${COMPANION_PACKAGE}/.AdbBridgeReceiver`
     );
 
     const result = await this.waitForResult<{ certificates: string[] }>('list');

--- a/src/adb/notifications-commands.ts
+++ b/src/adb/notifications-commands.ts
@@ -1,8 +1,9 @@
 import { AdbClient } from './adb-client.js';
 
 const COMPANION_PACKAGE = 'com.example.wifimcpcompanion';
-const COMMAND_FILE = '/sdcard/Download/wifi_mcp_command.json';
-const RESULT_FILE = '/sdcard/Download/wifi_mcp_result.json';
+// IPC files live in the companion app's private filesDir, accessed via run-as.
+const COMMAND_FILE_REL = 'files/wifi_mcp_command.json';
+const RESULT_FILE_REL = 'files/wifi_mcp_result.json';
 const RESULT_TIMEOUT = 10000; // 10s for a single broadcast round-trip
 
 /**
@@ -22,7 +23,7 @@ export class NotificationCommands {
   }
 
   async getStatus(): Promise<NotificationStatus> {
-    await this.adb.shell(`rm -f ${RESULT_FILE}`);
+    await this.clearResultFile();
     await this.adb.shell(
       `am broadcast -a ${COMPANION_PACKAGE}.NOTIFICATION_STATUS -n ${COMPANION_PACKAGE}/.AdbBridgeReceiver`
     );
@@ -58,9 +59,9 @@ export class NotificationCommands {
       config.limit = opts.limit;
     }
     await this.writeCommandFile(config);
-    await this.adb.shell(`rm -f ${RESULT_FILE}`);
+    await this.clearResultFile();
     await this.adb.shell(
-      `am broadcast -a ${COMPANION_PACKAGE}.LIST_NOTIFICATIONS -n ${COMPANION_PACKAGE}/.AdbBridgeReceiver --es config_file "${COMMAND_FILE}"`
+      `am broadcast -a ${COMPANION_PACKAGE}.LIST_NOTIFICATIONS -n ${COMPANION_PACKAGE}/.AdbBridgeReceiver`
     );
     const result = await this.waitForResult();
     if (!result) {
@@ -136,8 +137,14 @@ export class NotificationCommands {
 
   private async writeCommandFile(payload: object): Promise<void> {
     const json = JSON.stringify(payload);
-    const escaped = json.replace(/'/g, "'\\''");
-    await this.adb.shell(`echo '${escaped}' > ${COMMAND_FILE}`);
+    const b64 = Buffer.from(json, 'utf-8').toString('base64');
+    await this.adb.shell(
+      `run-as ${COMPANION_PACKAGE} sh -c 'echo ${b64} | base64 -d > ${COMMAND_FILE_REL}'`
+    );
+  }
+
+  private async clearResultFile(): Promise<void> {
+    await this.adb.shell(`run-as ${COMPANION_PACKAGE} rm -f ${RESULT_FILE_REL}`);
   }
 
   private async waitForResult(): Promise<Record<string, unknown> | null> {
@@ -145,11 +152,13 @@ export class NotificationCommands {
     const pollInterval = 300;
     while (Date.now() - start < RESULT_TIMEOUT) {
       await new Promise((res) => setTimeout(res, pollInterval));
-      const cat = await this.adb.shell(`cat ${RESULT_FILE} 2>/dev/null`);
+      const cat = await this.adb.shell(
+        `run-as ${COMPANION_PACKAGE} cat ${RESULT_FILE_REL} 2>/dev/null`
+      );
       if (cat.success && cat.stdout.trim()) {
         try {
           const parsed = JSON.parse(cat.stdout) as Record<string, unknown>;
-          await this.adb.shell(`rm -f ${RESULT_FILE}`);
+          await this.clearResultFile();
           return parsed;
         } catch {
           // partial write — keep polling


### PR DESCRIPTION
## Summary

- Move the companion-app IPC bridge off `/sdcard/Download/` (broken by Android 11+ scoped storage) and into the app's private `filesDir`, accessed from the host via `adb shell run-as <pkg> ...`.
- Switch `adb-client.ts` from `child_process.exec` to `execFile` so shell metacharacters survive intact through to the device shell.
- Drop the `--es config_file` extra and the unused `intent` parameter on receiver handlers.

## Why

After #21 unmasked the underlying failure, every command requiring a config file (`connect_enterprise`, `install_certificate`, `disconnect`, `list_notifications` with filters) returned `Failed to read config file` because the companion app — `targetSdk=34, minSdk=30` — cannot read `/sdcard/Download/` files written by `adb shell` on modern Android. Logcat:

```
java.io.FileNotFoundException: /sdcard/Download/wifi_mcp_command.json: open failed: EACCES (Permission denied)
    at AdbBridgeReceiver.readConfigFile(AdbBridgeReceiver.kt:289)
```

The fix moves the bridge into territory both sides own:
- App reads/writes from `context.filesDir` (`/data/data/<pkg>/files/`) — natively allowed.
- Host writes via `adb shell run-as <pkg> sh -c 'echo <b64> | base64 -d > files/...'` — works because the manifest has `android:debuggable="true"`.

A second host-side bug surfaced during the rewrite: `adb-client.ts` was using `child_process.exec`, which spawns `/bin/sh -c <command-string>` and re-tokenizes our carefully-built `run-as <pkg> sh -c '<inner script>'`. The host `/bin/sh` strips the inner single quotes during arg parsing, leaving the device shell to see mangled tokens. Switching to `execFile` (direct args array, no host shell layer) preserves the quoting end-to-end. **No behaviour change for callers that don't use shell metacharacters**; for callers that do (e.g. `dumpsys wifi | grep ...`), the pipe now runs on the device shell instead of the host shell — equivalent output, more correct semantics.

## Files changed

| File | Change |
|---|---|
| `src/adb/enterprise-wifi.ts` | New `COMMAND_FILE_REL` / `RESULT_FILE_REL` constants relative to filesDir. `writeCommandFile` base64-pipes payload through `run-as`. Reads and clears wrap in `run-as`. Broadcasts drop `--es config_file`. |
| `src/adb/notifications-commands.ts` | Same `run-as` wrapping in `getStatus` / `listRecent` / `writeCommandFile` / `waitForResult`. |
| `src/adb/adb-client.ts` | `exec` → `execFile`, no host-shell parsing layer. Bumps maxBuffer to 8 MB to cover `wifi_scan` (~57 KB) and any future large outputs. |
| `companion-app/.../AdbBridgeReceiver.kt` | Drop `Environment.getExternalStoragePublicDirectory(...)` constants. Compute `commandFile(context)` / `resultFile(context)` from `context.filesDir` on demand. Drop `EXTRA_CONFIG_FILE` extra and the `intent` parameter on handlers that no longer read from it. |

## Test plan

- [x] `npm run build` clean
- [x] `npm run test:unit` — 26/26 pass
- [x] `cd companion-app && ANDROID_HOME=~/Android/Sdk ./gradlew assembleDebug` — clean, no warnings
- [x] `adb install -r app/build/outputs/apk/debug/app-debug.apk` — Success
- [x] **End-to-end on Pixel 8 / Android 14**: `wifi_connect_enterprise` with bogus PEAP args now reaches the EAP config build and returns `Enterprise configuration mandates server certificate but validation is not enabled` (the right error for that input). 4.2 s elapsed. The `Failed to read config file` failure mode is gone.
- [x] **wifi_check_companion_app** still works — returns clean status (3.3 s) via the same `run-as`-based path. Confirms no regression on the previously-working notification-status flow.

## Follow-ups (not in this PR)

- #25 — companion app's failure messages still being silently dropped on the host side (`message` vs `error` field-name mismatch). Surfaces as `{success: false, ssid, eapMethod}` without an error string. Independent of this PR.
- The deeper "tool reports `success: true` after `addNetworkSuggestions` registration, before the device actually connects or fails EAP" gap from #20's earlier comment is now ungated for testing — file separately once a real 802.1x test is run end-to-end.

Fixes #22.