### PR TITLE
Phase 0a: HTTP-only backend + bundled stdio shim for Claude Code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,27 +11,34 @@ The user is a QA engineer. Treat this as a test-tool first: prefer reliability, 
 ## Architecture
 
 ```
-Claude Code  ──MCP──►  android-wifi-mcp (this server)  ──ADB──►  phone
-                              │
-                              └──MCP/stdio──►  upstream MCPs (e.g. @playwright/mcp)
-                                                    (transparently proxied — see #14)
+Zed / Cursor / etc.  ──HTTP──►  android-wifi-mcp (this server)  ──ADB──►  phone
+                                       │
+Claude Code ─stdio─► shim ─HTTP─►      │
+                                       └──MCP/stdio──►  upstream MCPs (e.g. @playwright/mcp)
+                                                              (transparently proxied — see #14)
 ```
 
-- **Server entrypoint:** `src/index.ts` picks transport (HTTP default, `--stdio` for stdio).
-- **Tool registry:** `src/server.ts` — `createMcpServer(deviceManager)` returns `{ server, nativeToolNames }` and registers 29 native tools.
+- **Server entrypoint:** `src/index.ts` boots a long-running HTTP server (Streamable HTTP transport). Stdio support was removed in #51 Phase 0a — Claude Code clients connect via the bundled stdio shim (`bin/android-wifi-shim.mjs`).
+- **Tool registry:** `src/server.ts` — `createMcpServer(deviceManager)` returns `{ server, nativeToolNames }` and registers 30 native tools.
 - **Proxy:** `src/mcp/upstream-proxy.ts` spawns upstream MCP subprocesses on startup and merges their tools into one tools/list. Configured via `UPSTREAM_MCP` env var.
 - **ADB layer:** `src/adb/` — `adb-client.ts` (process wrapper), `device-manager.ts` (multi-device), then per-domain wrappers: `wifi-commands.ts`, `screenshot-commands.ts`, `sms-commands.ts`, `enterprise-wifi.ts`, `settings-commands.ts`, `file-commands.ts`.
 - **Companion app:** `companion-app/` — Kotlin Android app that handles 802.1X enterprise WiFi (the only flow that needs an on-device daemon today).
 - **Network helpers:** `src/network/network-check.ts`.
 - **Test framework:** `cicd/tests/` — custom YAML-driven runner. See "Tests" below.
 
-## Transport — stdio is primary
+## Transport — HTTP only, with shim for Claude Code
 
-The HTTP transport is **known to crash Claude Code's MCP client** (issue #7, currently low-priority). Stdio is the recommended path for everything: production registration, tests, ad-hoc clients.
+The backend speaks **Streamable HTTP only**. Stdio support in our codebase was deleted in #51 Phase 0a. Reasoning:
 
-- `npm start` → HTTP on `:3000` (kept for manual curl / debugging only)
-- `npm run start:stdio` → stdio (registered with Claude Code via `claude mcp add --transport stdio ...`)
-- `cicd/tests/src/mcp-client.ts` always uses stdio
+- The unified-server vision (one persistent backend, all clients connect to it for shared logging/observability/session routing) needs a long-running process. Stdio's "spawn-per-client" model is incompatible.
+- Modern MCP clients (Zed, Cursor, etc.) speak HTTP natively.
+- Claude Code's bundled HTTP MCP client crashes (issue #7, upstream bug). We sidestep by shipping our own stdio shim — `bin/android-wifi-shim.mjs` — which translates stdio↔HTTP for Claude Code only. The shim is ~30 LOC, lives in our repo, no external dependencies.
+
+Operational notes:
+- `npm start` → HTTP on `:3000` (override via `PORT` env). Pass `PORT=0` to let the OS assign (used by tests).
+- Modern clients: `claude mcp add --transport http android-wifi http://localhost:3000/mcp`.
+- Claude Code: `claude mcp add --transport stdio android-wifi android-wifi-shim http://localhost:3000/mcp` (after `npm install -g .`).
+- `cicd/tests/src/mcp-client.ts` spawns its own server (HTTP, OS-assigned port) per test step, parses the listening line from stderr, connects via `StreamableHTTPClientTransport`, calls one tool, tears down. Per-test isolation matches the prior stdio model.
 
 ## Tests
 
