### PR TITLE
Extract CompanionAppBridge to dedupe IPC layer (#39)

### DIFF
--- a/src/adb/companion-bridge.ts
+++ b/src/adb/companion-bridge.ts
@@ -1,0 +1,123 @@
+import { AdbClient } from './adb-client.js';
+
+export const COMPANION_PACKAGE = 'com.example.wifimcpcompanion';
+
+// IPC files live in the companion app's private filesDir, accessed via
+// `run-as`. /sdcard/Download/ was the previous location but Android 11+
+// scoped storage blocks the app from reading shell-written files there.
+const COMMAND_FILE_REL = 'files/wifi_mcp_command.json';
+const RESULT_FILE_REL = 'files/wifi_mcp_result.json';
+
+const DEFAULT_RESULT_TIMEOUT_MS = 30_000;
+const DEFAULT_POLL_INTERVAL_MS = 500;
+
+export interface BridgeOptions {
+  /** How long to wait for the companion app to write its result file. */
+  resultTimeoutMs?: number;
+  /** How often to poll the result file while waiting. */
+  pollIntervalMs?: number;
+}
+
+export interface BridgeResponse {
+  /** Parsed result from the companion app, or `null` on timeout. */
+  raw: Record<string, unknown> | null;
+  /** Set when `am broadcast` itself failed (rare — usually a malformed action). */
+  broadcastError?: string;
+}
+
+/**
+ * Single owner of the file-IPC bridge to the companion app.
+ *
+ * Used by `EnterpriseWifiCommands` and `NotificationCommands` to send a
+ * broadcast and read the response file the companion writes. The race
+ * contract — *clear before broadcast, never between broadcast and the first
+ * cat poll* — is enforced inside {@link sendBroadcastAndWait}; callers cannot
+ * forget the order because they don't write it.
+ *
+ * History: this class is the dedupe of two previously-parallel implementations
+ * in `enterprise-wifi.ts` and `notifications-commands.ts`. See #21 (race fix),
+ * #22 (scoped-storage rewrite), #25 (message passthrough), #38 (test net),
+ * #39 (this dedupe).
+ */
+export class CompanionAppBridge {
+  private adb: AdbClient;
+  private resultTimeoutMs: number;
+  private pollIntervalMs: number;
+
+  constructor(adb: AdbClient, opts: BridgeOptions = {}) {
+    this.adb = adb;
+    this.resultTimeoutMs = opts.resultTimeoutMs ?? DEFAULT_RESULT_TIMEOUT_MS;
+    this.pollIntervalMs = opts.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+  }
+
+  /**
+   * Send `action` to the companion app's `AdbBridgeReceiver`, optionally with
+   * a JSON `payload` written into its filesDir, and wait for the response.
+   *
+   * Returns `{ raw }` with the parsed JSON on success, `{ raw: null }` on
+   * timeout, or `{ broadcastError }` if `am broadcast` itself failed.
+   *
+   * The order is fixed: write payload (if any) → clear stale result → broadcast
+   * → poll. Specifically, no `clearResultFile` happens between broadcast and the
+   * first cat poll — that would race the receiver's synchronous write (~50 ms).
+   */
+  async sendBroadcastAndWait(action: string, payload?: object): Promise<BridgeResponse> {
+    if (payload !== undefined) {
+      await this.writeCommandFile(payload);
+    }
+    await this.clearResultFile();
+
+    const broadcastResult = await this.adb.shell(
+      `am broadcast -a ${COMPANION_PACKAGE}.${action} -n ${COMPANION_PACKAGE}/.AdbBridgeReceiver`
+    );
+    if (!broadcastResult.success) {
+      return { raw: null, broadcastError: broadcastResult.stderr || broadcastResult.stdout || 'Unknown error' };
+    }
+
+    const raw = await this.waitForResult();
+    return { raw };
+  }
+
+  /**
+   * Write `payload` as JSON into the companion app's filesDir.
+   * Payload is base64-encoded so embedded JSON quotes / cert hyphens cannot
+   * break shell escaping.
+   */
+  private async writeCommandFile(payload: object): Promise<void> {
+    const json = JSON.stringify(payload);
+    const b64 = Buffer.from(json, 'utf-8').toString('base64');
+    await this.adb.shell(
+      `run-as ${COMPANION_PACKAGE} sh -c 'echo ${b64} | base64 -d > ${COMMAND_FILE_REL}'`
+    );
+  }
+
+  private async clearResultFile(): Promise<void> {
+    await this.adb.shell(`run-as ${COMPANION_PACKAGE} rm -f ${RESULT_FILE_REL}`);
+  }
+
+  /**
+   * Poll the result file the companion app writes after handling a broadcast.
+   * Caller must have already cleared the result file before broadcasting;
+   * this method does not — see {@link sendBroadcastAndWait} for the contract.
+   */
+  private async waitForResult(): Promise<Record<string, unknown> | null> {
+    const startTime = Date.now();
+    while (Date.now() - startTime < this.resultTimeoutMs) {
+      await new Promise((resolve) => setTimeout(resolve, this.pollIntervalMs));
+
+      const checkResult = await this.adb.shell(
+        `run-as ${COMPANION_PACKAGE} cat ${RESULT_FILE_REL} 2>/dev/null`
+      );
+      if (checkResult.success && checkResult.stdout.trim()) {
+        try {
+          const parsed = JSON.parse(checkResult.stdout) as Record<string, unknown>;
+          await this.clearResultFile();
+          return parsed;
+        } catch {
+          // Partial write — keep polling.
+        }
+      }
+    }
+    return null;
+  }
+}

--- a/src/adb/enterprise-wifi.ts
+++ b/src/adb/enterprise-wifi.ts
@@ -1,4 +1,5 @@
 import { AdbClient } from './adb-client.js';
+import { CompanionAppBridge, COMPANION_PACKAGE } from './companion-bridge.js';
 import {
   EapConfig,
   EapMethod,
@@ -6,21 +7,13 @@ import {
   CertificateInstallResult,
 } from '../types.js';
 
-const COMPANION_PACKAGE = 'com.example.wifimcpcompanion';
-// IPC files live in the companion app's private filesDir, accessed via
-// `run-as`. /sdcard/Download/ was the previous location but Android 11+
-// scoped storage blocks the app from reading shell-written files there.
-const COMMAND_FILE_NAME = 'wifi_mcp_command.json';
-const RESULT_FILE_NAME = 'wifi_mcp_result.json';
-const RESULT_FILE_REL = `files/${RESULT_FILE_NAME}`;
-const COMMAND_FILE_REL = `files/${COMMAND_FILE_NAME}`;
-const RESULT_TIMEOUT = 30000; // 30 seconds
-
 export class EnterpriseWifiCommands {
   private adb: AdbClient;
+  private bridge: CompanionAppBridge;
 
   constructor(adb: AdbClient) {
     this.adb = adb;
+    this.bridge = new CompanionAppBridge(adb, { resultTimeoutMs: 30_000, pollIntervalMs: 500 });
   }
 
   /**
@@ -35,7 +28,6 @@ export class EnterpriseWifiCommands {
    * Connect to an enterprise WiFi network (802.1X/EAP)
    */
   async connectEnterprise(config: EapConfig): Promise<EnterpriseConnectionResult> {
-    // Validate config based on EAP method
     if ((config.eapMethod === 'peap' || config.eapMethod === 'ttls') && !config.password) {
       return {
         success: false,
@@ -54,9 +46,7 @@ export class EnterpriseWifiCommands {
       };
     }
 
-    // Check if companion app is installed
-    const appInstalled = await this.isCompanionAppInstalled();
-    if (!appInstalled) {
+    if (!(await this.isCompanionAppInstalled())) {
       return {
         success: false,
         ssid: config.ssid,
@@ -65,35 +55,21 @@ export class EnterpriseWifiCommands {
       };
     }
 
-    // Write config to file
-    const commandPayload = {
+    const payload = {
       action: 'connect_enterprise',
       timestamp: Date.now(),
       ...config,
     };
+    const { raw, broadcastError } = await this.bridge.sendBroadcastAndWait('CONNECT_ENTERPRISE', payload);
 
-    await this.writeCommandFile(commandPayload);
-    await this.clearResultFile();
-
-    // Send broadcast to companion app
-    const broadcastResult = await this.adb.shell(
-      `am broadcast -a ${COMPANION_PACKAGE}.CONNECT_ENTERPRISE ` +
-      `-n ${COMPANION_PACKAGE}/.AdbBridgeReceiver`
-    );
-
-    if (!broadcastResult.success) {
+    if (broadcastError) {
       return {
         success: false,
         ssid: config.ssid,
         eapMethod: config.eapMethod,
-        error: `Failed to send broadcast: ${broadcastResult.stderr}`,
+        error: `Failed to send broadcast: ${broadcastError}`,
       };
     }
-
-    // Wait for result. The companion app emits a wire format with `message`
-    // (and optional `ssid` / `eapMethod`); normalize into our typed result so
-    // `error` is always populated on failure.
-    const raw = await this.waitForResult<Record<string, unknown>>(config.ssid);
     if (!raw) {
       return {
         success: false,
@@ -102,17 +78,8 @@ export class EnterpriseWifiCommands {
         error: 'Timeout waiting for connection result',
       };
     }
-    const success = !!raw.success;
-    return {
-      success,
-      ssid: (typeof raw.ssid === 'string' ? raw.ssid : config.ssid),
-      eapMethod: (typeof raw.eapMethod === 'string' ? raw.eapMethod as EapMethod : config.eapMethod),
-      error: success
-        ? undefined
-        : (typeof raw.error === 'string' ? raw.error
-          : typeof raw.message === 'string' ? raw.message
-          : 'Unknown error'),
-    };
+
+    return normalizeEnterpriseResult(raw, config.ssid, config.eapMethod);
   }
 
   /**
@@ -123,9 +90,7 @@ export class EnterpriseWifiCommands {
     alias: string,
     type: 'ca' | 'client'
   ): Promise<CertificateInstallResult> {
-    // Check if companion app is installed
-    const appInstalled = await this.isCompanionAppInstalled();
-    if (!appInstalled) {
+    if (!(await this.isCompanionAppInstalled())) {
       return {
         success: false,
         alias,
@@ -134,35 +99,23 @@ export class EnterpriseWifiCommands {
       };
     }
 
-    // Write config to file
-    const commandPayload = {
+    const payload = {
       action: 'install_certificate',
       timestamp: Date.now(),
       certificate,
       alias,
       type,
     };
+    const { raw, broadcastError } = await this.bridge.sendBroadcastAndWait('INSTALL_CERTIFICATE', payload);
 
-    await this.writeCommandFile(commandPayload);
-    await this.clearResultFile();
-
-    // Send broadcast to companion app
-    const broadcastResult = await this.adb.shell(
-      `am broadcast -a ${COMPANION_PACKAGE}.INSTALL_CERTIFICATE ` +
-      `-n ${COMPANION_PACKAGE}/.AdbBridgeReceiver`
-    );
-
-    if (!broadcastResult.success) {
+    if (broadcastError) {
       return {
         success: false,
         alias,
         type,
-        error: `Failed to send broadcast: ${broadcastResult.stderr}`,
+        error: `Failed to send broadcast: ${broadcastError}`,
       };
     }
-
-    // Wait for result. Normalize companion `message` → our typed `error`.
-    const raw = await this.waitForResult<Record<string, unknown>>(alias);
     if (!raw) {
       return {
         success: false,
@@ -171,91 +124,65 @@ export class EnterpriseWifiCommands {
         error: 'Timeout waiting for certificate installation result',
       };
     }
-    const success = !!raw.success;
-    return {
-      success,
-      alias: (typeof raw.alias === 'string' ? raw.alias : alias),
-      type: (raw.type === 'ca' || raw.type === 'client' ? raw.type : type),
-      error: success
-        ? undefined
-        : (typeof raw.error === 'string' ? raw.error
-          : typeof raw.message === 'string' ? raw.message
-          : 'Unknown error'),
-    };
-  }
 
-  /**
-   * Write command payload into the companion app's private filesDir via run-as.
-   * Payload is base64-encoded so embedded JSON quotes / cert hyphens cannot
-   * break shell escaping.
-   */
-  private async writeCommandFile(payload: object): Promise<void> {
-    const json = JSON.stringify(payload);
-    const b64 = Buffer.from(json, 'utf-8').toString('base64');
-    await this.adb.shell(
-      `run-as ${COMPANION_PACKAGE} sh -c 'echo ${b64} | base64 -d > ${COMMAND_FILE_REL}'`
-    );
-  }
-
-  private async clearResultFile(): Promise<void> {
-    await this.adb.shell(`run-as ${COMPANION_PACKAGE} rm -f ${RESULT_FILE_REL}`);
-  }
-
-  /**
-   * Poll for the result file the companion app writes after handling a broadcast.
-   *
-   * Caller must call `clearResultFile()` between writing the command file and
-   * sending the broadcast. The receiver runs synchronously (~50 ms) so a
-   * post-broadcast cleanup would race the app's write and produce spurious
-   * timeouts.
-   */
-  private async waitForResult<T>(identifier: string): Promise<T | null> {
-    const startTime = Date.now();
-    const pollInterval = 500; // 500ms
-
-    while (Date.now() - startTime < RESULT_TIMEOUT) {
-      await new Promise(resolve => setTimeout(resolve, pollInterval));
-
-      const checkResult = await this.adb.shell(
-        `run-as ${COMPANION_PACKAGE} cat ${RESULT_FILE_REL} 2>/dev/null`
-      );
-      if (checkResult.success && checkResult.stdout.trim()) {
-        try {
-          const result = JSON.parse(checkResult.stdout) as T;
-          await this.clearResultFile();
-          return result;
-        } catch {
-          // JSON not ready yet, continue waiting
-        }
-      }
-    }
-
-    return null;
+    return normalizeCertificateResult(raw, alias, type);
   }
 
   /**
    * Get list of installed certificates (via companion app)
    */
   async listCertificates(): Promise<string[]> {
-    const appInstalled = await this.isCompanionAppInstalled();
-    if (!appInstalled) {
+    if (!(await this.isCompanionAppInstalled())) {
       return [];
     }
 
-    const commandPayload = {
-      action: 'list_certificates',
-      timestamp: Date.now(),
-    };
-
-    await this.writeCommandFile(commandPayload);
-    await this.clearResultFile();
-
-    await this.adb.shell(
-      `am broadcast -a ${COMPANION_PACKAGE}.LIST_CERTIFICATES ` +
-      `-n ${COMPANION_PACKAGE}/.AdbBridgeReceiver`
-    );
-
-    const result = await this.waitForResult<{ certificates: string[] }>('list');
-    return result?.certificates || [];
+    const payload = { action: 'list_certificates', timestamp: Date.now() };
+    const { raw } = await this.bridge.sendBroadcastAndWait('LIST_CERTIFICATES', payload);
+    if (!raw) return [];
+    const certs = raw.certificates;
+    return Array.isArray(certs) ? (certs as string[]) : [];
   }
+}
+
+/**
+ * Translate the companion app's wire format into our typed result.
+ *
+ * Companion emits `message` for diagnostics and may omit `ssid` / `eapMethod`
+ * when it failed before reaching the EAP layer (e.g. "Failed to read config
+ * file"). The host type expects `error` and always-populated identity fields,
+ * so we normalize at the boundary.
+ */
+function normalizeEnterpriseResult(
+  raw: Record<string, unknown>,
+  fallbackSsid: string,
+  fallbackEapMethod: EapMethod
+): EnterpriseConnectionResult {
+  const success = !!raw.success;
+  return {
+    success,
+    ssid: typeof raw.ssid === 'string' ? raw.ssid : fallbackSsid,
+    eapMethod: typeof raw.eapMethod === 'string' ? (raw.eapMethod as EapMethod) : fallbackEapMethod,
+    error: success ? undefined : pickErrorMessage(raw),
+  };
+}
+
+function normalizeCertificateResult(
+  raw: Record<string, unknown>,
+  fallbackAlias: string,
+  fallbackType: 'ca' | 'client'
+): CertificateInstallResult {
+  const success = !!raw.success;
+  return {
+    success,
+    alias: typeof raw.alias === 'string' ? raw.alias : fallbackAlias,
+    type: raw.type === 'ca' || raw.type === 'client' ? raw.type : fallbackType,
+    error: success ? undefined : pickErrorMessage(raw),
+  };
+}
+
+/** Prefer companion's `error` over `message`; fall back to a generic string. */
+function pickErrorMessage(raw: Record<string, unknown>): string {
+  if (typeof raw.error === 'string') return raw.error;
+  if (typeof raw.message === 'string') return raw.message;
+  return 'Unknown error';
 }

--- a/src/adb/enterprise-wifi.ts
+++ b/src/adb/enterprise-wifi.ts
@@ -161,7 +161,10 @@ function normalizeEnterpriseResult(
   return {
     success,
     ssid: typeof raw.ssid === 'string' ? raw.ssid : fallbackSsid,
-    eapMethod: typeof raw.eapMethod === 'string' ? (raw.eapMethod as EapMethod) : fallbackEapMethod,
+    eapMethod:
+      raw.eapMethod === 'peap' || raw.eapMethod === 'ttls' || raw.eapMethod === 'tls'
+        ? raw.eapMethod
+        : fallbackEapMethod,
     error: success ? undefined : pickErrorMessage(raw),
   };
 }

--- a/src/adb/notifications-commands.ts
+++ b/src/adb/notifications-commands.ts
@@ -1,14 +1,9 @@
 import { AdbClient } from './adb-client.js';
-
-const COMPANION_PACKAGE = 'com.example.wifimcpcompanion';
-// IPC files live in the companion app's private filesDir, accessed via run-as.
-const COMMAND_FILE_REL = 'files/wifi_mcp_command.json';
-const RESULT_FILE_REL = 'files/wifi_mcp_result.json';
-const RESULT_TIMEOUT = 10000; // 10s for a single broadcast round-trip
+import { CompanionAppBridge } from './companion-bridge.js';
 
 /**
- * Talks to the companion app's NotificationCaptureService over the same
- * file-IPC bridge the enterprise-wifi flow uses.
+ * Talks to the companion app's NotificationCaptureService over the file-IPC
+ * bridge (see {@link CompanionAppBridge}).
  *
  * The service captures every notification posted system-wide (WhatsApp,
  * email, banking apps, etc.) so we can extract OTPs that don't come via
@@ -16,19 +11,16 @@ const RESULT_TIMEOUT = 10000; // 10s for a single broadcast round-trip
  * Settings → Notifications → Notification access.
  */
 export class NotificationCommands {
-  private adb: AdbClient;
+  private bridge: CompanionAppBridge;
 
   constructor(adb: AdbClient) {
-    this.adb = adb;
+    // 10 s + 300 ms poll — single round-trip; no retries from the caller.
+    this.bridge = new CompanionAppBridge(adb, { resultTimeoutMs: 10_000, pollIntervalMs: 300 });
   }
 
   async getStatus(): Promise<NotificationStatus> {
-    await this.clearResultFile();
-    await this.adb.shell(
-      `am broadcast -a ${COMPANION_PACKAGE}.NOTIFICATION_STATUS -n ${COMPANION_PACKAGE}/.AdbBridgeReceiver`
-    );
-    const result = await this.waitForResult();
-    if (!result) {
+    const { raw } = await this.bridge.sendBroadcastAndWait('NOTIFICATION_STATUS');
+    if (!raw) {
       return {
         listenerConnected: false,
         capturedCount: 0,
@@ -37,12 +29,12 @@ export class NotificationCommands {
       };
     }
     return {
-      listenerConnected: !!result.listenerConnected,
-      capturedCount: typeof result.capturedCount === 'number' ? result.capturedCount : 0,
-      warning: result.success
+      listenerConnected: !!raw.listenerConnected,
+      capturedCount: typeof raw.capturedCount === 'number' ? raw.capturedCount : 0,
+      warning: raw.success
         ? undefined
-        : typeof result.message === 'string'
-        ? result.message
+        : typeof raw.message === 'string'
+        ? raw.message
         : 'Unknown error',
     };
   }
@@ -58,12 +50,7 @@ export class NotificationCommands {
     if (opts.limit !== undefined) {
       config.limit = opts.limit;
     }
-    await this.writeCommandFile(config);
-    await this.clearResultFile();
-    await this.adb.shell(
-      `am broadcast -a ${COMPANION_PACKAGE}.LIST_NOTIFICATIONS -n ${COMPANION_PACKAGE}/.AdbBridgeReceiver`
-    );
-    const result = await this.waitForResult();
+    const { raw: result } = await this.bridge.sendBroadcastAndWait('LIST_NOTIFICATIONS', config);
     if (!result) {
       return {
         notifications: [],
@@ -135,38 +122,6 @@ export class NotificationCommands {
     return { found: false, waitedMs: Date.now() - start, warning: lastWarning };
   }
 
-  private async writeCommandFile(payload: object): Promise<void> {
-    const json = JSON.stringify(payload);
-    const b64 = Buffer.from(json, 'utf-8').toString('base64');
-    await this.adb.shell(
-      `run-as ${COMPANION_PACKAGE} sh -c 'echo ${b64} | base64 -d > ${COMMAND_FILE_REL}'`
-    );
-  }
-
-  private async clearResultFile(): Promise<void> {
-    await this.adb.shell(`run-as ${COMPANION_PACKAGE} rm -f ${RESULT_FILE_REL}`);
-  }
-
-  private async waitForResult(): Promise<Record<string, unknown> | null> {
-    const start = Date.now();
-    const pollInterval = 300;
-    while (Date.now() - start < RESULT_TIMEOUT) {
-      await new Promise((res) => setTimeout(res, pollInterval));
-      const cat = await this.adb.shell(
-        `run-as ${COMPANION_PACKAGE} cat ${RESULT_FILE_REL} 2>/dev/null`
-      );
-      if (cat.success && cat.stdout.trim()) {
-        try {
-          const parsed = JSON.parse(cat.stdout) as Record<string, unknown>;
-          await this.clearResultFile();
-          return parsed;
-        } catch {
-          // partial write — keep polling
-        }
-      }
-    }
-    return null;
-  }
 }
 
 export interface NotificationStatus {


### PR DESCRIPTION
## Summary

Extracts the parallel IPC bridge code from `enterprise-wifi.ts` and `notifications-commands.ts` into a single `CompanionAppBridge` class, with the race contract enforced by construction inside `sendBroadcastAndWait` (no longer just by docstring).

Net diff: **+200 / −195** across 3 files. Slight overall reduction; meaningful contract-strength gain.

## Why

Both classes had been carrying byte-identical `writeCommandFile` / `clearResultFile` and same-shape `waitForResult` (differing only in poll interval / timeout). Bridge bugs (#21 race, #22 scoped storage) had to be applied to both copies. A third caller would have compounded the maintenance burden.

#38 landed a unit-test net for the bridge invariants; this PR refactors on top of it.

## API

```ts
// src/adb/companion-bridge.ts (new)
export class CompanionAppBridge {
  constructor(adb: AdbClient, opts?: { resultTimeoutMs?: number; pollIntervalMs?: number });

  async sendBroadcastAndWait(action: string, payload?: object): Promise<BridgeResponse>;
}

interface BridgeResponse {
  raw: Record<string, unknown> | null;  // parsed companion JSON, or null on timeout
  broadcastError?: string;              // set when am broadcast itself failed (rare)
}
```

Internally: write payload (if any) → clear stale result → broadcast → poll. The race invariant — *no clear between broadcast and first cat poll* — is now **structural**, not docstring-enforced. A caller cannot forget the order because they don't write it.

## Caller-side simplification

### `enterprise-wifi.ts`

Each method now reads as: build payload → `sendBroadcastAndWait` → branch on `broadcastError` | `!raw` | normalize. The two normalizers (connectEnterprise / installCertificate) extracted into module-level `normalizeEnterpriseResult` / `normalizeCertificateResult` + a shared `pickErrorMessage` helper.

### `notifications-commands.ts`

Same shape. `getStatus` passes no payload (matches the existing behavior of clearing result + broadcasting without a config file). `listRecent` passes its filter object. Private `writeCommandFile` / `clearResultFile` / `waitForResult` deleted.

## Test plan

- [x] `npm run build` clean
- [x] **`npm run test:unit` — 36/36 pass** ← the key validation. The same invariant tests from #38, locked against the previous duplicated implementation, now lock the same invariants against the new shared class. The regression-net plan worked exactly as described.
- [x] `cd cicd/tests && npm test -- --suite smoke` — 13/13 pass on Pixel 8 / Android 14
- [x] No tools added / removed (`tools:count` unchanged at 29)

## Sequence completion

This closes the option-A track follow-ups for the IPC layer:
- ✅ #38 (test net) — merged
- ✅ #39 (this dedupe) — open
- ✅ #28 (parent issue) — closed; spun out as #38 + #39

Fixes #39.