### PR TITLE
Add device_settings_get / device_settings_put (#20, PR 1/3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,9 +18,9 @@ Claude Code  ──MCP──►  android-wifi-mcp (this server)  ──ADB──
 ```
 
 - **Server entrypoint:** `src/index.ts` picks transport (HTTP default, `--stdio` for stdio).
-- **Tool registry:** `src/server.ts` — `createMcpServer(deviceManager)` returns `{ server, nativeToolNames }` and registers 30 native tools.
+- **Tool registry:** `src/server.ts` — `createMcpServer(deviceManager)` returns `{ server, nativeToolNames }` and registers 34 native tools.
 - **Proxy:** `src/mcp/upstream-proxy.ts` spawns upstream MCP subprocesses on startup and merges their tools into one tools/list. Configured via `UPSTREAM_MCP` env var.
-- **ADB layer:** `src/adb/` — `adb-client.ts` (process wrapper), `device-manager.ts` (multi-device), then per-domain wrappers: `wifi-commands.ts`, `ui-commands.ts`, `sms-commands.ts`, `enterprise-wifi.ts`.
+- **ADB layer:** `src/adb/` — `adb-client.ts` (process wrapper), `device-manager.ts` (multi-device), then per-domain wrappers: `wifi-commands.ts`, `ui-commands.ts`, `sms-commands.ts`, `enterprise-wifi.ts`, `settings-commands.ts`.
 - **Companion app:** `companion-app/` — Kotlin Android app that handles 802.1X enterprise WiFi (the only flow that needs an on-device daemon today).
 - **Network helpers:** `src/network/network-check.ts`.
 - **Test framework:** `cicd/tests/` — custom YAML-driven runner. See "Tests" below.
@@ -57,7 +57,7 @@ To add a test, use the **`ci-testcase`** project skill (`.claude/skills/ci-testc
 
 ## Tool surface
 
-30 native tools across 6 categories (`device_*`, `wifi_*`, `wifi_*_enterprise`, `network_*`, `device_*` UI, `sms_*`). With `UPSTREAM_MCP=playwright=...` set, an additional 21 `browser_*` tools from `@playwright/mcp` are proxied through — **51 total**.
+34 native tools across 7 categories (`device_*` mgmt, `device_settings_*`, `wifi_*`, `wifi_*_enterprise`, `network_*`, `device_*` UI, `sms_*`). With `UPSTREAM_MCP=playwright=...` set, an additional 21 `browser_*` tools from `@playwright/mcp` are proxied through — **55 total**.
 
 The unified namespace is the design goal: Claude Code sees one server, gets one tools/list. Don't add a feature here that exists in a mature upstream — proxy it instead. (#10 was closed and #14 implemented for exactly this reason.)
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Enterprise WiFi (802.1X/EAP) requires a companion Android app because the `cmd w
 
 ## Available Tools
 
-**32 native tools** in 7 categories below. With the optional `@playwright/mcp` upstream enabled (see [Proxying upstream MCPs](#proxying-upstream-mcps)), an additional **21 `browser_*` tools** are surfaced through the same endpoint for **53 total**.
+**34 native tools** in 8 categories below. With the optional `@playwright/mcp` upstream enabled (see [Proxying upstream MCPs](#proxying-upstream-mcps)), an additional **21 `browser_*` tools** are surfaced through the same endpoint for **55 total**.
 
 ### Device Management
 
@@ -190,6 +190,13 @@ Enterprise WiFi (802.1X/EAP) requires a companion Android app because the `cmd w
 | `device_list` | List all connected Android devices |
 | `device_select` | Select a device for operations |
 | `device_info` | Get detailed device information |
+
+### Device Settings (system / secure / global)
+
+| Tool | Description |
+|------|-------------|
+| `device_settings_get` | Read a value from `adb shell settings get <namespace> <key>` |
+| `device_settings_put` | Write a value via `adb shell settings put <namespace> <key> <value>` |
 
 ### WiFi Control
 
@@ -429,7 +436,7 @@ Upstreams start eagerly at server boot. On `SIGINT` / `SIGTERM` the server close
 
 ### Verified composition
 
-The default `UPSTREAM_MCP` in `.env.example` is `@playwright/mcp` — running our server with that set yields **51 total tools** (30 native + 21 from `@playwright/mcp`), all reachable from one MCP endpoint. See `cicd/tests/testcases/proxy/TC-PROXY-002.yml` for the end-to-end smoke test.
+The default `UPSTREAM_MCP` in `.env.example` is `@playwright/mcp` — running our server with that set yields **55 total tools** (34 native + 21 from `@playwright/mcp`), all reachable from one MCP endpoint. See `cicd/tests/testcases/proxy/TC-PROXY-002.yml` for the end-to-end smoke test.
 
 ## Testing
 

--- a/cicd/tests/testcases/smoke/TC-SMK-008.yml
+++ b/cicd/tests/testcases/smoke/TC-SMK-008.yml
@@ -1,0 +1,24 @@
+id: TC-SMK-008
+name: device_settings_get reads a known global setting
+suite: smoke
+tags: [smoke, settings]
+priority: 8
+timeout: 30000
+dependencies: []
+
+steps:
+  - name: Read airplane_mode_on from the global namespace
+    command: npx tsx cicd/tests/src/mcp-client.ts device_settings_get '{"namespace":"global","key":"airplane_mode_on"}'
+    expectPatterns:
+      - "namespace.*global"
+      - "key.*airplane_mode_on"
+      - "value"
+    rejectPatterns:
+      - "isError"
+
+criteria: |
+  Verify device_settings_get reads `airplane_mode_on` from the global settings namespace.
+  - Tool returns successfully without errors
+  - Response includes the namespace, key, and value fields
+  - Confirms the host can shell out to `adb shell settings get` and parse the result
+  - Does not assert a specific value (0 or 1) — just that read works

--- a/cicd/tests/testcases/smoke/TC-SMK-009.yml
+++ b/cicd/tests/testcases/smoke/TC-SMK-009.yml
@@ -1,0 +1,30 @@
+id: TC-SMK-009
+name: device_settings_put round-trips a value through the system namespace
+suite: smoke
+tags: [smoke, settings]
+priority: 9
+timeout: 60000
+dependencies: []
+
+steps:
+  - name: Write a sentinel value into a non-load-bearing system setting
+    command: npx tsx cicd/tests/src/mcp-client.ts device_settings_put '{"namespace":"system","key":"wifi_mcp_smoke_{{TEST_RUN_ID}}","value":"hello"}'
+    expectPatterns:
+      - "success.*true"
+      - "wifi_mcp_smoke_{{TEST_RUN_ID}}"
+    rejectPatterns:
+      - "isError"
+
+  - name: Read the sentinel back
+    command: npx tsx cicd/tests/src/mcp-client.ts device_settings_get '{"namespace":"system","key":"wifi_mcp_smoke_{{TEST_RUN_ID}}"}'
+    expectPatterns:
+      - "value.*hello"
+    rejectPatterns:
+      - "isError"
+
+criteria: |
+  Verify a put-then-get round-trip on a TEST_RUN_ID-namespaced sentinel key.
+  - Put returns success
+  - Get returns the same value we wrote
+  - Sentinel key is namespaced by TEST_RUN_ID so concurrent runs don't collide
+  - Stays in the `system` namespace (cheapest, no security implications)

--- a/src/adb/device-manager.ts
+++ b/src/adb/device-manager.ts
@@ -3,11 +3,12 @@ import { WifiCommands } from './wifi-commands.js';
 import { UICommands } from './ui-commands.js';
 import { SmsCommands } from './sms-commands.js';
 import { NotificationCommands } from './notifications-commands.js';
+import { SettingsCommands } from './settings-commands.js';
 import { Device, DeviceInfo } from '../types.js';
 
 /**
  * Manages connected Android devices and provides unified access
- * to ADB, WiFi, UI, SMS, and notification commands.
+ * to ADB, WiFi, UI, SMS, notification, and settings commands.
  */
 export class DeviceManager {
   private adb: AdbClient;
@@ -15,6 +16,7 @@ export class DeviceManager {
   private ui: UICommands;
   private sms: SmsCommands;
   private notifications: NotificationCommands;
+  private settings: SettingsCommands;
   private devices: Map<string, DeviceInfo> = new Map();
 
   constructor(adbPath?: string) {
@@ -23,6 +25,7 @@ export class DeviceManager {
     this.ui = new UICommands(this.adb);
     this.sms = new SmsCommands(this.adb);
     this.notifications = new NotificationCommands(this.adb);
+    this.settings = new SettingsCommands(this.adb);
   }
 
   /**
@@ -58,6 +61,13 @@ export class DeviceManager {
    */
   getNotificationCommands(): NotificationCommands {
     return this.notifications;
+  }
+
+  /**
+   * Get the settings commands instance
+   */
+  getSettingsCommands(): SettingsCommands {
+    return this.settings;
   }
 
   /**

--- a/src/adb/settings-commands.ts
+++ b/src/adb/settings-commands.ts
@@ -1,0 +1,67 @@
+import { AdbClient } from './adb-client.js';
+
+export type SettingsNamespace = 'system' | 'secure' | 'global';
+
+export interface SettingsGetResult {
+  namespace: SettingsNamespace;
+  key: string;
+  value: string | null;
+}
+
+export interface SettingsPutResult {
+  namespace: SettingsNamespace;
+  key: string;
+  value: string;
+  success: boolean;
+  error?: string;
+}
+
+/**
+ * Read and write entries in Android's settings provider via
+ * `adb shell settings get|put <namespace> <key> [<value>]`.
+ *
+ * Three namespaces — `system` (user prefs), `secure` (security/auth), `global`
+ * (device-wide). The ADB shell user holds `WRITE_SECURE_SETTINGS` by default
+ * on dev/userdebug builds, so all three are writable from the host without
+ * additional permission grants.
+ */
+export class SettingsCommands {
+  private adb: AdbClient;
+
+  constructor(adb: AdbClient) {
+    this.adb = adb;
+  }
+
+  async get(namespace: SettingsNamespace, key: string): Promise<SettingsGetResult> {
+    const result = await this.adb.shell(`settings get ${namespace} ${shellQuote(key)}`);
+    if (!result.success) {
+      throw new Error(`settings get failed: ${result.stderr || result.stdout}`);
+    }
+    const trimmed = result.stdout.trim();
+    // `settings get` prints the literal string "null" when the key is unset.
+    const value = trimmed === 'null' || trimmed === '' ? null : trimmed;
+    return { namespace, key, value };
+  }
+
+  async put(namespace: SettingsNamespace, key: string, value: string): Promise<SettingsPutResult> {
+    const result = await this.adb.shell(
+      `settings put ${namespace} ${shellQuote(key)} ${shellQuote(value)}`
+    );
+    if (!result.success) {
+      return {
+        namespace,
+        key,
+        value,
+        success: false,
+        error: result.stderr || result.stdout || 'Unknown error',
+      };
+    }
+    return { namespace, key, value, success: true };
+  }
+}
+
+function shellQuote(s: string): string {
+  // Single-quote and escape any embedded single quotes. Safe for both host
+  // execFile (no host shell) and the device shell that adb forwards to.
+  return `'${s.replace(/'/g, "'\\''")}'`;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -111,6 +111,64 @@ export function createMcpServer(deviceManager: DeviceManager): CreateServerResul
     }
   );
 
+  // ============ Device Settings (system / secure / global) ============
+
+  mcpServer.tool(
+    'device_settings_get',
+    'Read a value from the Android settings provider via `adb shell settings get`. Namespaces: system (user prefs), secure (auth/lockscreen/IME), global (airplane_mode_on, mobile_data, private_dns_*, captive_portal_server, etc).',
+    {
+      namespace: z.enum(['system', 'secure', 'global']).describe('Settings namespace'),
+      key: z.string().describe('Setting key, e.g. "airplane_mode_on" or "default_input_method"'),
+    },
+    async ({ namespace, key }) => {
+      await ensureDevice();
+      const settings = deviceManager.getSettingsCommands();
+      const result = await settings.get(namespace, key);
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(result, null, 2),
+          },
+        ],
+      };
+    }
+  );
+
+  mcpServer.tool(
+    'device_settings_put',
+    'Write a value to the Android settings provider via `adb shell settings put`. Requires WRITE_SECURE_SETTINGS, which the ADB shell user holds by default on dev/userdebug builds.',
+    {
+      namespace: z.enum(['system', 'secure', 'global']).describe('Settings namespace'),
+      key: z.string().describe('Setting key'),
+      value: z.string().describe('New value (always written as a string; the settings provider preserves it as text)'),
+    },
+    async ({ namespace, key, value }) => {
+      await ensureDevice();
+      const settings = deviceManager.getSettingsCommands();
+      const result = await settings.put(namespace, key, value);
+      if (result.success) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(result, null, 2),
+            },
+          ],
+        };
+      }
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(result, null, 2),
+          },
+        ],
+        isError: true,
+      };
+    }
+  );
+
   // ============ WiFi Tools ============
 
   mcpServer.tool(


### PR DESCRIPTION
## Summary

- First of three PRs implementing the option-A scope finalized in #20.
- Adds `device_settings_get` and `device_settings_put` — narrow ADB-level escape hatches that mobile-mcp does not provide.
- Net surface: 32 native tools → **34**.
- 9/9 smoke tests pass (added 2 new ones), 26/26 unit tests pass.

## Why

Per #20's project focus statement: *"the ADB-level control plane mobile-mcp won't touch."* Android's settings provider has three namespaces (`system`, `secure`, `global`) totalling several hundred keys — the QA-flow-critical ones include `airplane_mode_on`, `mobile_data`, `private_dns_mode`, `captive_portal_server`. mobile-mcp has no programmatic accessor; its only path is to drive Settings.app via the UI, which is fragile across Android versions. We expose the two generic accessors only, per the spec sanity gate — named wrappers land when a real scenario needs them.

## Tool surface

| Tool | Behavior |
|---|---|
| `device_settings_get` | `adb shell settings get <namespace> <key>` → `{ namespace, key, value }`. The literal `"null"` from missing keys is normalized to JS `null`. |
| `device_settings_put` | `adb shell settings put <namespace> <key> <value>` → `{ namespace, key, value, success, error? }`. ADB shell holds `WRITE_SECURE_SETTINGS` by default on dev/userdebug builds. |

## Files

- `src/adb/settings-commands.ts` (new) — `SettingsCommands` class with `get` / `put`. `shellQuote` for embedded special chars.
- `src/adb/device-manager.ts` — wire `SettingsCommands` in the existing pattern (private field, constructor, getter).
- `src/server.ts` — register both tools in a new "Device Settings" block above WiFi.
- `README.md`, `CLAUDE.md` — counts (32 → 34, proxy total 51 → 55), new table row, category list updated.
- `cicd/tests/testcases/smoke/TC-SMK-008.yml` — smoke: read `global.airplane_mode_on`.
- `cicd/tests/testcases/smoke/TC-SMK-009.yml` — smoke: put-then-get round-trip on a `TEST_RUN_ID`-namespaced sentinel in `system`.

## Test plan

- [x] `npm run build` clean
- [x] `npm run tools:count` → 34 (was 32)
- [x] `npm run test:unit` — 26/26 pass
- [x] **End-to-end on Pixel 8 / Android 14**:
  ```
  settings_get global airplane_mode_on → value: "0"
  settings_put system wifi_mcp_smoke_PROBE hello → success: true
  settings_get system wifi_mcp_smoke_PROBE → value: "hello"
  ```
- [x] `cd cicd/tests && npm test -- --suite smoke` → 9/9 pass

## Sequencing

This is **PR 1 of 3** for #20:
- **PR 1 (this)**: Add settings tools.
- **PR 2**: Add `device_push_file` / `device_pull_file`.
- **PR 3**: Cut the 8 overlap tools (`device_tap`, `device_swipe`, `device_keyevent`, `device_type_text`, `device_open_url`, `device_launch_app`, `device_list_packages`, `device_ui_dump`) + `docs/integrations/` note about mobile-mcp's UiAutomator retry-loop trick + final README/CLAUDE.md trim.

Refs #20.