@@ -39,7 +46,7 @@ YAML-driven framework under `cicd/tests/`, ported from `ruckus1-mcp` and adapted
 
 - **`cicd/tests/src/cli.ts`** — `commander`-based CLI: `run` (with `--suite`, `--tag`, `--id` filters) and `list`.
 - **`cicd/tests/src/executor.ts`** — runs each test step as a shell command, captures stdout/stderr, applies `expectPatterns` / `rejectPatterns`. **Per-test** snapshot/restore of WiFi state via `device-state.ts` so a failing test cannot poison the next.
-- **`cicd/tests/src/mcp-client.ts`** — spawns `node dist/index.js --stdio`, calls one tool, prints JSON result.
+- **`cicd/tests/src/mcp-client.ts`** — spawns `node dist/index.js` (HTTP, `PORT=0`), parses the listening URL from stderr, connects via `StreamableHTTPClientTransport`, calls one tool, prints JSON result, tears server down.
 
 Test cases live in `cicd/tests/testcases/<suite>/TC-<SUITE>-NNN.yml`. Suites: `smoke` (read-only + roundtrips), `sms`, `notifications`, `proxy`, plus pending `wifi`/`enterprise`/`portal`. Each test step runs `npx tsx cicd/tests/src/mcp-client.ts <tool> '<args>'`.
 

--- a/README.md
+++ b/README.md
@@ -100,51 +100,19 @@ cd android-wifi-mcp
 npm install
 npm run build
 npm start             # HTTP transport on http://localhost:3000
-# or
-npm run start:stdio   # stdio transport (no port)
 ```
 
-#### Transport modes
+The server speaks **Streamable HTTP** (the MCP-spec transport). One process serves all connected MCP clients.
 
-The server supports two transports:
+### 4. Configure your MCP client
 
-| Transport | Command | When to use |
-|---|---|---|
-| **HTTP** (default) | `npm start` | Long-running server, multiple clients, ad-hoc curl/health checks |
-| **stdio** | `npm run start:stdio` (or `node dist/index.js --stdio`) | MCP clients that spawn the server as a subprocess (Claude Code, test framework). Recommended — known stable. |
+#### Zed, Cursor, and other MCP clients with native HTTP support
 
-In stdio mode the server reads/writes JSON-RPC on stdin/stdout; all logs go to stderr.
-
-### 4. Configure Claude Code
-
-#### Using Claude Code CLI (Recommended)
-
-**HTTP transport** (requires server running):
 ```bash
 claude mcp add --transport http android-wifi http://localhost:3000/mcp
 ```
 
-**Stdio transport** (auto-starts server, recommended):
-```bash
-claude mcp add --transport stdio android-wifi -- node /path/to/android-wifi-mcp/dist/index.js --stdio
-```
-
-#### Manual JSON Configuration (Alternative)
-
-Add to your MCP settings:
-
-```json
-{
-  "mcpServers": {
-    "android-wifi": {
-      "command": "node",
-      "args": ["/path/to/android-wifi-mcp/dist/index.js", "--stdio"]
-    }
-  }
-}
-```
-
-Or connect via HTTP transport:
+Or in JSON config:
 
 ```json
 {
@@ -154,6 +122,23 @@ Or connect via HTTP transport:
     }
   }
 }
+```
+
+#### Claude Code (uses the bundled stdio shim)
+
+Claude Code's bundled HTTP MCP client crashes when registered against a Streamable HTTP server (issue #7 — bug is in their binary, not ours). Use the stdio shim shipped with this package as the bridge:
+
+```bash
+# After `npm install -g .` (or wherever the package is installed)
+claude mcp add --transport stdio android-wifi android-wifi-shim http://localhost:3000/mcp
+```
+
+The shim is a ~30-LOC Node CLI that pretends to be a stdio MCP server to Claude Code and forwards every call to the HTTP backend. No Python or other extra dependencies — same Node toolchain you already have.
+
+If you didn't install globally:
+
+```bash
+claude mcp add --transport stdio android-wifi node /path/to/android-wifi-mcp/bin/android-wifi-shim.mjs http://localhost:3000/mcp
 ```
 
 ### 5. Setup Enterprise WiFi (Optional)
@@ -454,7 +439,7 @@ The default `UPSTREAM_MCP` in `.env.example` is `@playwright/mcp` — running ou
 
 ## Testing
 
-YAML-driven test framework under `cicd/tests/` runs against an attached Android device using the stdio transport.
+YAML-driven test framework under `cicd/tests/` runs against an attached Android device. Each test step spawns its own server (HTTP transport, OS-assigned port) so per-test `UPSTREAM_MCP` env isolation works the same way it did under stdio.
 
 ### Run smoke tests locally
 
@@ -474,7 +459,7 @@ Results land in `cicd/results/<timestamp>_<suite>/` (`summary.json` plus one `<t
 
 ### How the runner works
 
