### PR TITLE
Fix wifi_connect saving SSID with literal quote characters

### DIFF
--- a/src/adb/wifi-commands.ts
+++ b/src/adb/wifi-commands.ts
@@ -156,10 +156,14 @@ export class WifiCommands {
     security: SecurityType,
     password?: string
   ): Promise<WifiConnectionResult> {
-    // Use escaped quotes to survive shell processing
-    let command = `cmd wifi connect-network '"${ssid}"' ${security}`;
+    // Single-quote for the device shell only. `cmd wifi connect-network`
+    // takes the bare SSID; the framework adds wpa_supplicant's on-disk
+    // quoting itself. Wrapping with literal `"..."` here would persist
+    // those characters as part of the SSID and break association.
+    const sq = (s: string) => `'${s.replace(/'/g, `'\\''`)}'`;
+    let command = `cmd wifi connect-network ${sq(ssid)} ${security}`;
     if (password && security !== 'open') {
-      command += ` '"${password}"'`;
+      command += ` ${sq(password)}`;
     }
 
     const result = await this.adb.shell(command);


### PR DESCRIPTION
## Summary
- `wifi_connect` wrapped the SSID as `'\"${ssid}\"'`. The host shell forwards `\"ssid\"` to the device shell verbatim; the device shell strips only the single quotes, so `cmd wifi connect-network` receives the SSID with literal double-quote characters embedded.
- WifiConfiguration then persists those quotes as part of the SSID, wpa_supplicant searches for a beacon whose SSID contains them, and association silently fails on every retry.
- Fix: single-quote SSID and password once for the device shell (escaping any embedded single quotes). The framework adds wpa_supplicant's on-disk `ssid=\"...\"` quoting itself.

## Test plan
- [ ] On a device with an Open SSID in range, `wifi_connect { ssid: \"Aurora-Lodge-Guest\", security: \"open\" }` succeeds and `wifi_list_networks` reports the SSID without embedded quotes.
- [ ] WPA2-PSK round-trip with a passphrase containing a `'` still associates.
- [ ] Existing smoke suite: `cd cicd/tests && npm test -- --suite smoke` stays green.

Fixes #43