### PR TITLE
Add device_push_file / device_pull_file (#20, PR 2/3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,9 +18,9 @@ Claude Code  ──MCP──►  android-wifi-mcp (this server)  ──ADB──
 ```
 
 - **Server entrypoint:** `src/index.ts` picks transport (HTTP default, `--stdio` for stdio).
-- **Tool registry:** `src/server.ts` — `createMcpServer(deviceManager)` returns `{ server, nativeToolNames }` and registers 34 native tools.
+- **Tool registry:** `src/server.ts` — `createMcpServer(deviceManager)` returns `{ server, nativeToolNames }` and registers 36 native tools.
 - **Proxy:** `src/mcp/upstream-proxy.ts` spawns upstream MCP subprocesses on startup and merges their tools into one tools/list. Configured via `UPSTREAM_MCP` env var.
-- **ADB layer:** `src/adb/` — `adb-client.ts` (process wrapper), `device-manager.ts` (multi-device), then per-domain wrappers: `wifi-commands.ts`, `ui-commands.ts`, `sms-commands.ts`, `enterprise-wifi.ts`, `settings-commands.ts`.
+- **ADB layer:** `src/adb/` — `adb-client.ts` (process wrapper), `device-manager.ts` (multi-device), then per-domain wrappers: `wifi-commands.ts`, `ui-commands.ts`, `sms-commands.ts`, `enterprise-wifi.ts`, `settings-commands.ts`, `file-commands.ts`.
 - **Companion app:** `companion-app/` — Kotlin Android app that handles 802.1X enterprise WiFi (the only flow that needs an on-device daemon today).
 - **Network helpers:** `src/network/network-check.ts`.
 - **Test framework:** `cicd/tests/` — custom YAML-driven runner. See "Tests" below.
@@ -57,7 +57,7 @@ To add a test, use the **`ci-testcase`** project skill (`.claude/skills/ci-testc
 
 ## Tool surface
 
-34 native tools across 7 categories (`device_*` mgmt, `device_settings_*`, `wifi_*`, `wifi_*_enterprise`, `network_*`, `device_*` UI, `sms_*`). With `UPSTREAM_MCP=playwright=...` set, an additional 21 `browser_*` tools from `@playwright/mcp` are proxied through — **55 total**.
+36 native tools across 8 categories (`device_*` mgmt, `device_settings_*`, `device_*_file`, `wifi_*`, `wifi_*_enterprise`, `network_*`, `device_*` UI, `sms_*`). With `UPSTREAM_MCP=playwright=...` set, an additional 21 `browser_*` tools from `@playwright/mcp` are proxied through — **57 total**.
 
 The unified namespace is the design goal: Claude Code sees one server, gets one tools/list. Don't add a feature here that exists in a mature upstream — proxy it instead. (#10 was closed and #14 implemented for exactly this reason.)
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Enterprise WiFi (802.1X/EAP) requires a companion Android app because the `cmd w
 
 ## Available Tools
 
-**34 native tools** in 8 categories below. With the optional `@playwright/mcp` upstream enabled (see [Proxying upstream MCPs](#proxying-upstream-mcps)), an additional **21 `browser_*` tools** are surfaced through the same endpoint for **55 total**.
+**36 native tools** in 9 categories below. With the optional `@playwright/mcp` upstream enabled (see [Proxying upstream MCPs](#proxying-upstream-mcps)), an additional **21 `browser_*` tools** are surfaced through the same endpoint for **57 total**.
 
 ### Device Management
 
@@ -197,6 +197,13 @@ Enterprise WiFi (802.1X/EAP) requires a companion Android app because the `cmd w
 |------|-------------|
 | `device_settings_get` | Read a value from `adb shell settings get <namespace> <key>` |
 | `device_settings_put` | Write a value via `adb shell settings put <namespace> <key> <value>` |
+
+### Device File Transfer
+
+| Tool | Description |
+|------|-------------|
+| `device_push_file` | Host → device via `adb push`. Use for staging certs, profiles, PCAPs |
+| `device_pull_file` | Device → host via `adb pull`. Use for capturing downloads, app dumps, log files |
 
 ### WiFi Control
 
@@ -436,7 +443,7 @@ Upstreams start eagerly at server boot. On `SIGINT` / `SIGTERM` the server close
 
 ### Verified composition
 
-The default `UPSTREAM_MCP` in `.env.example` is `@playwright/mcp` — running our server with that set yields **55 total tools** (34 native + 21 from `@playwright/mcp`), all reachable from one MCP endpoint. See `cicd/tests/testcases/proxy/TC-PROXY-002.yml` for the end-to-end smoke test.
+The default `UPSTREAM_MCP` in `.env.example` is `@playwright/mcp` — running our server with that set yields **57 total tools** (36 native + 21 from `@playwright/mcp`), all reachable from one MCP endpoint. See `cicd/tests/testcases/proxy/TC-PROXY-002.yml` for the end-to-end smoke test.
 
 ## Testing
 

--- a/cicd/tests/testcases/smoke/TC-SMK-010.yml
+++ b/cicd/tests/testcases/smoke/TC-SMK-010.yml
@@ -1,0 +1,43 @@
+id: TC-SMK-010
+name: device_push_file / device_pull_file round-trip with byte-equality
+suite: smoke
+tags: [smoke, files]
+priority: 10
+timeout: 60000
+dependencies: []
+
+steps:
+  - name: Stage a fixture on the host and push it to /data/local/tmp/
+    command: |
+      printf 'mcp-smoke-{{TEST_RUN_ID}}-content\n' > /tmp/file_tools_in_{{TEST_RUN_ID}}.txt && \
+      npx tsx cicd/tests/src/mcp-client.ts device_push_file '{"localPath":"/tmp/file_tools_in_{{TEST_RUN_ID}}.txt","remotePath":"/data/local/tmp/file_tools_{{TEST_RUN_ID}}.txt"}'
+    expectPatterns:
+      - "success.*true"
+      - "1 file pushed"
+    rejectPatterns:
+      - "isError"
+
+  - name: Pull the file back to a different host path
+    command: npx tsx cicd/tests/src/mcp-client.ts device_pull_file '{"remotePath":"/data/local/tmp/file_tools_{{TEST_RUN_ID}}.txt","localPath":"/tmp/file_tools_out_{{TEST_RUN_ID}}.txt"}'
+    expectPatterns:
+      - "success.*true"
+      - "1 file pulled"
+    rejectPatterns:
+      - "isError"
+
+  - name: Verify byte-for-byte equality and clean up
+    command: |
+      diff /tmp/file_tools_in_{{TEST_RUN_ID}}.txt /tmp/file_tools_out_{{TEST_RUN_ID}}.txt && \
+      echo ROUND_TRIP_EQUAL && \
+      rm -f /tmp/file_tools_in_{{TEST_RUN_ID}}.txt /tmp/file_tools_out_{{TEST_RUN_ID}}.txt && \
+      adb shell "rm -f /data/local/tmp/file_tools_{{TEST_RUN_ID}}.txt"
+    expectPatterns:
+      - "ROUND_TRIP_EQUAL"
+
+criteria: |
+  Verify a host → device → host file round-trip preserves byte content.
+  - Push reports success and `1 file pushed`
+  - Pull reports success and `1 file pulled`
+  - `diff` returns no differences (zero exit code), and the verification step
+    cleans up both host fixtures and the device staging file
+  - TEST_RUN_ID-namespaced filenames so concurrent runs don't collide

--- a/src/adb/device-manager.ts
+++ b/src/adb/device-manager.ts
@@ -4,11 +4,12 @@ import { UICommands } from './ui-commands.js';
 import { SmsCommands } from './sms-commands.js';
 import { NotificationCommands } from './notifications-commands.js';
 import { SettingsCommands } from './settings-commands.js';
+import { FileCommands } from './file-commands.js';
 import { Device, DeviceInfo } from '../types.js';
 
 /**
  * Manages connected Android devices and provides unified access
- * to ADB, WiFi, UI, SMS, notification, and settings commands.
+ * to ADB, WiFi, UI, SMS, notification, settings, and file commands.
  */
 export class DeviceManager {
   private adb: AdbClient;
@@ -17,6 +18,7 @@ export class DeviceManager {
   private sms: SmsCommands;
   private notifications: NotificationCommands;
   private settings: SettingsCommands;
+  private files: FileCommands;
   private devices: Map<string, DeviceInfo> = new Map();
 
   constructor(adbPath?: string) {
@@ -26,6 +28,7 @@ export class DeviceManager {
     this.sms = new SmsCommands(this.adb);
     this.notifications = new NotificationCommands(this.adb);
     this.settings = new SettingsCommands(this.adb);
+    this.files = new FileCommands(this.adb);
   }
 
   /**
@@ -68,6 +71,13 @@ export class DeviceManager {
    */
   getSettingsCommands(): SettingsCommands {
     return this.settings;
+  }
+
+  /**
+   * Get the file transfer commands instance
+   */
+  getFileCommands(): FileCommands {
+    return this.files;
   }
 
   /**

--- a/src/adb/file-commands.ts
+++ b/src/adb/file-commands.ts
@@ -1,0 +1,73 @@
+import { AdbClient } from './adb-client.js';
+
+export interface FileTransferResult {
+  success: boolean;
+  localPath: string;
+  remotePath: string;
+  output: string;
+  error?: string;
+}
+
+/**
+ * File staging primitives via `adb push` / `adb pull`. Used for cert install
+ * (push), captured downloaded files / app-private dumps (pull), or anything
+ * else that needs to cross the host/device boundary as bytes rather than
+ * shell text.
+ *
+ * Scoping notes:
+ *   • `/data/local/tmp/` is the safest target — shell-owned, readable on
+ *     pull, writable on push.
+ *   • `/sdcard/Download/` works for pull (host can `adb pull`) but on
+ *     Android 11+ apps cannot read shell-written files there (scoped
+ *     storage), so it is a poor staging area for handing files to apps.
+ *     For app-private staging use `adb shell run-as <pkg> ...` (see the
+ *     enterprise-wifi bridge), not push.
+ *   • `/data/data/<pkg>/` is unwritable from `adb push` even on debuggable
+ *     apps — `run-as` is required for that.
+ */
+export class FileCommands {
+  private adb: AdbClient;
+
+  constructor(adb: AdbClient) {
+    this.adb = adb;
+  }
+
+  async push(localPath: string, remotePath: string): Promise<FileTransferResult> {
+    const result = await this.adb.exec(['push', localPath, remotePath]);
+    if (!result.success) {
+      return {
+        success: false,
+        localPath,
+        remotePath,
+        output: result.stdout,
+        error: result.stderr || result.stdout || 'Unknown error',
+      };
+    }
+    return {
+      success: true,
+      localPath,
+      remotePath,
+      // adb writes the progress / summary to stderr; stdout is usually empty.
+      output: result.stderr || result.stdout,
+    };
+  }
+
+  async pull(remotePath: string, localPath: string): Promise<FileTransferResult> {
+    const result = await this.adb.exec(['pull', remotePath, localPath]);
+    if (!result.success) {
+      return {
+        success: false,
+        localPath,
+        remotePath,
+        output: result.stdout,
+        error: result.stderr || result.stdout || 'Unknown error',
+      };
+    }
+    return {
+      success: true,
+      localPath,
+      remotePath,
+      output: result.stderr || result.stdout,
+    };
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -169,6 +169,54 @@ export function createMcpServer(deviceManager: DeviceManager): CreateServerResul
     }
   );
 
+  // ============ Device File Transfer ============
+
+  mcpServer.tool(
+    'device_push_file',
+    'Push a file from the host to the device via `adb push`. Useful for staging certs, profiles, PCAPs. Targets like `/data/local/tmp/` work; `/data/data/<pkg>/` requires `run-as` (use the companion-app bridge instead).',
+    {
+      localPath: z.string().describe('Absolute path on the host machine'),
+      remotePath: z.string().describe('Destination path on the device'),
+    },
+    async ({ localPath, remotePath }) => {
+      await ensureDevice();
+      const files = deviceManager.getFileCommands();
+      const result = await files.push(localPath, remotePath);
+      if (result.success) {
+        return {
+          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+        };
+      }
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+        isError: true,
+      };
+    }
+  );
+
+  mcpServer.tool(
+    'device_pull_file',
+    'Pull a file from the device to the host via `adb pull`. Useful for capturing downloaded files, app-private dumps for assertions, log files. Source must be readable by the adb shell user.',
+    {
+      remotePath: z.string().describe('Source path on the device'),
+      localPath: z.string().describe('Absolute destination path on the host machine'),
+    },
+    async ({ remotePath, localPath }) => {
+      await ensureDevice();
+      const files = deviceManager.getFileCommands();
+      const result = await files.pull(remotePath, localPath);
+      if (result.success) {
+        return {
+          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+        };
+      }
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+        isError: true,
+      };
+    }
+  );
+
   // ============ WiFi Tools ============
 
   mcpServer.tool(


### PR DESCRIPTION
## Summary

- Second of three PRs implementing #20's option-A scope.
- Adds host ↔ device file staging via `adb push` / `adb pull` — the missing QA primitive that neither mobile-mcp nor playwright covers.
- Net surface: 34 → **36 native tools** (proxy total 55 → 57).
- 10/10 smoke pass (added 1 new test), 26/26 unit pass.

## Why

Per #20's project focus: cert/profile/PCAP staging (push) and capture of portal-issued certs / app dumps / log files (pull) are pure ADB-level operations with no overlap. They pair naturally with `wifi_install_certificate` (push the cert, then install) and unblock future captive-portal scenarios (pull what the portal hands the device).

## Tool surface

| Tool | Behavior |
|---|---|
| `device_push_file` | `adb push <local> <remote>` → `{ success, localPath, remotePath, output, error? }`. Surfaces adb's progress line (e.g. `1 file pushed, 0 skipped. 0.5 MB/s (32 bytes in 0.000s)`) in `output`. |
| `device_pull_file` | `adb pull <remote> <local>` → same shape. |

## Files

- `src/adb/file-commands.ts` (new) — `FileCommands` class. Documents the staging-target boundaries inline (`/data/local/tmp/` works, `/data/data/<pkg>/` needs run-as, `/sdcard/Download/` poor for app handoff on Android 11+).
- `src/adb/device-manager.ts` — wire `FileCommands` in the existing pattern.
- `src/server.ts` — register both tools in a new "Device File Transfer" block above WiFi. `isError` on failure only.
- `README.md` — 34 → 36, 8 → 9 categories, proxy total 55 → 57, new "Device File Transfer" table.
- `CLAUDE.md` — same count and category updates; add `file-commands.ts` to the ADB-layer pointer.
- `cicd/tests/testcases/smoke/TC-SMK-010.yml` — three-step push → pull → diff round-trip. Asserts byte-equality and cleans up host + device files. `TEST_RUN_ID`-namespaced.

## Test plan

- [x] `npm run build` clean
- [x] `npm run tools:count` → 36 (was 34)
- [x] `npm run test:unit` — 26/26 pass
- [x] **End-to-end on Pixel 8 / Android 14** (32-byte fixture):
  - `device_push_file` → `success: true`, `1 file pushed, 0 skipped. 0.5 MB/s (32 bytes in 0.000s)`
  - `device_pull_file` → `success: true`, `1 file pulled, 0 skipped. 0.0 MB/s (32 bytes in 0.004s)`
  - `diff` between original and pulled → equal
- [x] `cd cicd/tests && npm test -- --suite smoke` → 10/10 pass

## Sequencing

This is **PR 2 of 3** for #20:
- ✅ PR 1 (#29, merged): settings tools
- **PR 2 (this)**: file transfer tools
- ⏭️ PR 3: cut the 8 overlap tools (`device_tap`, `device_swipe`, `device_keyevent`, `device_type_text`, `device_open_url`, `device_launch_app`, `device_list_packages`, `device_ui_dump`) + `docs/integrations/` note about mobile-mcp's UiAutomator retry-loop trick + final README/CLAUDE.md trim.

Refs #20.