-- `mcp-client.ts` spawns `node dist/index.js --stdio`, calls one tool, prints the JSON result. Each test step is one such call.
+- `mcp-client.ts` spawns `node dist/index.js` (HTTP, OS-assigned port), waits for the listening line on stderr, connects via `StreamableHTTPClientTransport`, calls one tool, prints the JSON result, then tears the server down. Each test step is one such call.
 - `executor.ts` snapshots WiFi state (enabled flag, current SSID, saved-network IDs) before each test and restores it after — **per-test**, so a failing test cannot poison the next one. Snapshot/restore goes through `adb` directly so the framework doesn't depend on the very thing under test.
 - `simple-judge.ts` decides pass/fail from exit codes plus `expectPatterns`/`rejectPatterns`.
 
@@ -516,7 +501,7 @@ GitHub Actions workflows under `.github/workflows/`:
 ```
 android-wifi-mcp/
 ├── src/
-│   ├── index.ts                # Entry — picks transport (HTTP / stdio)
+│   ├── index.ts                # Entry — HTTP server bootstrap
 │   ├── server.ts               # MCP server factory + tool registrations
 │   ├── types.ts                # TypeScript interfaces
 │   ├── mcp/
@@ -544,7 +529,7 @@ android-wifi-mcp/
 │   │   │   ├── cli.ts
 │   │   │   ├── executor.ts     # per-test snapshot/restore of device state
 │   │   │   ├── device-state.ts # adb-direct snapshot/restore helpers
-│   │   │   ├── mcp-client.ts   # stdio MCP client
+│   │   │   ├── mcp-client.ts   # HTTP MCP client (spawns server, waits for ready, calls)
 │   │   │   ├── loader.ts, judge/, reporter/, types.ts, config.ts
 │   │   │   └── ...
 │   │   ├── testcases/<suite>/  # smoke, sms, notifications, proxy (wifi/enterprise/portal pending)

--- a/bin/android-wifi-shim.mjs
+++ b/bin/android-wifi-shim.mjs
@@ -63,6 +63,11 @@ try {
   process.exit(1);
 }
 
+if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+  process.stderr.write(`android-wifi-shim: backend URL must use http:// or https://, got '${parsedUrl.protocol}'\n`);
+  process.exit(1);
+}
+
 const clientTransport = new StreamableHTTPClientTransport(parsedUrl);
 const client = new Client({ name: 'android-wifi-shim', version: '1.0.0' });
 

