### PR TITLE
File transfer polish: 5min timeout default + negative-case smoke (#32)

### DIFF
--- a/cicd/tests/testcases/smoke/TC-SMK-012.yml
+++ b/cicd/tests/testcases/smoke/TC-SMK-012.yml
@@ -1,0 +1,38 @@
+id: TC-SMK-012
+name: device_push_file / device_pull_file failure paths surface clean errors
+suite: smoke
+tags: [smoke, files]
+priority: 12
+timeout: 60000
+dependencies: []
+
+steps:
+  - name: Push a nonexistent local file — expect "cannot stat" error
+    command: npx tsx cicd/tests/src/mcp-client.ts device_push_file '{"localPath":"/tmp/wifi_mcp_nonexistent_{{TEST_RUN_ID}}.txt","remotePath":"/data/local/tmp/should_not_appear_{{TEST_RUN_ID}}.txt"}'
+    expectPatterns:
+      - "success.*false"
+      - "isError.*true"
+      - "cannot stat"
+      - "No such file"
+
+  - name: Pull a nonexistent remote file — expect "failed to stat remote object"
+    command: npx tsx cicd/tests/src/mcp-client.ts device_pull_file '{"remotePath":"/data/local/tmp/wifi_mcp_nonexistent_{{TEST_RUN_ID}}.txt","localPath":"/tmp/should_not_appear_{{TEST_RUN_ID}}.txt"}'
+    expectPatterns:
+      - "success.*false"
+      - "isError.*true"
+      - "failed to stat remote object"
+
+  - name: Pull from an app-private path — expect "Permission denied"
+    command: npx tsx cicd/tests/src/mcp-client.ts device_pull_file '{"remotePath":"/data/data/com.android.settings/databases/settings.db","localPath":"/tmp/should_not_appear_{{TEST_RUN_ID}}.txt"}'
+    expectPatterns:
+      - "success.*false"
+      - "isError.*true"
+      - "Permission denied"
+
+criteria: |
+  Verify the failure paths of device_push_file / device_pull_file produce
+  clean structured errors instead of throwing or hanging.
+  - Each failed call returns success: false with isError: true
+  - The diagnostic from adb appears in the response's error field
+  - Three orthogonal failure modes covered: missing host file, missing
+    device file, permission denied on a path the shell user can't read

--- a/src/adb/file-commands.ts
+++ b/src/adb/file-commands.ts
@@ -1,5 +1,11 @@
 import { AdbClient } from './adb-client.js';
 
+// File transfers can run over slow USB links or against multi-MB payloads
+// (cert bundles, PCAPs, app-private DB dumps). adb-client.ts defaults to 30 s,
+// which is enough for the smoke fixture but cuts off real captures. 5 min is
+// generous without hiding genuinely-stuck transfers.
+const TRANSFER_TIMEOUT_MS = 5 * 60 * 1000;
+
 export interface FileTransferResult {
   success: boolean;
   localPath: string;
@@ -33,7 +39,7 @@ export class FileCommands {
   }
 
   async push(localPath: string, remotePath: string): Promise<FileTransferResult> {
-    const result = await this.adb.exec(['push', localPath, remotePath]);
+    const result = await this.adb.exec(['push', localPath, remotePath], TRANSFER_TIMEOUT_MS);
     if (!result.success) {
       return {
         success: false,
@@ -53,7 +59,7 @@ export class FileCommands {
   }
 
   async pull(remotePath: string, localPath: string): Promise<FileTransferResult> {
-    const result = await this.adb.exec(['pull', remotePath, localPath]);
+    const result = await this.adb.exec(['pull', remotePath, localPath], TRANSFER_TIMEOUT_MS);
     if (!result.success) {
       return {
         success: false,


### PR DESCRIPTION
## Summary

Two small follow-ups from PR #31's review:

1. **5 min default timeout** for `device_push_file` / `device_pull_file`. Was inheriting `adb-client.ts`'s 30 s default — fine for the 32-byte smoke fixture, but a real cert bundle / PCAP / app-private DB dump could hit it on slow USB.
2. **Negative-case smoke** — `TC-SMK-012` covers the three failure paths verified manually during the prior review.

Net diff: **+46 / −2** across two files.

## Changes

### `src/adb/file-commands.ts`

```ts
const TRANSFER_TIMEOUT_MS = 5 * 60 * 1000;
// ...
async push(...) { return this.adb.exec(['push', ...], TRANSFER_TIMEOUT_MS); }
async pull(...) { return this.adb.exec(['pull', ...], TRANSFER_TIMEOUT_MS); }
```

Constant lives in `file-commands.ts` (not `adb-client.ts`) — only file ops need the long window. Other adb calls keep the 30 s default.

### `cicd/tests/testcases/smoke/TC-SMK-012.yml`

Three steps, each calling a tool that **should** fail, asserting:
- `success.*false` — the result body marks the call as failed
- `isError.*true` — the MCP wrapper sets the error flag
- The relevant adb diagnostic substring is present in `error`

Failure modes covered:
| Step | Setup | Expected diagnostic |
|---|---|---|
| 1 | `device_push_file` of `/tmp/wifi_mcp_nonexistent_<RUNID>.txt` | `cannot stat`, `No such file` |
| 2 | `device_pull_file` of `/data/local/tmp/wifi_mcp_nonexistent_<RUNID>.txt` | `failed to stat remote object` |
| 3 | `device_pull_file` of `/data/data/com.android.settings/databases/settings.db` | `Permission denied` |

## Test plan

- [x] `npm run build` clean
- [x] `npm run test:unit` — 26/26 pass
- [x] `cd cicd/tests && npm test -- --suite smoke` — **12/12 pass** (was 11/11)
- [x] `tools:count` unchanged at 28 (no schema changes)

Fixes #32.