### PR TITLE
Add proxy_restart to recover upstream cache death after wifi

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Enterprise WiFi (802.1X/EAP) requires a companion Android app because the `cmd w
 
 ## Available Tools
 
-**29 native tools** in 8 categories below. With the optional `@playwright/mcp` upstream enabled (see [Proxying upstream MCPs](#proxying-upstream-mcps)), an additional **21 `browser_*` tools** are surfaced through the same endpoint for **50 total**.
+**30 native tools** in 9 categories below. With the optional `@playwright/mcp` upstream enabled (see [Proxying upstream MCPs](#proxying-upstream-mcps)), an additional **21 `browser_*` tools** are surfaced through the same endpoint for **51 total**.
 
 ### Device Management
 
@@ -270,6 +270,12 @@ For OTPs that don't come via SMS — WhatsApp, banking apps, email clients, etc.
 |------|-------------|
 | `notifications_list_recent` | List recent captured notifications, optionally filtered by package or body regex |
 | `notifications_wait_for_otp` | Poll captured notifications until a matching OTP arrives or timeout elapses |
+
+### Proxy lifecycle
+
+| Tool | Description |
+|------|-------------|
+| `proxy_restart` | Tear down and respawn one upstream MCP subprocess by name. Use after `wifi_disconnect` or any device-level event that breaks the upstream's cached state — `@playwright/mcp` keeps a closed `Page` handle and surfaces "Target page, context or browser has been closed" for every call until the subprocess is restarted. Restoring `adb forward` alone does not fix it. |
 
 ### Proxied (optional)
 
@@ -444,7 +450,7 @@ Upstreams start eagerly at server boot. On `SIGINT` / `SIGTERM` the server close
 
 ### Verified composition
 
-The default `UPSTREAM_MCP` in `.env.example` is `@playwright/mcp` — running our server with that set yields **50 total tools** (29 native + 21 from `@playwright/mcp`), all reachable from one MCP endpoint. See `cicd/tests/testcases/proxy/TC-PROXY-002.yml` for the end-to-end smoke test.
+The default `UPSTREAM_MCP` in `.env.example` is `@playwright/mcp` — running our server with that set yields **51 total tools** (30 native + 21 from `@playwright/mcp`), all reachable from one MCP endpoint. See `cicd/tests/testcases/proxy/TC-PROXY-002.yml` for the end-to-end smoke test.
 
 ## Testing
 

--- a/cicd/tests/fixtures/proxy-restart-roundtrip.mjs
+++ b/cicd/tests/fixtures/proxy-restart-roundtrip.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+/**
+ * One-shot script for TC-PROXY-003.
+ *
+ * `mcp-client.ts` is one-call-per-spawn, but proxy_restart is only
+ * meaningful inside a single server lifetime — testing that the
+ * upstream really respawned requires a second tool call against the
+ * same server process. So we spawn the server once, call mock_echo,
+ * call proxy_restart, then call mock_echo again, and print the three
+ * results separated by markers the YAML can match against.
+ */
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(here, '..', '..', '..');
+const serverEntry = path.join(projectRoot, 'dist', 'index.js');
+
+const transport = new StdioClientTransport({
+  command: 'node',
+  args: [serverEntry, '--stdio'],
+  env: { ...process.env },
+});
+const client = new Client({ name: 'proxy-restart-test', version: '1.0.0' });
+await client.connect(transport);
+
+const before = await client.callTool({ name: 'mock_echo', arguments: { text: 'before-restart' } });
+console.log('--- before ---');
+console.log(JSON.stringify(before, null, 2));
+
+const restarted = await client.callTool({ name: 'proxy_restart', arguments: { name: 'mock' } });
+console.log('--- restart ---');
+console.log(JSON.stringify(restarted, null, 2));
+
+const after = await client.callTool({ name: 'mock_echo', arguments: { text: 'after-restart' } });
+console.log('--- after ---');
+console.log(JSON.stringify(after, null, 2));
+
+await client.close();

--- a/cicd/tests/testcases/proxy/TC-PROXY-003.yml
+++ b/cicd/tests/testcases/proxy/TC-PROXY-003.yml
@@ -1,0 +1,31 @@
+id: TC-PROXY-003
+name: proxy_restart respawns an upstream and re-registers its tools
+suite: proxy
+tags: [proxy, restart]
+priority: 1
+timeout: 60000
+dependencies: []
+
+steps:
+  - name: mock_echo works, then proxy_restart, then mock_echo still works
+    command: |
+      UPSTREAM_MCP='mock=node cicd/tests/fixtures/mock-mcp-upstream.mjs' \
+        node cicd/tests/fixtures/proxy-restart-roundtrip.mjs
+    expectPatterns:
+      - "MOCK_ECHO: before-restart"
+      - "MOCK_ECHO: after-restart"
+      - "connected"
+    rejectPatterns:
+      - "isError"
+      - "Unknown tool"
+      - "No upstream named"
+
+criteria: |
+  Verify proxy_restart actually tears down and respawns an upstream:
+  - First mock_echo confirms the upstream is healthy and routed.
+  - proxy_restart kills + respawns the mock subprocess and reports
+    state: "connected" with toolCount > 0.
+  - Second mock_echo proves the new subprocess re-registered mock_echo
+    and the proxy routes through to the new process (a stale tool map
+    pointing at the dead client would surface "Unknown tool" or a
+    transport error).

--- a/docs/integrations/canary-cdp.md
+++ b/docs/integrations/canary-cdp.md
@@ -99,12 +99,13 @@ Claude orchestrates the seven steps. No code on your side beyond registering the
 |---|---|---|
 | `curl http://localhost:9222/json/version` returns nothing | Canary not running, or wrong app | Foreground Canary on the device; verify it's `com.chrome.canary` not stable Chrome (`com.android.chrome`) |
 | `adb forward` succeeds but the curl hangs | Stable Chrome was forwarded by accident | The socket name `localabstract:chrome_devtools_remote` is shared — only one Chrome variant should be in foreground. Force-stop the others |
