### PR TITLE
Unit tests for the companion-app IPC bridge (#38)

### DIFF
--- a/tests/unit/companion-bridge.test.mjs
+++ b/tests/unit/companion-bridge.test.mjs
@@ -1,0 +1,237 @@
+/**
+ * Unit tests for the companion-app IPC bridge.
+ *
+ * Covers the invariants we caught the hard way (#21 race, #22 scoped storage,
+ * #25 message passthrough). Drives the public methods of EnterpriseWifiCommands
+ * and NotificationCommands against a fake AdbClient that records every shell
+ * call and serves scripted result-file content.
+ *
+ * Run with: npm run test:unit
+ * Requires: npm run build (these tests import from dist/)
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { EnterpriseWifiCommands } from '../../dist/adb/enterprise-wifi.js';
+import { NotificationCommands } from '../../dist/adb/notifications-commands.js';
+
+const COMPANION_PACKAGE = 'com.example.wifimcpcompanion';
+
+/**
+ * Minimal AdbClient stand-in. Records every `shell` call. Branches on command
+ * pattern to script useful responses (companion-app installed check, the
+ * `cat files/wifi_mcp_result.json` poll). Everything else returns success
+ * with empty stdout — enough to drive the real callers' control flow without
+ * touching a device.
+ */
+class FakeAdbClient {
+  constructor(opts = {}) {
+    this.calls = [];
+    this.resultFileContent = opts.resultFileContent ?? null;
+    this.companionAppInstalled = opts.companionAppInstalled ?? true;
+  }
+
+  async shell(command, _timeout) {
+    this.calls.push(command);
+    if (command.includes('pm list packages')) {
+      return ok(this.companionAppInstalled ? `package:${COMPANION_PACKAGE}` : '');
+    }
+    if (command.includes('cat files/wifi_mcp_result.json')) {
+      return ok(this.resultFileContent ?? '');
+    }
+    return ok('');
+  }
+
+  async exec(_args, _timeout) {
+    return ok('');
+  }
+}
+
+function ok(stdout) {
+  return { success: true, stdout, stderr: '', exitCode: 0 };
+}
+
+function validPeapConfig() {
+  return {
+    ssid: 'TestSSID',
+    eapMethod: 'peap',
+    identity: 'user',
+    domainSuffixMatch: 'corp.example.com',
+    password: 'pw',
+  };
+}
+
+// ============ Race-fix invariant (#21) ============
+//
+// Contract: between `am broadcast` and the first `cat` poll of the result
+// file, the bridge MUST NOT call `rm -f` on the result file. The receiver
+// runs synchronously (~50 ms) and writes the result file before the host can
+// resume — a `rm` in this window would delete the live result and the poll
+// would time out for nothing.
+//
+// (A `rm -f` AFTER a cat that successfully read+parsed JSON is fine — that's
+// the legitimate post-read cleanup at the tail of waitForResult.)
+
+function assertNoClearBetweenBroadcastAndFirstCat(calls) {
+  const broadcastIdx = calls.findIndex((c) => c.includes('am broadcast'));
+  assert.ok(broadcastIdx >= 0, 'expected an am broadcast call');
+  const firstCatIdx = calls.findIndex(
+    (c, i) => i > broadcastIdx && c.includes('cat files/wifi_mcp_result.json')
+  );
+  assert.ok(firstCatIdx > broadcastIdx, 'expected a cat call after broadcast');
+  for (let i = broadcastIdx + 1; i < firstCatIdx; i++) {
+    assert.doesNotMatch(
+      calls[i],
+      /rm -f files\/wifi_mcp_result\.json/,
+      `clearResultFile must not happen between broadcast and first cat poll ` +
+        `(would race the receiver write); call #${i}: ${calls[i]}`
+    );
+  }
+}
+
+test('race: connectEnterprise clears result before broadcast, not after', async () => {
+  const fake = new FakeAdbClient({
+    resultFileContent: JSON.stringify({ success: true, ssid: 'TestSSID', eapMethod: 'peap' }),
+  });
+  const ent = new EnterpriseWifiCommands(fake);
+  await ent.connectEnterprise(validPeapConfig());
+
+  assert.match(fake.calls[1], /run-as .* base64 -d > files\/wifi_mcp_command\.json/);
+  assert.match(fake.calls[2], /run-as .* rm -f files\/wifi_mcp_result\.json/);
+  assert.match(fake.calls[3], /am broadcast/);
+  assertNoClearBetweenBroadcastAndFirstCat(fake.calls);
+});
+
+test('race: installCertificate clears result before broadcast, not after', async () => {
+  const fake = new FakeAdbClient({
+    resultFileContent: JSON.stringify({ success: true, alias: 'a', type: 'ca' }),
+  });
+  const ent = new EnterpriseWifiCommands(fake);
+  await ent.installCertificate('PEM', 'a', 'ca');
+
+  assertNoClearBetweenBroadcastAndFirstCat(fake.calls);
+});
+
+test('race: getStatus clears result before broadcast, not after', async () => {
+  const fake = new FakeAdbClient({
+    resultFileContent: JSON.stringify({ success: true, listenerConnected: true, capturedCount: 0 }),
+  });
+  const notif = new NotificationCommands(fake);
+  await notif.getStatus();
+
+  assertNoClearBetweenBroadcastAndFirstCat(fake.calls);
+});
+
+test('race: listRecent clears result before broadcast, not after', async () => {
+  const fake = new FakeAdbClient({
+    resultFileContent: JSON.stringify({ success: true, count: 0, notifications: [] }),
+  });
+  const notif = new NotificationCommands(fake);
+  await notif.listRecent({});
+
+  assertNoClearBetweenBroadcastAndFirstCat(fake.calls);
+});
+
+// ============ Result normalization (#25) ============
+//
+// connectEnterprise / installCertificate translate the companion app's wire
+// format into our typed result. The companion writes `message`; the host type
+// expects `error`. The normalization needs to hide that difference.
+
+test('normalize: success=true returns success with no error', async () => {
+  const fake = new FakeAdbClient({
+    resultFileContent: JSON.stringify({ success: true, ssid: 'TestSSID', eapMethod: 'peap' }),
+  });
+  const ent = new EnterpriseWifiCommands(fake);
+  const result = await ent.connectEnterprise(validPeapConfig());
+
+  assert.equal(result.success, true);
+  assert.equal(result.error, undefined);
+  assert.equal(result.ssid, 'TestSSID');
+  assert.equal(result.eapMethod, 'peap');
+});
+
+test('normalize: failure with raw.error uses error verbatim', async () => {
+  const fake = new FakeAdbClient({
+    resultFileContent: JSON.stringify({ success: false, error: 'cert validation failed' }),
+  });
+  const ent = new EnterpriseWifiCommands(fake);
+  const result = await ent.connectEnterprise(validPeapConfig());
+
+  assert.equal(result.success, false);
+  assert.equal(result.error, 'cert validation failed');
+});
+
+test('normalize: failure with only raw.message uses message', async () => {
+  const fake = new FakeAdbClient({
+    resultFileContent: JSON.stringify({ success: false, message: 'Failed to read config file' }),
+  });
+  const ent = new EnterpriseWifiCommands(fake);
+  const result = await ent.connectEnterprise(validPeapConfig());
+
+  assert.equal(result.success, false);
+  assert.equal(result.error, 'Failed to read config file');
+});
+
+test('normalize: failure with both error and message prefers error (more specific)', async () => {
+  const fake = new FakeAdbClient({
+    resultFileContent: JSON.stringify({
+      success: false,
+      error: 'specific reason',
+      message: 'generic reason',
+    }),
+  });
+  const ent = new EnterpriseWifiCommands(fake);
+  const result = await ent.connectEnterprise(validPeapConfig());
+
+  assert.equal(result.error, 'specific reason');
+});
+
+test('normalize: ssid / eapMethod fall back to call-site values when companion omits them', async () => {
+  // Companion app's "Failed to read config file" path can't populate ssid /
+  // eapMethod (it never reached the EAP layer). Normalizer falls back.
+  const fake = new FakeAdbClient({
+    resultFileContent: JSON.stringify({ success: false, message: 'Failed to read config file' }),
+  });
+  const ent = new EnterpriseWifiCommands(fake);
+  const result = await ent.connectEnterprise(validPeapConfig());
+
+  assert.equal(result.ssid, 'TestSSID');
+  assert.equal(result.eapMethod, 'peap');
+});
+
+// ============ Run-as command shape (#22) ============
+//
+// writeCommandFile must produce a shell-correct command that survives
+// child_process.execFile + adb shell tokenization to land in the app's
+// private filesDir. The b64-pipe-decode pattern was chosen specifically so
+// JSON quotes and cert hyphens cannot break shell escaping.
+
+test('run-as: writeCommandFile produces b64-pipe-decode command with correct payload', async () => {
+  const fake = new FakeAdbClient({
+    resultFileContent: JSON.stringify({ success: true, ssid: 'TestSSID', eapMethod: 'peap' }),
+  });
+  const ent = new EnterpriseWifiCommands(fake);
+  await ent.connectEnterprise(validPeapConfig());
+
+  const writeCall = fake.calls.find(
+    (c) => c.includes('base64 -d') && c.includes('files/wifi_mcp_command.json')
+  );
+  assert.ok(writeCall, 'expected a writeCommandFile call');
+
+  // Shape: run-as <pkg> sh -c 'echo <b64> | base64 -d > files/wifi_mcp_command.json'
+  assert.match(writeCall, /^run-as com\.example\.wifimcpcompanion sh -c '/);
+  assert.match(writeCall, /'echo [A-Za-z0-9+/=]+ \| base64 -d > files\/wifi_mcp_command\.json'$/);
+
+  // Decode the b64 and verify it round-trips to the expected JSON
+  const m = writeCall.match(/echo ([A-Za-z0-9+/=]+) \| base64 -d/);
+  assert.ok(m, 'expected b64 payload in command');
+  const decoded = JSON.parse(Buffer.from(m[1], 'base64').toString('utf-8'));
+
+  assert.equal(decoded.action, 'connect_enterprise');
+  assert.equal(decoded.ssid, 'TestSSID');
+  assert.equal(decoded.eapMethod, 'peap');
+  assert.equal(decoded.identity, 'user');
+  assert.equal(decoded.domainSuffixMatch, 'corp.example.com');
+  assert.equal(decoded.password, 'pw');
+  assert.ok(typeof decoded.timestamp === 'number');
+});


### PR DESCRIPTION
## Summary

Adds 10 unit tests for the companion-app IPC bridge, locking the three invariants we caught the hard way this session (#21 race, #22 scoped storage, #25 message passthrough). No production-code changes — tests exercise the existing implementations via a `FakeAdbClient`.

Net diff: **+237 / 0** (one new test file).

## Test groups

### Race-fix invariant (#21) — 4 tests

One per public caller: `connectEnterprise`, `installCertificate`, `getStatus`, `listRecent`. Each asserts:

> No `rm -f files/wifi_mcp_result.json` between `am broadcast` and the first `cat files/wifi_mcp_result.json` poll.

**Note** — the post-read `rm` at the tail of `waitForResult` (after JSON.parse succeeds) is legitimate housekeeping and **not** flagged. My first attempt at the assertion forbade *all* `rm` after broadcast, which the test correctly caught as wrong: the legitimate post-read cleanup tripped it. Refined to "between broadcast and first cat poll" — captures the actual race window.

### Result normalization (#25) — 5 tests

- `raw.success === true` → returns `{success: true, error: undefined}`
- `raw.error` populated → uses `error` verbatim
- only `raw.message` populated → uses `message` (closing the field-name mismatch)
- both `error` and `message` → prefers `error` (more specific)
- companion couldn't reach EAP layer (no `ssid`/`eapMethod` in raw) → fall back to call-site config values

### Run-as command shape (#22) — 1 test

Asserts `writeCommandFile` produces:

```
run-as com.example.wifimcpcompanion sh -c 'echo <b64> | base64 -d > files/wifi_mcp_command.json'
```

…and the b64 round-trips to the expected JSON payload (catches anyone reverting to the old `echo '${escaped}'` pattern that broke under `child_process.exec`).

## Test plan

- [x] `npm run build` clean
- [x] `npm run test:unit` — **36/36 pass** (was 26/26; +10 new)
- [x] Total runtime ~4.8s (race tests dominate at 500 ms each, bounded by `waitForResult`'s poll interval)
- [x] No production-code changes — pure addition

## Why before #39

PR #39 (the `CompanionAppBridge` dedupe) extracts the duplicated bridge code into a shared class. That refactor needs an automated regression net: this PR establishes one. After #39 lands, these same tests should still pass against the refactored implementation — same invariants, exercised against the new shared class.

Fixes #38.