--- a/bin/android-wifi-shim.mjs
+++ b/bin/android-wifi-shim.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+/**
+ * android-wifi-shim — stdio↔HTTP MCP transport bridge.
+ *
+ * Why this exists: as of 2026-04, Claude Code's bundled MCP HTTP client
+ * crashes when registered against a Streamable HTTP MCP server (see
+ * issue #7). Stdio still works. This shim runs as a stdio MCP server to
+ * Claude Code, and internally is an MCP HTTP client to our backend.
+ *
+ * Other modern MCP clients (Zed, Cursor, etc.) speak HTTP natively and
+ * don't need this — point them at the backend URL directly.
+ *
+ * Usage:
+ *   android-wifi-shim <backend-url>
+ *
+ * Example:
+ *   android-wifi-shim http://localhost:3000/mcp
+ *
+ * Registering with Claude Code:
+ *   claude mcp add --transport stdio android-wifi android-wifi-shim http://localhost:3000/mcp
+ */
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import {
+  ListToolsRequestSchema,
+  CallToolRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+
+function usage(exitCode = 0) {
+  process.stderr.write(`android-wifi-shim — stdio↔HTTP MCP transport bridge
+
+Usage:
+  android-wifi-shim <backend-url>
+
+Example:
+  android-wifi-shim http://localhost:3000/mcp
+
+Registering with Claude Code:
+  claude mcp add --transport stdio android-wifi android-wifi-shim http://localhost:3000/mcp
+
+Environment:
+  ANDROID_WIFI_SHIM_BACKEND  Backend URL (overrides positional arg if set)
+`);
+  process.exit(exitCode);
+}
+
+const args = process.argv.slice(2);
+if (args.includes('-h') || args.includes('--help')) usage(0);
+
+const backendUrl = process.env.ANDROID_WIFI_SHIM_BACKEND || args[0];
+if (!backendUrl) {
+  process.stderr.write('android-wifi-shim: backend URL required (positional arg or ANDROID_WIFI_SHIM_BACKEND env)\n');
+  usage(1);
+}
+
+let parsedUrl;
+try {
+  parsedUrl = new URL(backendUrl);
+} catch (e) {
+  process.stderr.write(`android-wifi-shim: invalid URL '${backendUrl}': ${e.message}\n`);
+  process.exit(1);
+}
+
+const clientTransport = new StreamableHTTPClientTransport(parsedUrl);
+const client = new Client({ name: 'android-wifi-shim', version: '1.0.0' });
+
+try {
+  await client.connect(clientTransport);
+} catch (e) {
+  process.stderr.write(`android-wifi-shim: failed to connect to backend ${backendUrl}: ${e.message}\n`);
+  process.exit(1);
+}
+
+const server = new Server(
+  { name: 'android-wifi-shim', version: '1.0.0' },
+  { capabilities: { tools: {} } }
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => {
+  return await client.listTools();
+});
+
+server.setRequestHandler(CallToolRequestSchema, async (req) => {
+  return await client.callTool({
+    name: req.params.name,
+    arguments: req.params.arguments,
+  });
+});
+
+const stdioTransport = new StdioServerTransport();
+await server.connect(stdioTransport);
+process.stderr.write(`android-wifi-shim: forwarding stdio → ${backendUrl}\n`);
+
+const shutdown = async () => {
+  try { await client.close(); } catch { /* ignore */ }
+  process.exit(0);
+};
+process.on('SIGTERM', shutdown);
+process.on('SIGINT', shutdown);

--- a/cicd/tests/fixtures/proxy-restart-roundtrip.mjs
+++ b/cicd/tests/fixtures/proxy-restart-roundtrip.mjs
@@ -5,12 +5,14 @@
  * `mcp-client.ts` is one-call-per-spawn, but proxy_restart is only
  * meaningful inside a single server lifetime — testing that the
  * upstream really respawned requires a second tool call against the
- * same server process. So we spawn the server once, call mock_echo,
- * call proxy_restart, then call mock_echo again, and print the three
- * results separated by markers the YAML can match against.
+ * same server process. So we spawn the server once (HTTP transport,
+ * OS-assigned port), call mock_echo, call proxy_restart, then call
+ * mock_echo again, and print the three results separated by markers
+ * the YAML can match against.
  */
+import { spawn } from 'child_process';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
@@ -18,24 +20,61 @@ const here = path.dirname(fileURLToPath(import.meta.url));
 const projectRoot = path.resolve(here, '..', '..', '..');
 const serverEntry = path.join(projectRoot, 'dist', 'index.js');
 
-const transport = new StdioClientTransport({
-  command: 'node',
-  args: [serverEntry, '--stdio'],
-  env: { ...process.env },
+const proc = spawn('node', [serverEntry], {
+  env: { ...process.env, PORT: '0' },
+  stdio: ['ignore', 'pipe', 'pipe'],
 });
+
+const startTimeoutMs = 10000;
+const readyPattern = /listening on (http:\/\/[\d.]+:\d+)/;
+
+const baseUrl = await new Promise((resolve, reject) => {
+  const deadline = setTimeout(() => {
+    proc.kill('SIGKILL');
+    reject(new Error(`Server did not start within ${startTimeoutMs}ms`));
+  }, startTimeoutMs);
+
+  const onLine = (chunk) => {
+    const text = chunk.toString();
+    process.stderr.write(text);
+    const m = text.match(readyPattern);
+    if (m) {
+      clearTimeout(deadline);
+      resolve(m[1]);
+    }
+  };
+
+  proc.stdout.on('data', onLine);
+  proc.stderr.on('data', onLine);
+  proc.on('error', (err) => { clearTimeout(deadline); reject(err); });
+  proc.on('exit', (code) => { clearTimeout(deadline); reject(new Error(`Server exited with code ${code} before listening`)); });
+});
+
+const cleanup = () => { if (!proc.killed) proc.kill('SIGTERM'); };
+process.on('exit', cleanup);
+process.on('SIGINT', () => { cleanup(); process.exit(130); });
+process.on('SIGTERM', () => { cleanup(); process.exit(143); });
+
+const transport = new StreamableHTTPClientTransport(new URL(`${baseUrl}/mcp`));
 const client = new Client({ name: 'proxy-restart-test', version: '1.0.0' });
-await client.connect(transport);
 
-const before = await client.callTool({ name: 'mock_echo', arguments: { text: 'before-restart' } });
-console.log('--- before ---');
-console.log(JSON.stringify(before, null, 2));
+try {
+  await client.connect(transport);
 
-const restarted = await client.callTool({ name: 'proxy_restart', arguments: { name: 'mock' } });
-console.log('--- restart ---');
-console.log(JSON.stringify(restarted, null, 2));
+  const before = await client.callTool({ name: 'mock_echo', arguments: { text: 'before-restart' } });
+  console.log('--- before ---');
+  console.log(JSON.stringify(before, null, 2));
 
-const after = await client.callTool({ name: 'mock_echo', arguments: { text: 'after-restart' } });
-console.log('--- after ---');
-console.log(JSON.stringify(after, null, 2));
+  const restarted = await client.callTool({ name: 'proxy_restart', arguments: { name: 'mock' } });
+  console.log('--- restart ---');
+  console.log(JSON.stringify(restarted, null, 2));
 
-await client.close();
+  const after = await client.callTool({ name: 'mock_echo', arguments: { text: 'after-restart' } });
+  console.log('--- after ---');
+  console.log(JSON.stringify(after, null, 2));
+
+  await client.close();
+} finally {
+  cleanup();
+  await new Promise((r) => proc.on('exit', r));
+}

--- a/cicd/tests/src/mcp-client.ts
+++ b/cicd/tests/src/mcp-client.ts
@@ -1,12 +1,18 @@
 #!/usr/bin/env npx tsx
 /**
  * Lightweight MCP client CLI for integration testing.
- * Spawns the MCP server over stdio, calls a tool, prints the result as JSON.
+ * Spawns the MCP server (HTTP transport, OS-assigned port), waits for it
+ * to start listening, calls one tool over HTTP, prints the result as JSON,
+ * then tears the server down.
  *
  * Usage: npx tsx cicd/tests/src/mcp-client.ts <tool_name> '<json_args>'
+ *
+ * Each invocation spawns its own server, so per-test UPSTREAM_MCP env
+ * isolation matches the prior stdio behavior.
  */
+import { spawn } from 'child_process';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
@@ -18,21 +24,62 @@ if (!toolName) {
 
 const args = argsJson ? JSON.parse(argsJson) : {};
 
-// Resolve dist/index.js relative to this file so the client works from any CWD.
 const here = path.dirname(fileURLToPath(import.meta.url));
 const projectRoot = path.resolve(here, '..', '..', '..');
 const serverEntry = path.join(projectRoot, 'dist', 'index.js');
 
-const transport = new StdioClientTransport({
-  command: 'node',
-  args: [serverEntry, '--stdio'],
-  env: { ...process.env } as Record<string, string>,
+const proc = spawn('node', [serverEntry], {
+  env: { ...process.env, PORT: '0' },
+  stdio: ['ignore', 'pipe', 'pipe'],
 });
 
+const startTimeoutMs = 10000;
+const readyPattern = /listening on (http:\/\/[\d.]+:\d+)/;
+
+const baseUrl = await new Promise<string>((resolve, reject) => {
+  const deadline = setTimeout(() => {
+    proc.kill('SIGKILL');
+    reject(new Error(`Server did not start within ${startTimeoutMs}ms`));
+  }, startTimeoutMs);
+
+  const onLine = (chunk: Buffer) => {
+    const text = chunk.toString();
+    process.stderr.write(text);
+    const m = text.match(readyPattern);
+    if (m) {
+      clearTimeout(deadline);
+      resolve(m[1]);
+    }
+  };
+
+  proc.stdout.on('data', onLine);
+  proc.stderr.on('data', onLine);
+  proc.on('error', (err) => {
+    clearTimeout(deadline);
+    reject(err);
+  });
+  proc.on('exit', (code) => {
+    clearTimeout(deadline);
+    reject(new Error(`Server exited with code ${code} before listening`));
+  });
+});
+
+const cleanup = () => {
+  if (!proc.killed) proc.kill('SIGTERM');
+};
+process.on('exit', cleanup);
+process.on('SIGINT', () => { cleanup(); process.exit(130); });
+process.on('SIGTERM', () => { cleanup(); process.exit(143); });
+
+const transport = new StreamableHTTPClientTransport(new URL(`${baseUrl}/mcp`));
 const client = new Client({ name: 'android-wifi-mcp-test-client', version: '1.0.0' });
-await client.connect(transport);
 
-const result = await client.callTool({ name: toolName, arguments: args });
-console.log(JSON.stringify(result, null, 2));
-
-await client.close();
+try {
+  await client.connect(transport);
+  const result = await client.callTool({ name: toolName, arguments: args });
+  console.log(JSON.stringify(result, null, 2));
+  await client.close();
+} finally {
+  cleanup();
+  await new Promise((r) => proc.on('exit', r));
+}

--- a/package.json
+++ b/package.json
@@ -4,10 +4,12 @@
   "description": "MCP Server for WiFi control on Android devices via ADB",
   "type": "module",
   "main": "dist/index.js",
+  "bin": {
+    "android-wifi-shim": "./bin/android-wifi-shim.mjs"
+  },
   "scripts": {
     "build": "tsc",
     "start": "node dist/index.js",
-    "start:stdio": "node dist/index.js --stdio",
     "dev": "tsc --watch",
     "test:unit": "node --test 'tests/unit/**/*.test.mjs'",
     "tools:count": "echo \"Native tools registered in src/server.ts: $(grep -c 'mcpServer\\.tool(' src/server.ts)\""

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,8 @@
+import express from 'express';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { DeviceManager } from './adb/device-manager.js';
 import { createMcpServer } from './server.js';
 import { UpstreamProxy, parseUpstreamConfig } from './mcp/upstream-proxy.js';
-
-const useStdio = process.argv.includes('--stdio');
-
-// In stdio mode, stdout is the JSON-RPC channel — any non-protocol bytes
-// break the client. Redirect console.log to stderr so device-manager init
-// messages don't poison the stream.
-if (useStdio) {
-  console.log = console.error;
-}
 
 const deviceManager = new DeviceManager();
 const upstreamProxy = new UpstreamProxy();
@@ -49,23 +42,7 @@ async function initUpstreamProxy(): Promise<void> {
   upstreamProxy.attach(mcpServer);
 }
 
-async function startStdio(): Promise<void> {
-  const { StdioServerTransport } = await import('@modelcontextprotocol/sdk/server/stdio.js');
-
-  await initDevice();
-  await initUpstreamProxy();
-
-  const transport = new StdioServerTransport();
-  await mcpServer.connect(transport);
-  console.error('android-wifi-mcp listening on stdio');
-}
-
-async function startHttp(): Promise<void> {
-  const express = (await import('express')).default;
-  const { StreamableHTTPServerTransport } = await import(
-    '@modelcontextprotocol/sdk/server/streamableHttp.js'
-  );
-
+async function start(): Promise<void> {
   const app = express();
   app.use(express.json());
 
@@ -113,24 +90,19 @@ async function startHttp(): Promise<void> {
   await initDevice();
   await initUpstreamProxy();
 
-  const PORT = process.env.PORT || 3000;
+  const PORT = process.env.PORT ?? '3000';
   const HOST = process.env.HOST || '0.0.0.0';
 
-  app.listen(Number(PORT), HOST, () => {
-    console.log(`android-wifi-mcp server listening on http://${HOST}:${PORT}`);
-    console.log(`MCP endpoint: http://${HOST}:${PORT}/mcp`);
-    console.log(`Health check: http://${HOST}:${PORT}/health`);
+  const httpServer = app.listen(Number(PORT), HOST, () => {
+    const addr = httpServer.address();
+    const actualPort = typeof addr === 'object' && addr ? addr.port : PORT;
+    console.log(`android-wifi-mcp server listening on http://${HOST}:${actualPort}`);
+    console.log(`MCP endpoint: http://${HOST}:${actualPort}/mcp`);
+    console.log(`Health check: http://${HOST}:${actualPort}/health`);
   });
 }
 
-if (useStdio) {
-  startStdio().catch((err) => {
-    console.error('Failed to start stdio server:', err);
-    process.exit(1);
-  });
-} else {
-  startHttp().catch((err) => {
-    console.error('Failed to start HTTP server:', err);
-    process.exit(1);
-  });
-}
+start().catch((err) => {
+  console.error('Failed to start server:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Phase 0a of the #51 plan. Removes stdio support from the backend, ships our own ~30 LOC Node shim as the bridge for Claude Code clients (whose bundled HTTP MCP client crashes per #7).

**Why this shape:** the unified-server vision (one persistent backend, observability/logging/session routing all in one place) needs a long-running process. Stdio's spawn-per-client model is incompatible. Modern MCP clients speak HTTP natively; Claude Code is the lone laggard, so we sidestep with a small stdio↔HTTP translation layer that ships in this repo.

**Why our own shim and not \`sparfenyuk/mcp-proxy\`:** Python pip dependency for users + bus factor of an individual maintainer. Our Node shim is ~30 LOC, fits the existing toolchain, no extra install for users.

## Changes

### Server
- \`src/index.ts\`: deleted stdio startup path (~30 LOC removed). HTTP is now default and only.
- Logs actual bound port (not the requested \`PORT=0\`) so test fixtures can parse it from stderr.

### Shim
- \`bin/android-wifi-shim.mjs\`: stdio MCP server to parent (Claude Code), HTTP MCP client to backend. Forwards \`tools/list\` and \`tools/call\`. Includes \`--help\`, error handling, signal cleanup.
- \`package.json\`: registered as \`bin\` entry so \`npm install -g .\` exposes \`android-wifi-shim\` as a global CLI.

### Test infra
- \`cicd/tests/src/mcp-client.ts\`: switched from \`StdioClientTransport\` to HTTP. Each call still spawns its own server (\`PORT=0\`, OS-assigned port), parses the listening URL from stderr, connects via \`StreamableHTTPClientTransport\`. Per-test \`UPSTREAM_MCP\` isolation preserved.
- \`cicd/tests/fixtures/proxy-restart-roundtrip.mjs\`: same migration. TC-PROXY-003 still validates restart round-trip.

### Docs
- \`README.md\`: stdio-as-primary section removed. Two install paths: Zed/Cursor (native HTTP) and Claude Code (via shim). Removed \`npm run start:stdio\` references.
- \`CLAUDE.md\`: transport section rewritten. Native-tool count updated to 30. Architecture diagram updated.

## Breaking change

Users who previously registered with \`claude mcp add --transport stdio ... --stdio\` must re-register. The README has the new commands:

\`\`\`bash
# Zed / Cursor / etc. — native HTTP
claude mcp add --transport http android-wifi http://localhost:3000/mcp

# Claude Code — via bundled shim
claude mcp add --transport stdio android-wifi android-wifi-shim http://localhost:3000/mcp
\`\`\`

## Test plan

- [x] \`npm run build\` clean
- [x] \`npm run test:unit\` — 36/36 pass (no transport surface in unit tests)
- [x] \`cd cicd/tests && npm test -- --suite proxy\` — 3/3 pass, including TC-PROXY-002 against real \`@playwright/mcp\`
- [x] Spike already exercised concurrent calls + round-trip behavior (\`spike/phase-0/test-concurrent.mjs\`, \`spike/phase-0/test-roundtrip.mjs\`)
- [ ] Smoke suite against a real device — needs hardware. The MCP-protocol path is identical to today's stdio (just over HTTP), so smoke should pass; deferred to merge time
- [ ] Manual register-with-Claude-Code test using the new shim — also needs your environment; deferred

## What's NOT in this PR

Phase 0b (Postgres + structured logging), Phase 1 (sessions/NAT routing, observer subscriptions, cross-layer attribution). All scoped in #51 and follow this lands.

Refs #51