-| `playwright-android` reports `Connected` in `claude mcp list` but `browser_snapshot` fails | Bridge or Canary not up at call time | The MCP server is connected; the CDP endpoint isn't. Run the `adb forward` command and foreground Canary, then retry the tool call |
+| `playwright-android` reports `Connected` in `claude mcp list` but `browser_snapshot` fails immediately on first call | Bridge or Canary not up at call time | The MCP server is connected; the CDP endpoint isn't. Run the `adb forward` command and foreground Canary, then retry the tool call |
+| `browser_*` calls fail with `Target page, context or browser has been closed`, even after `adb forward` is restored and `curl /json/version` returns fresh JSON | The upstream MCP cached a `Page` handle that died (typically after `wifi_disconnect` or device sleep). `adb forward` repairs the bridge but the cache is in the upstream's process memory | Call `proxy_restart {"name":"playwright"}` (assuming you registered the upstream with `name=playwright`). It kills and respawns the upstream subprocess, which reattaches to a fresh CDP target. No host restart needed |
 | Captive-portal page is blank when attached | Navigated into a strict-cert URL | Don't navigate — attach to the page Android opened via the captive-portal notification |
 
 ## What this MCP server does and does not do here
 
-- **Does**: drives the WiFi join (`wifi_connect`), detects the captive portal (`network_check_captive`), pulls / pushes files (`device_push_file` / `device_pull_file`), captures OTPs from notifications.
+- **Does**: drives the WiFi join (`wifi_connect`), detects the captive portal (`network_check_captive`), pulls / pushes files (`device_push_file` / `device_pull_file`), captures OTPs from notifications, recovers the browser MCP after a wifi event (`proxy_restart`).
 - **Does not**: ship a `device_open_canary_cdp` or `device_attach_browser` tool. The bridge is one `adb forward` line that the user sets up once per session — adding a tool around it would be more state to manage than it's worth.
 
 ## See also

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,8 +12,8 @@ if (useStdio) {
 }
 
 const deviceManager = new DeviceManager();
-const { server: mcpServer, nativeToolNames } = createMcpServer(deviceManager);
 const upstreamProxy = new UpstreamProxy();
