### PR TITLE
Add session summary for 2026-04-29

### DIFF
--- a/docs/session_summaries/2026-04-29_1850_summary.md
+++ b/docs/session_summaries/2026-04-29_1850_summary.md
@@ -1,0 +1,55 @@
+---
+date: 2026-04-29
+session_id: 20260429-1850
+workflow_patterns: [Maintenance, Meta]
+outcome: Completed
+scale: Long
+commands_used: [/clear, /usage, /mcp, /utility:session-summary]
+mcp_categories: [github (via gh CLI), android-wifi (live device probes), bash, file-system]
+---
+
+## Goal
+
+Acted on a parent issue covering scope review (option-A trim) of an open-source MCP server project; turned it into a sprint that fixed three companion-app IPC bugs, trimmed an overlap surface (~8 tools), added new ADB-level capabilities, established a unit-test net, dedup'd a duplicated bridge layer, wrote two integrations docs, and reorganized the user's MCP server config.
+
+## Artifacts
+
+- TypeScript modules: 4 new (one shared bridge class, three per-domain command classes), 2 substantially refactored, 1 fixed (host shell-handling layer)
+- YAML test cases: 6 new, 1 modified, 8 deleted (the cut UI tests)
+- Unit-test file: 1 new (10 new tests)
+- Markdown docs: 2 new in a new `docs/integrations/` directory
+- README + project-config docs: edited for tool-count alignment ~5 times
+- GitHub PRs: 11 merged (one per logical concern)
+- GitHub issues: 5 filed for follow-ups + 3 closed (parent + spinouts)
+- User config files: 1 edited (config-file move + extension to a second project)
+
+## Workflow
+
+Repeated cycle: identify scope → branch → edit → build → unit test → smoke test on a live device → commit → push → open PR → self-review → optionally fold in fixes → merge → pull main → repeat. Eleven turns of this. Bug-fix track came first (manual probe → diagnose → file issue → fix → test), then add tools, then trim overlap, then docs, then test-net, then refactor on top of the test-net.
+
+## Friction Points
+
+- **Tool stalls under bug** — initial diagnostic probe via the live MCP tool stalled on a 30s timeout per call, masking the real failure. Manual ADB shell probes were faster than the tool path, so debugging shifted to those.
+- **Multi-layer shell escaping bug** — the tool's host-side `child_process.exec` was re-tokenizing inner-quoted strings, corrupting `run-as` commands. Caught by surprise; fix was a swap to `execFile`.
+- **Test-pattern collision** — a smoke test's `rejectPattern: "isError"` matched both `isError: true` and `isError: false`. Required tightening the wrapper to only emit `isError` on failure.
+- **Test caught my own bad spec** — a unit-test invariant assertion was initially overly strict (forbade *any* post-broadcast cleanup); the legitimate post-read cleanup tripped it, forcing the spec to be sharpened.
+- **Doc factual error caught in review** — claimed a hardware-button-keycode tool could tap notifications; it cannot. Fixed during PR review, before merge.
+- **File-permission regression** — `mv` from `/tmp` dropped a sensitive config file from `0600` to `0644`. Caught at the verify step and restored.
+- **Mid-PR scope creep tension** — recurrent question of "fix this small adjacent thing in the PR vs. file as follow-up?" Each PR explicitly named what was deferred.
+
+## Patterns Detected
+
+- **Repeated sequence: branch → edit → build → unit + smoke → commit → push → PR → review → merge → pull main** ran ~11 times. This is just dev workflow; not really a candidate for a single command since each iteration's content differs. But the *self-review-before-merge* step caught real issues 4+ times — strong evidence that automated pre-merge review (`dw-review-pr` or similar) earns its keep on this codebase.
+- **Repeated sequence: file follow-up issue → close parent → spin out** happened three times. Pattern is healthy: parent issue stays clean, follow-ups get tracked at proper granularity. No improvement needed.
+- **Workflow gap: post-edit MCP server reload** — when production code changes, the running MCP server in the harness still has stale code; fresh probes need a separate test-runner spawn. Manual workaround works but is mildly awkward. Not a clear candidate for a command.
+- **Efficiency win: test-net-before-refactor** — adding unit tests to a duplicated implementation, then refactoring the duplication out, with the same tests still passing on the new shared class, was a clean validation pattern. The tests literally proved behavior preservation. Worth holding as a template for future "extract-shared-class" PRs.
+- **Efficiency win: each PR named its deferred follow-ups in the body** — kept scope tight, made the cleanup PRs traceable. Worth keeping as a habit.
+- **Efficiency win: `gh pr merge --merge --delete-branch` then `git pull --ff-only`** — clean post-merge state every time, no stale local branches. Standard but worth noting.
+
+## Signals for /evolve
+
+- A repository's `CLAUDE.md` often contains a tool-count line that drifts as PRs land; `npm run tools:count` exists but is easy to forget. Pattern: on every PR that adds/removes a tool registration, run the count check and update the count line in the same commit. Could be a hook or a `dw-review-pr` checklist item.
+- The PR-self-review-before-merge step caught at least 4 real issues this session (factual error, test pattern collision, stale docs reference, missing observability detail). Strong signal: automate or formalize pre-merge review for this project.
+- File-permission preservation is a recurring footgun when editing config files via `/tmp`. Pattern: any time a config file with restricted perms (0600 / 0644) is rewritten via temp-file + `mv`, restore perms with `chmod` after. Could be a `safe-config-edit` helper.
+- The settings-tooling PR landed with 3 follow-ups already filed; same shape with the file-tooling PR. Repeated pattern: ship a focused feature PR, file the polish items as a single bundled follow-up issue. Working well.
+- One MCP-server registration was discovered mid-session to **not** be a separate package — it's a configuration of an existing package with a flag pointing at a forwarded port. Pattern: when documenting integrations, verify the actual command from the live config rather than recalling from memory.

