### PR TITLE
Surface companion-app failure messages on the host (#25)

### DIFF
--- a/src/adb/enterprise-wifi.ts
+++ b/src/adb/enterprise-wifi.ts
@@ -1,6 +1,7 @@
 import { AdbClient } from './adb-client.js';
 import {
   EapConfig,
+  EapMethod,
   EnterpriseConnectionResult,
   CertificateInstallResult,
 } from '../types.js';
@@ -89,13 +90,28 @@ export class EnterpriseWifiCommands {
       };
     }
 
-    // Wait for result
-    const result = await this.waitForResult<EnterpriseConnectionResult>(config.ssid);
-    return result || {
-      success: false,
-      ssid: config.ssid,
-      eapMethod: config.eapMethod,
-      error: 'Timeout waiting for connection result',
+    // Wait for result. The companion app emits a wire format with `message`
+    // (and optional `ssid` / `eapMethod`); normalize into our typed result so
+    // `error` is always populated on failure.
+    const raw = await this.waitForResult<Record<string, unknown>>(config.ssid);
+    if (!raw) {
+      return {
+        success: false,
+        ssid: config.ssid,
+        eapMethod: config.eapMethod,
+        error: 'Timeout waiting for connection result',
+      };
+    }
+    const success = !!raw.success;
+    return {
+      success,
+      ssid: (typeof raw.ssid === 'string' ? raw.ssid : config.ssid),
+      eapMethod: (typeof raw.eapMethod === 'string' ? raw.eapMethod as EapMethod : config.eapMethod),
+      error: success
+        ? undefined
+        : (typeof raw.error === 'string' ? raw.error
+          : typeof raw.message === 'string' ? raw.message
+          : 'Unknown error'),
     };
   }
 
@@ -145,13 +161,26 @@ export class EnterpriseWifiCommands {
       };
     }
 
-    // Wait for result
-    const result = await this.waitForResult<CertificateInstallResult>(alias);
-    return result || {
-      success: false,
-      alias,
-      type,
-      error: 'Timeout waiting for certificate installation result',
+    // Wait for result. Normalize companion `message` → our typed `error`.
+    const raw = await this.waitForResult<Record<string, unknown>>(alias);
+    if (!raw) {
+      return {
+        success: false,
+        alias,
+        type,
+        error: 'Timeout waiting for certificate installation result',
+      };
+    }
+    const success = !!raw.success;
+    return {
+      success,
+      alias: (typeof raw.alias === 'string' ? raw.alias : alias),
+      type: (raw.type === 'ca' || raw.type === 'client' ? raw.type : type),
+      error: success
+        ? undefined
+        : (typeof raw.error === 'string' ? raw.error
+          : typeof raw.message === 'string' ? raw.message
+          : 'Unknown error'),
     };
   }
 


### PR DESCRIPTION
## Summary

- Normalize the companion app's wire format (`message`) into the host's typed result (`error`) at the `connectEnterprise` / `installCertificate` boundary.
- Failure responses now always include the actual diagnostic string instead of an empty `{ "success": false }`.

## Why

After #21 + #22 landed, every failure path returned `{ "success": false }` with no error message. The companion app populates `message` on the wire; the host's `EnterpriseConnectionResult` / `CertificateInstallResult` types expect `error`. `JSON.stringify` drops undefined keys, so the message was silently lost.

## Approach

`waitForResult` now returns a raw `Record<string, unknown>` to the two callers, which re-shape it into the typed result:

```ts
const success = !!raw.success;
return {
  success,
  ssid: (typeof raw.ssid === 'string' ? raw.ssid : config.ssid),
  eapMethod: (typeof raw.eapMethod === 'string' ? raw.eapMethod as EapMethod : config.eapMethod),
  error: success ? undefined
    : (typeof raw.error === 'string' ? raw.error
      : typeof raw.message === 'string' ? raw.message
      : 'Unknown error'),
};
```

Same shape applied to `installCertificate` for `alias` / `type` / `error` / `message`. `ssid` / `eapMethod` / `alias` / `type` fall back to the call-site values when the companion didn't reach the layer that populates them (e.g., `Failed to read config file` from before #22 was fixed).

## Test plan

- [x] `npm run build` clean
- [x] `npm run test:unit` — 26/26 pass
- [x] **End-to-end on Pixel 8 / Android 14**: `wifi_connect_enterprise` with bogus PEAP args now returns:
  ```json
  {
    "success": false,
    "ssid": "BogusProbe",
    "eapMethod": "peap",
    "error": "Enterprise configuration mandates server certificate but validation is not enabled."
  }
  ```
  3.8s elapsed.

## Out of scope

- The "tool reports `success: true` after `addNetworkSuggestions` registration before the device actually connects or fails EAP" gap from #20's earlier comment is still a separate, larger issue. It's now ungated for testing — file separately once a real 802.1x scenario is exercised end-to-end.

Fixes #25.