+const { server: mcpServer, nativeToolNames } = createMcpServer(deviceManager, upstreamProxy);
 
 const shutdown = async () => {
   console.log('Shutting down...');

--- a/src/mcp/upstream-proxy.ts
+++ b/src/mcp/upstream-proxy.ts
@@ -162,9 +162,12 @@ export class UpstreamProxy {
       throw new Error(`No upstream named '${name}' is configured`);
     }
 
-    // Best-effort close. The transport may already be dead (that is, after
-    // all, why the caller is asking for a restart), so failures here are
-    // expected and non-fatal.
+    // Best-effort close of the current client. The transport may already
+    // be dead (that's usually why the caller is asking for a restart), so
+    // failures here are expected and non-fatal. We leave entry.client
+    // referencing the closed object until connectOne overwrites it; that
+    // also keeps the type as `Client | undefined` so the partial-failure
+    // close in the catch block below doesn't trip TS narrowing.
     try {
       await entry.client?.close();
     } catch {
@@ -179,8 +182,6 @@ export class UpstreamProxy {
       this.toolDefs.delete(finalName);
     }
     entry.toolNameMap.clear();
-    entry.client = undefined;
-    entry.transport = undefined;
     entry.status.state = 'disconnected';
     entry.status.toolCount = 0;
     entry.status.lastError = undefined;
@@ -188,6 +189,17 @@ export class UpstreamProxy {
     try {
       await this.connectOne(entry);
     } catch (e) {
+      // connectOne assigns entry.client / entry.transport before listTools,
+      // so a partial success leaves a half-spawned subprocess attached. Close
+      // whatever ended up there so we don't leak a process and poison the
+      // next restart attempt.
+      try {
+        await entry.client?.close();
+      } catch {
+        // ignore
+      }
+      entry.client = undefined;
+      entry.transport = undefined;
       entry.status.state = 'failed';
       entry.status.lastError = (e as Error).message;
       throw new Error(

--- a/src/mcp/upstream-proxy.ts
+++ b/src/mcp/upstream-proxy.ts
@@ -145,6 +145,58 @@ export class UpstreamProxy {
     });
   }
 
+  /**
+   * Tear down one upstream and respawn it, re-registering its tools.
+   *
+   * Why this exists: some upstream MCPs (notably `@playwright/mcp`) cache
+   * handles to remote state — e.g. a CDP `Page` — and surface
+   * `Target page, context or browser has been closed` for every subsequent
+   * call once that state dies. The cache lives in the upstream's process
+   * memory and there's no protocol-level reset; the only fix is to kill
+   * and respawn the subprocess. This tool gives the agent a way to do that
+   * in-conversation instead of telling the user to restart the host.
+   */
+  async restartOne(name: string): Promise<UpstreamStatus> {
+    const entry = this.upstreams.get(name);
+    if (!entry) {
+      throw new Error(`No upstream named '${name}' is configured`);
+    }
+
+    // Best-effort close. The transport may already be dead (that is, after
+    // all, why the caller is asking for a restart), so failures here are
+    // expected and non-fatal.
+    try {
+      await entry.client?.close();
+    } catch {
+      // ignore
+    }
+
+    // Drop every tool this upstream had registered. If the respawned
+    // upstream comes back with a different tool list, stale entries
+    // pointing at the dead client must not survive.
+    for (const finalName of entry.toolNameMap.keys()) {
+      this.toolToUpstream.delete(finalName);
+      this.toolDefs.delete(finalName);
+    }
+    entry.toolNameMap.clear();
+    entry.client = undefined;
+    entry.transport = undefined;
+    entry.status.state = 'disconnected';
+    entry.status.toolCount = 0;
+    entry.status.lastError = undefined;
+
+    try {
+      await this.connectOne(entry);
+    } catch (e) {
+      entry.status.state = 'failed';
+      entry.status.lastError = (e as Error).message;
+      throw new Error(
+        `Failed to restart upstream '${name}': ${(e as Error).message}`
+      );
+    }
+    return { ...entry.status };
+  }
+
   async closeAll(): Promise<void> {
     for (const entry of this.upstreams.values()) {
       try {

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { DeviceManager } from './adb/device-manager.js';
 import { NetworkCheck } from './network/network-check.js';
 import { EnterpriseWifiCommands } from './adb/enterprise-wifi.js';
+import { UpstreamProxy } from './mcp/upstream-proxy.js';
 import { SecurityType, EapMethod, Phase2Method } from './types.js';
 
 export interface CreateServerResult {
@@ -10,7 +11,10 @@ export interface CreateServerResult {
   nativeToolNames: string[];
 }
 
-export function createMcpServer(deviceManager: DeviceManager): CreateServerResult {
+export function createMcpServer(
+  deviceManager: DeviceManager,
+  upstreamProxy?: UpstreamProxy
+): CreateServerResult {
   const mcpServer = new McpServer({
     name: 'android-wifi-mcp',
     version: '1.0.0',
@@ -888,6 +892,35 @@ export function createMcpServer(deviceManager: DeviceManager): CreateServerResul
       return {
         content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
       };
+    }
+  );
+
+  // ============ Proxy Lifecycle ============
+
+  mcpServer.tool(
+    'proxy_restart',
+    'Tear down and respawn one upstream MCP subprocess by name (e.g. "playwright"). Use after a wifi_disconnect or any device-level event that breaks the upstream\'s cached state — @playwright/mcp keeps a closed Page handle and returns "Target page, context or browser has been closed" forever otherwise. Restoring adb forward alone is not enough; the cache lives in the upstream process memory.',
+    {
+      name: z.string().describe('Upstream name as configured in UPSTREAM_MCP (e.g. "playwright")'),
+    },
+    async ({ name }) => {
+      if (!upstreamProxy) {
+        return {
+          content: [{ type: 'text', text: JSON.stringify({ error: 'No upstream proxy configured (UPSTREAM_MCP unset)' }, null, 2) }],
+          isError: true,
+        };
+      }
+      try {
+        const status = await upstreamProxy.restartOne(name);
+        return {
+          content: [{ type: 'text', text: JSON.stringify(status, null, 2) }],
+        };
+      } catch (e) {
+        return {
+          content: [{ type: 'text', text: JSON.stringify({ error: (e as Error).message }, null, 2) }],
+          isError: true,
+        };
+      }
     }
   );
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -906,7 +906,7 @@ export function createMcpServer(
     async ({ name }) => {
       if (!upstreamProxy) {
         return {
-          content: [{ type: 'text', text: JSON.stringify({ error: 'No upstream proxy configured (UPSTREAM_MCP unset)' }, null, 2) }],
+          content: [{ type: 'text', text: JSON.stringify({ error: 'No upstream proxy attached to this server' }, null, 2) }],
           isError: true,
         };
       }


### PR DESCRIPTION
## Summary
- After `wifi_disconnect` (or any event that tears down the device's CDP transport), `@playwright/mcp` keeps a cached `Page` handle that's now closed and surfaces `Target page, context or browser has been closed` for every `browser_*` call. Restoring `adb forward` repairs the bridge but the cache lives in the upstream's process memory — there is no protocol-level reset, so the agent has had no way to recover short of asking the user to exit Claude Code.
- New native tool `proxy_restart {\"name\":\"playwright\"}` kills and respawns the named upstream subprocess, drops its old tool map entries, runs the MCP `initialize` handshake on the fresh process, and re-merges its tools into our unified `tools/list`. The fresh upstream connects to the existing `adb forward` (which survived everything) and gets a fresh CDP target.
- Tool count: 30 native (was 29), 51 total with `@playwright/mcp` upstream. README and `docs/integrations/canary-cdp.md` updated; the canary-cdp troubleshooting table had a row for this failure whose prescribed fix did not actually work — corrected.

## Test plan
- [x] `npm run build` clean.
- [x] `npm run test:unit` — 36/36 pass.
- [x] `cd cicd/tests && npm test -- --suite proxy` — 3/3 pass: TC-PROXY-001 (mock), TC-PROXY-002 (real `@playwright/mcp` against host Chromium), and the new TC-PROXY-003 (mock_echo → proxy_restart → mock_echo round-trip in one server lifetime, proving routing now lands on the new subprocess).
- [ ] Manual on a device: trigger the original failure — call `browser_navigate`, then `wifi_disconnect`, then `browser_*` (errors), then `proxy_restart {\"name\":\"playwright\"}`, then `browser_navigate` (works). This is the canonical fix for #47 and the only one that exercises the real CDP teardown path.

Fixes #47