--- a/docs/session_summaries/patterns.md
+++ b/docs/session_summaries/patterns.md
@@ -1,0 +1,29 @@
+# Session Patterns
+
+Last updated: 2026-04-29
+Total sessions recorded: 1
+
+## Workflow Distribution
+
+| Pattern | Count | Last Seen |
+|---------|-------|-----------|
+| Maintenance | 1 | 2026-04-29 |
+| Meta | 1 | 2026-04-29 |
+
+## Recurring Friction Points
+
+| Friction Point | Occurrences | First Seen | Last Seen | Status |
+|----------------|-------------|------------|-----------|--------|
+| Test-pattern collision (rejectPattern matched both true and false JSON values) | 1 | 2026-04-29 | 2026-04-29 | Open — could be addressed by tightening MCP wrappers to omit isError on success |
+| File-permission regression after `mv` from `/tmp` for sensitive config | 1 | 2026-04-29 | 2026-04-29 | Open — candidate for `safe-config-edit` helper |
+| Tool-count drift between code and CLAUDE.md / README | 1 | 2026-04-29 | 2026-04-29 | Open — already have `tools:count`; needs enforcement step |
+| Stale running-MCP-server during dev (post-edit cache) | 1 | 2026-04-29 | 2026-04-29 | Open — worked around with test-runner spawn; minor |
+
+## Improvement Candidates
+
+| Candidate | Evidence Count | Suggestion | Status |
+|-----------|---------------|------------|--------|
+| Formalize pre-merge self-review (caught 4 real issues this session) | 4 | Bake into a `dw-review-pr`-style checklist or hook for this project | Proposed |
+| `safe-config-edit` helper that preserves perms after temp-file + mv | 1 | Wrap the pattern: backup → jq edit → atomic mv → chmod restore | Proposed |
+| Tool-count enforcement (auto-update CLAUDE.md / README count line on tool change) | 1 | Pre-commit hook or `dw-review-pr` checklist | Proposed |
+| Test-net-before-refactor pattern as documented template | 1 | Worked cleanly once; capture as a project convention for future "extract-shared-class" work | Proposed |


### PR DESCRIPTION
## Summary

Adds a privacy-safe session summary capturing the long maintenance session that landed 11 PRs (#24, #26, #27, #29, #31, #33, #35, #36, #37, #40, #41) plus the supporting issue grooming and config edits.

Generated by `/utility:session-summary`. The privacy checklist was applied during draft review:
- No ticket IDs (the open-source GitHub issue numbers used here are public to this project)
- No tenant or company names
- No credentials, real IPs, person names, emails, or device serials

## Files

- `docs/session_summaries/2026-04-29_1850_summary.md` — the session record
- `docs/session_summaries/patterns.md` — first entry; seeds 4 friction points and 4 improvement candidates for future `/evolve` runs

## Why commit (vs. local-only)

The skill's default is local-only, but committing makes the patterns available to future sessions across machines and gives `/evolve` a stable input. Worth the visibility trade-off here since the content is generic.

## Test plan

- [x] Privacy checklist passed during draft review
- [x] Markdown renders cleanly (no broken syntax)
- [x] Both files in the new `docs/session_summaries/` directory