### PR TITLE
Settings tools polish: delete tool, get error shape, secure coverage (#30)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ Claude Code  ──MCP──►  android-wifi-mcp (this server)  ──ADB──
 ```
 
 - **Server entrypoint:** `src/index.ts` picks transport (HTTP default, `--stdio` for stdio).
-- **Tool registry:** `src/server.ts` — `createMcpServer(deviceManager)` returns `{ server, nativeToolNames }` and registers 28 native tools.
+- **Tool registry:** `src/server.ts` — `createMcpServer(deviceManager)` returns `{ server, nativeToolNames }` and registers 29 native tools.
 - **Proxy:** `src/mcp/upstream-proxy.ts` spawns upstream MCP subprocesses on startup and merges their tools into one tools/list. Configured via `UPSTREAM_MCP` env var.
 - **ADB layer:** `src/adb/` — `adb-client.ts` (process wrapper), `device-manager.ts` (multi-device), then per-domain wrappers: `wifi-commands.ts`, `screenshot-commands.ts`, `sms-commands.ts`, `enterprise-wifi.ts`, `settings-commands.ts`, `file-commands.ts`.
 - **Companion app:** `companion-app/` — Kotlin Android app that handles 802.1X enterprise WiFi (the only flow that needs an on-device daemon today).
@@ -57,7 +57,7 @@ To add a test, use the **`ci-testcase`** project skill (`.claude/skills/ci-testc
 
 ## Tool surface
 
-28 native tools across 7 categories (`device_*` mgmt, `device_settings_*`, `device_*_file`, `wifi_*`, `wifi_*_enterprise`, `network_*`, `sms_*` / `notifications_*`). Generic UI automation (`device_tap` / `device_swipe` / `device_keyevent` / `device_type_text` / `device_open_url` / `device_launch_app` / `device_list_packages` / `device_ui_dump`) was intentionally removed in #20 — compose with [`mobile-next/mobile-mcp`](https://github.com/mobile-next/mobile-mcp) for selector-based UI work and `playwright-android` for browser DOM. With `UPSTREAM_MCP=playwright=...` set, an additional 21 `browser_*` tools from `@playwright/mcp` are proxied through — **49 total**.
+29 native tools across 7 categories (`device_*` mgmt, `device_settings_*`, `device_*_file`, `wifi_*`, `wifi_*_enterprise`, `network_*`, `sms_*` / `notifications_*`). Generic UI automation (`device_tap` / `device_swipe` / `device_keyevent` / `device_type_text` / `device_open_url` / `device_launch_app` / `device_list_packages` / `device_ui_dump`) was intentionally removed in #20 — compose with [`mobile-next/mobile-mcp`](https://github.com/mobile-next/mobile-mcp) for selector-based UI work and `playwright-android` for browser DOM. With `UPSTREAM_MCP=playwright=...` set, an additional 21 `browser_*` tools from `@playwright/mcp` are proxied through — **50 total**.
 
 The unified namespace is the design goal: Claude Code sees one server, gets one tools/list. Don't add a feature here that exists in a mature upstream — proxy it instead. (#10 was closed and #14 implemented for exactly this reason.)
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Enterprise WiFi (802.1X/EAP) requires a companion Android app because the `cmd w
 
 ## Available Tools
 
-**28 native tools** in 8 categories below. With the optional `@playwright/mcp` upstream enabled (see [Proxying upstream MCPs](#proxying-upstream-mcps)), an additional **21 `browser_*` tools** are surfaced through the same endpoint for **49 total**.
+**29 native tools** in 8 categories below. With the optional `@playwright/mcp` upstream enabled (see [Proxying upstream MCPs](#proxying-upstream-mcps)), an additional **21 `browser_*` tools** are surfaced through the same endpoint for **50 total**.
 
 ### Device Management
 
@@ -213,6 +213,7 @@ Enterprise WiFi (802.1X/EAP) requires a companion Android app because the `cmd w
 |------|-------------|
 | `device_settings_get` | Read a value from `adb shell settings get <namespace> <key>` |
 | `device_settings_put` | Write a value via `adb shell settings put <namespace> <key> <value>` |
+| `device_settings_delete` | Delete a key via `adb shell settings delete <namespace> <key>` |
 
 ### Device File Transfer
 
@@ -443,7 +444,7 @@ Upstreams start eagerly at server boot. On `SIGINT` / `SIGTERM` the server close
 
 ### Verified composition
 
-The default `UPSTREAM_MCP` in `.env.example` is `@playwright/mcp` — running our server with that set yields **49 total tools** (28 native + 21 from `@playwright/mcp`), all reachable from one MCP endpoint. See `cicd/tests/testcases/proxy/TC-PROXY-002.yml` for the end-to-end smoke test.
+The default `UPSTREAM_MCP` in `.env.example` is `@playwright/mcp` — running our server with that set yields **50 total tools** (29 native + 21 from `@playwright/mcp`), all reachable from one MCP endpoint. See `cicd/tests/testcases/proxy/TC-PROXY-002.yml` for the end-to-end smoke test.
 
 ## Testing
 

--- a/cicd/tests/testcases/smoke/TC-SMK-009.yml
+++ b/cicd/tests/testcases/smoke/TC-SMK-009.yml
@@ -1,5 +1,5 @@
 id: TC-SMK-009
-name: device_settings_put round-trips a value through the system namespace
+name: device_settings_put / get / delete round-trip through the system namespace
 suite: smoke
 tags: [smoke, settings]
 priority: 9
@@ -22,9 +22,26 @@ steps:
     rejectPatterns:
       - "isError"
 
+  - name: Delete the sentinel
+    command: npx tsx cicd/tests/src/mcp-client.ts device_settings_delete '{"namespace":"system","key":"wifi_mcp_smoke_{{TEST_RUN_ID}}"}'
+    expectPatterns:
+      - "success.*true"
+      - "wifi_mcp_smoke_{{TEST_RUN_ID}}"
+    rejectPatterns:
+      - "isError"
+
+  - name: Verify the sentinel is gone — get returns value null
+    command: npx tsx cicd/tests/src/mcp-client.ts device_settings_get '{"namespace":"system","key":"wifi_mcp_smoke_{{TEST_RUN_ID}}"}'
+    expectPatterns:
+      - "value.*null"
+    rejectPatterns:
+      - "isError"
+
 criteria: |
-  Verify a put-then-get round-trip on a TEST_RUN_ID-namespaced sentinel key.
-  - Put returns success
-  - Get returns the same value we wrote
-  - Sentinel key is namespaced by TEST_RUN_ID so concurrent runs don't collide
+  Verify the put → get → delete → get(null) round-trip on a TEST_RUN_ID-namespaced
+  sentinel key.
+  - Put returns success and the sentinel becomes readable
+  - Delete returns success
+  - Subsequent get returns value: null, confirming the row is gone
+  - The test is fully self-cleaning — no orphan sentinels accumulate across runs
   - Stays in the `system` namespace (cheapest, no security implications)

--- a/cicd/tests/testcases/smoke/TC-SMK-013.yml
+++ b/cicd/tests/testcases/smoke/TC-SMK-013.yml
@@ -1,0 +1,30 @@
+id: TC-SMK-013
+name: device_settings_get reads default_input_method from the secure namespace
+suite: smoke
+tags: [smoke, settings]
+priority: 13
+timeout: 30000
+dependencies: []
+
+steps:
+  - name: Read default_input_method from the secure namespace
+    command: npx tsx cicd/tests/src/mcp-client.ts device_settings_get '{"namespace":"secure","key":"default_input_method"}'
+    expectPatterns:
+      - "namespace.*secure"
+      - "key.*default_input_method"
+      - "value"
+    rejectPatterns:
+      - "isError"
+      - "value.*null"
+
+criteria: |
+  Verify device_settings_get reads from the `secure` namespace.
+  Closes a coverage gap noted in PR #29 review — TC-SMK-008 covered
+  global, TC-SMK-009 covered system, but secure had no coverage despite
+  being the highest-stakes namespace for QA flows (auth / lockscreen /
+  IME / accessibility).
+
+  - Tool returns the namespace and key fields
+  - Value is non-null (default_input_method is always populated on a
+    booted Android device — there's always some IME registered)
+  - No specific value asserted (varies across OEM keyboards)

--- a/src/adb/settings-commands.ts
+++ b/src/adb/settings-commands.ts
@@ -25,8 +25,8 @@ export interface SettingsDeleteResult {
 }
 
 /**
- * Read and write entries in Android's settings provider via
- * `adb shell settings get|put <namespace> <key> [<value>]`.
+ * Read, write, and delete entries in Android's settings provider via
+ * `adb shell settings get|put|delete <namespace> <key> [<value>]`.
  *
  * Three namespaces — `system` (user prefs), `secure` (security/auth), `global`
  * (device-wide). The ADB shell user holds `WRITE_SECURE_SETTINGS` by default

--- a/src/adb/settings-commands.ts
+++ b/src/adb/settings-commands.ts
@@ -6,12 +6,20 @@ export interface SettingsGetResult {
   namespace: SettingsNamespace;
   key: string;
   value: string | null;
+  error?: string;
 }
 
 export interface SettingsPutResult {
   namespace: SettingsNamespace;
   key: string;
   value: string;
+  success: boolean;
+  error?: string;
+}
+
+export interface SettingsDeleteResult {
+  namespace: SettingsNamespace;
+  key: string;
   success: boolean;
   error?: string;
 }
@@ -35,7 +43,12 @@ export class SettingsCommands {
   async get(namespace: SettingsNamespace, key: string): Promise<SettingsGetResult> {
     const result = await this.adb.shell(`settings get ${namespace} ${shellQuote(key)}`);
     if (!result.success) {
-      throw new Error(`settings get failed: ${result.stderr || result.stdout}`);
+      return {
+        namespace,
+        key,
+        value: null,
+        error: result.stderr || result.stdout || 'Unknown error',
+      };
     }
     const trimmed = result.stdout.trim();
     // `settings get` prints the literal string "null" when the key is unset.
@@ -57,6 +70,19 @@ export class SettingsCommands {
       };
     }
     return { namespace, key, value, success: true };
+  }
+
+  async delete(namespace: SettingsNamespace, key: string): Promise<SettingsDeleteResult> {
+    const result = await this.adb.shell(`settings delete ${namespace} ${shellQuote(key)}`);
+    if (!result.success) {
+      return {
+        namespace,
+        key,
+        success: false,
+        error: result.stderr || result.stdout || 'Unknown error',
+      };
+    }
+    return { namespace, key, success: true };
   }
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -124,13 +124,14 @@ export function createMcpServer(deviceManager: DeviceManager): CreateServerResul
       await ensureDevice();
       const settings = deviceManager.getSettingsCommands();
       const result = await settings.get(namespace, key);
+      if (result.error) {
+        return {
+          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+          isError: true,
+        };
+      }
       return {
-        content: [
-          {
-            type: 'text',
-            text: JSON.stringify(result, null, 2),
-          },
-        ],
+        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
       };
     }
   );
@@ -164,6 +165,29 @@ export function createMcpServer(deviceManager: DeviceManager): CreateServerResul
             text: JSON.stringify(result, null, 2),
           },
         ],
+        isError: true,
+      };
+    }
+  );
+
+  mcpServer.tool(
+    'device_settings_delete',
+    'Delete a key from the Android settings provider via `adb shell settings delete`. Subsequent gets return value: null. Same permission rules as device_settings_put.',
+    {
+      namespace: z.enum(['system', 'secure', 'global']).describe('Settings namespace'),
+      key: z.string().describe('Setting key to delete'),
+    },
+    async ({ namespace, key }) => {
+      await ensureDevice();
+      const settings = deviceManager.getSettingsCommands();
+      const result = await settings.delete(namespace, key);
+      if (result.success) {
+        return {
+          content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+        };
+      }
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
         isError: true,
       };
     }

--- a/src/server.ts
+++ b/src/server.ts
@@ -172,7 +172,7 @@ export function createMcpServer(deviceManager: DeviceManager): CreateServerResul
 
   mcpServer.tool(
     'device_settings_delete',
-    'Delete a key from the Android settings provider via `adb shell settings delete`. Subsequent gets return value: null. Same permission rules as device_settings_put.',
+    'Delete a key from the Android settings provider via `adb shell settings delete`. Subsequent gets return value: null. Same permission rules as device_settings_put. Idempotent — calling on a missing key still returns success: true.',
     {
       namespace: z.enum(['system', 'secure', 'global']).describe('Settings namespace'),
       key: z.string().describe('Setting key to delete'),


### PR DESCRIPTION
## Summary

Three follow-ups from PR #29's review, bundled because they all touch settings tooling and naturally cohere.

- **`SettingsCommands.get` error handling** — was throwing; now returns structured `{namespace, key, value: null, error}` matching put's shape.
- **`device_settings_delete` tool** — wraps `adb shell settings delete`. Idempotent on missing keys.
- **Smoke tests** — TC-SMK-009 grows a delete + null-get step (fully self-cleaning), TC-SMK-013 adds secure-namespace coverage.

Net: 28 → **29 native** (50 with proxy). Diff: +114 / −16 across 6 files.

## Changes

### `src/adb/settings-commands.ts`

- `SettingsGetResult` gains `error?: string`. `get()` no longer throws on adb shell failure — returns `{namespace, key, value: null, error}` instead.
- New `delete(namespace, key)` returning `SettingsDeleteResult` `{namespace, key, success, error?}`.
- `SettingsPutResult` shape unchanged.

### `src/server.ts`

- `device_settings_get` wrapper: now sets `isError: true` when `result.error` is populated. Success path unchanged.
- New `device_settings_delete` tool with the same `isError`-on-failure pattern as `put` and `delete`'s siblings.

### `cicd/tests/testcases/smoke/TC-SMK-009.yml`

Now four steps:
1. Put sentinel into `system.wifi_mcp_smoke_<TEST_RUN_ID>`
2. Get sentinel back, assert `value.*hello`
3. **(new)** Delete sentinel, assert `success.*true`
4. **(new)** Get again, assert `value.*null` — proves the row is gone

Test is now fully self-cleaning. No more orphans accumulating.

### `cicd/tests/testcases/smoke/TC-SMK-013.yml` (new)

Reads `secure.default_input_method`. Asserts namespace, key, value present (no specific IME asserted — varies across OEMs). Closes the coverage gap from PR #29 review — `global` and `system` both had tests, `secure` had none.

## Test plan

- [x] `npm run build` clean
- [x] `npm run tools:count` → 29 (was 28)
- [x] `npm run test:unit` — 26/26 pass
- [x] **End-to-end on Pixel 8 / Android 14**:
  - `device_settings_delete` on missing key → `success: true` (idempotent)
  - put → delete → get round-trip → `value: null` ✅
  - `device_settings_get secure default_input_method` → `com.google.android.inputmethod.latin/com.android.inputmethod.latin.LatinIME` ✅
- [x] `cd cicd/tests && npm test -- --suite smoke` → **13/13 pass** (was 12/12)

Fixes #30.