### PR TITLE
Phase 3a: device observer + last-seen hint (closes #49)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,13 +19,14 @@ Claude Code ─stdio─► shim ─HTTP─►      │
 ```
 
 - **Server entrypoint:** `src/index.ts` boots a long-running HTTP server (Streamable HTTP transport). Stdio support was removed in #51 Phase 0a — Claude Code clients connect via the bundled stdio shim (`bin/android-wifi-shim.mjs`).
-- **Tool registry:** `src/server.ts` — `createMcpServer(deviceManager)` returns `{ server, nativeToolNames }` and registers 30 native tools.
+- **Tool registry:** `src/server.ts` — `createMcpServer(deviceManager)` returns `{ server, nativeToolNames }` and registers 31 native tools.
 - **Proxy:** `src/mcp/upstream-proxy.ts` spawns upstream MCP subprocesses on startup and merges their tools into one tools/list. Configured via `UPSTREAM_MCP` env var.
 - **ADB layer:** `src/adb/` — `adb-client.ts` (process wrapper), `device-manager.ts` (multi-device), then per-domain wrappers: `wifi-commands.ts`, `screenshot-commands.ts`, `sms-commands.ts`, `enterprise-wifi.ts`, `settings-commands.ts`, `file-commands.ts`.
 - **Companion app:** `companion-app/` — Kotlin Android app that handles 802.1X enterprise WiFi (the only flow that needs an on-device daemon today).
 - **Network helpers:** `src/network/network-check.ts`.
 - **Structured logging (opt-in, Phase 0b of #51):** `src/db/{pool,writer}.ts` + `src/log/{logger,middleware}.ts`. `installCallRecording()` wraps the final `tools/call` handler and writes a row per call to `tool_calls`. Pool is lazy: when `DATABASE_URL` is unset, recording is a silent no-op. Postgres lives in `docker-compose.yml` (`make up`), migrations in `migrations/` via `node-pg-migrate` (`make migrate`). pino emits app logs to stderr (or `LOG_DEST=path`).
 - **Trace propagation (Phase 1 of #51):** `src/log/{traceparent,trace-context}.ts`. The express layer parses incoming W3C `traceparent` headers (or generates a fresh trace context) and runs `transport.handleRequest` inside an `AsyncLocalStorage`. The recording middleware reads `trace_id` from the ALS; the pino logger has a `mixin` that does the same, so every log line emitted while a tool call is in-flight is auto-tagged. Outgoing propagation to upstream stdio MCPs is deferred (no header concept in stdio JSON-RPC).
+- **Device observer (Phase 3a of #51):** `src/adb/device-observer.ts` spawns `adb track-devices` as a subprocess and parses the length-prefixed transition stream. Every state change → row in `device_events` (when `DATABASE_URL` is set) + entry in an in-memory ring buffer. `device_event_log` tool exposes the ring; `DeviceManager.ensureDeviceSelected()` enriches the "no device" error with the most recent detach so the agent can decide replug/restart/re-trust. Subprocess death is handled with exponential backoff. Transitions emit outside any tool-call ALS, so `device_events.trace_id` stays null (correlation in Phase 4 happens via serial + time).
 - **Test framework:** `cicd/tests/` — custom YAML-driven runner. See "Tests" below.
 
 ## Transport — HTTP only, with shim for Claude Code

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Enterprise WiFi (802.1X/EAP) requires a companion Android app because the `cmd w
 
 ## Available Tools
 
-**30 native tools** in 9 categories below. With the optional `@playwright/mcp` upstream enabled (see [Proxying upstream MCPs](#proxying-upstream-mcps)), an additional **21 `browser_*` tools** are surfaced through the same endpoint for **51 total**.
+**31 native tools** in 9 categories below. With the optional `@playwright/mcp` upstream enabled (see [Proxying upstream MCPs](#proxying-upstream-mcps)), an additional **21 `browser_*` tools** are surfaced through the same endpoint for **52 total**.
 
 ### Device Management
 
@@ -190,6 +190,7 @@ Enterprise WiFi (802.1X/EAP) requires a companion Android app because the `cmd w
 | `device_list` | List all connected Android devices |
 | `device_select` | Select a device for operations |
 | `device_info` | Get detailed device information |
+| `device_event_log` | Recent device-attach/detach/state-change transitions from the built-in `adb track-devices` listener |
 | `device_screenshot` | Capture a PNG (returns base64 or saves to a host path) |
 
 ### Device Settings (system / secure / global)
@@ -459,7 +460,7 @@ Upstreams start eagerly at server boot. On `SIGINT` / `SIGTERM` the server close
 
 ### Verified composition
 
-The default `UPSTREAM_MCP` in `.env.example` is `@playwright/mcp` — running our server with that set yields **51 total tools** (30 native + 21 from `@playwright/mcp`), all reachable from one MCP endpoint. See `cicd/tests/testcases/proxy/TC-PROXY-002.yml` for the end-to-end smoke test.
+The default `UPSTREAM_MCP` in `.env.example` is `@playwright/mcp` — running our server with that set yields **52 total tools** (31 native + 21 from `@playwright/mcp`), all reachable from one MCP endpoint. See `cicd/tests/testcases/proxy/TC-PROXY-002.yml` for the end-to-end smoke test.
 
 ## Testing
 

--- a/src/adb/device-manager.ts
+++ b/src/adb/device-manager.ts
@@ -6,6 +6,19 @@ import { NotificationCommands } from './notifications-commands.js';
 import { SettingsCommands } from './settings-commands.js';
 import { FileCommands } from './file-commands.js';
 import { Device, DeviceInfo } from '../types.js';
+import type { DeviceObserver } from './device-observer.js';
+
+function formatElapsed(ms: number): string {
+  if (ms < 0) return 'just now';
+  const s = Math.round(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.round(s / 60);
+  if (m < 60) return `${m}m`;
+  const h = Math.round(m / 60);
+  if (h < 24) return `${h}h`;
+  const d = Math.round(h / 24);
+  return `${d}d`;
+}
 
 /**
  * Manages connected Android devices and provides unified access
@@ -20,6 +33,7 @@ export class DeviceManager {
   private settings: SettingsCommands;
   private files: FileCommands;
   private devices: Map<string, DeviceInfo> = new Map();
+  private observer: DeviceObserver | null = null;
 
   constructor(adbPath?: string) {
     this.adb = new AdbClient(adbPath);
@@ -29,6 +43,19 @@ export class DeviceManager {
     this.notifications = new NotificationCommands(this.adb);
     this.settings = new SettingsCommands(this.adb);
     this.files = new FileCommands(this.adb);
+  }
+
+  /**
+   * Wire in the device observer so ensureDeviceSelected() can enrich its
+   * "no device" error with last-seen state. Optional — DeviceManager runs
+   * without it (just throws the plain message).
+   */
+  setObserver(observer: DeviceObserver): void {
+    this.observer = observer;
+  }
+
+  getObserver(): DeviceObserver | null {
+    return this.observer;
   }
 
   /**
@@ -183,7 +210,7 @@ export class DeviceManager {
     const connectedDevices = devices.filter(d => d.state === 'device');
 
     if (connectedDevices.length === 0) {
-      throw new Error('No Android devices connected. Please connect a device with USB debugging enabled.');
+      throw new Error(this.formatNoDeviceError());
     }
 
     if (connectedDevices.length > 1) {
@@ -196,6 +223,35 @@ export class DeviceManager {
     // Auto-select the only connected device
     this.adb.selectDevice(connectedDevices[0].serial);
     return connectedDevices[0].serial;
+  }
+
+  /**
+   * Build the "no device" error message, enriching with last-seen state from
+   * the observer when available. Goal is to let an agent decide between
+   * "ask user to replug", "restart emulator", and "re-accept RSA prompt"
+   * without falling back to host-side probing — the operational pain
+   * documented in #49.
+   */
+  private formatNoDeviceError(): string {
+    const base = 'No Android devices connected. Please connect a device with USB debugging enabled.';
+    if (!this.observer) return base;
+
+    const detach = this.observer.getMostRecentDetach();
+    if (!detach) return base;
+
+    const elapsedMs = Date.now() - detach.ts.getTime();
+    const elapsed = formatElapsed(elapsedMs);
+    const fromState = detach.prev_state ?? 'unknown';
+
+    return (
+      `${base} ` +
+      `Last seen: ${detach.serial} left '${fromState}' state ${elapsed} ago ` +
+      `(at ${detach.ts.toISOString()}). ` +
+      `Hint: depending on the prior state — 'device' suggests physical disconnect, ` +
+      `USB autosuspend, or device sleep; 'unauthorized' suggests RSA revocation; ` +
+      `'offline' suggests adb-server confusion or emulator death. ` +
+      `Use device_event_log for the full transition history.`
+    );
   }
 
   /**

--- a/src/adb/device-observer.ts
+++ b/src/adb/device-observer.ts
@@ -1,0 +1,265 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import { logger } from '../log/logger.js';
+import { recordDeviceEvent } from '../db/writer.js';
+import { getTraceId } from '../log/trace-context.js';
+
+const log = logger.child({ component: 'device-observer' });
+
+export interface DeviceSnapshot {
+  serial: string;
+  state: string;
+}
+
+export interface DeviceTransition {
+  serial: string;
+  /** State the device left. null = first time we've seen this serial. */
+  prev_state: string | null;
+  /** State the device entered. null = device disappeared from the list. */
+  new_state: string | null;
+  ts: Date;
+}
+
+/**
+ * Parse one length-prefixed `adb track-devices` payload into snapshots.
+ *
+ * Wire format per device row: `<serial>\t<state>` joined by `\n`.
+ * An empty payload means no devices are attached — returns [].
+ *
+ * Pure function — exported for unit testing.
+ */
+export function parseTrackDevicesPayload(payload: string): DeviceSnapshot[] {
+  if (!payload) return [];
+  const out: DeviceSnapshot[] = [];
+  for (const line of payload.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const tab = trimmed.indexOf('\t');
+    if (tab < 0) continue;
+    out.push({ serial: trimmed.slice(0, tab), state: trimmed.slice(tab + 1) });
+  }
+  return out;
+}
+
+/**
+ * Diff two snapshots into a list of transitions. A device that changed state
+ * is reported once with prev_state and new_state filled. A device that
+ * appeared has prev_state=null. A device that disappeared has new_state=null.
+ *
+ * Pure function — exported for unit testing.
+ */
+export function diffSnapshots(
+  prev: DeviceSnapshot[],
+  next: DeviceSnapshot[],
+  ts: Date
+): DeviceTransition[] {
+  const prevMap = new Map(prev.map((d) => [d.serial, d.state]));
+  const nextMap = new Map(next.map((d) => [d.serial, d.state]));
+  const transitions: DeviceTransition[] = [];
+
+  for (const [serial, newState] of nextMap) {
+    const prevState = prevMap.get(serial);
+    if (prevState === undefined) {
+      transitions.push({ serial, prev_state: null, new_state: newState, ts });
+    } else if (prevState !== newState) {
+      transitions.push({ serial, prev_state: prevState, new_state: newState, ts });
+    }
+  }
+  for (const [serial, prevState] of prevMap) {
+    if (!nextMap.has(serial)) {
+      transitions.push({ serial, prev_state: prevState, new_state: null, ts });
+    }
+  }
+  return transitions;
+}
+
+/**
+ * Stateful framer for the `adb track-devices` byte stream. Each frame is
+ * `<4-hex-length><payload>` where payload is exactly `length` bytes. We buffer
+ * incoming chunks until at least one complete frame is available, yield it,
+ * and keep the remainder.
+ *
+ * Exported for unit testing.
+ */
+export class FrameDecoder {
+  private buf = Buffer.alloc(0);
+
+  push(chunk: Buffer): string[] {
+    this.buf = Buffer.concat([this.buf, chunk]);
+    const frames: string[] = [];
+    for (;;) {
+      if (this.buf.length < 4) break;
+      const lenStr = this.buf.subarray(0, 4).toString('ascii');
+      const len = parseInt(lenStr, 16);
+      if (Number.isNaN(len)) {
+        // Stream is corrupt; drop everything we have and resync on next chunk.
+        // adb shouldn't send non-hex prefixes; if it does we'd rather lose
+        // data than spin in a parse loop.
+        this.buf = Buffer.alloc(0);
+        return frames;
+      }
+      if (this.buf.length < 4 + len) break;
+      frames.push(this.buf.subarray(4, 4 + len).toString('utf8'));
+      this.buf = this.buf.subarray(4 + len);
+    }
+    return frames;
+  }
+}
+
+const DEFAULT_RING_CAPACITY = 64;
+const RESTART_BACKOFF_MS = 1000;
+const MAX_BACKOFF_MS = 30_000;
+
+/**
+ * Long-lived subscriber to `adb track-devices`. Each device-list change is
+ * diffed into transitions, recorded to `device_events`, and kept in an
+ * in-memory ring so callers (e.g. the "no device connected" error handler)
+ * can show last-seen state without a DB round-trip.
+ *
+ * Subprocess death is handled with exponential backoff; the observer stays
+ * resilient to `adb kill-server` and similar host-side accidents.
+ */
+export class DeviceObserver {
+  private proc: ChildProcess | null = null;
+  private decoder = new FrameDecoder();
+  private prev: DeviceSnapshot[] = [];
+  private ring: DeviceTransition[] = [];
+  private subscribers: Array<(t: DeviceTransition) => void> = [];
+  private stopping = false;
+  private restartTimer: NodeJS.Timeout | null = null;
+  private backoffMs = RESTART_BACKOFF_MS;
+
+  constructor(
+    private readonly adbPath: string = 'adb',
+    private readonly ringCapacity: number = DEFAULT_RING_CAPACITY
+  ) {}
+
+  start(): void {
+    if (this.proc || this.stopping) return;
+    this.spawn();
+  }
+
+  async stop(): Promise<void> {
+    this.stopping = true;
+    if (this.restartTimer) {
+      clearTimeout(this.restartTimer);
+      this.restartTimer = null;
+    }
+    const proc = this.proc;
+    this.proc = null;
+    if (!proc) return;
+    proc.kill('SIGTERM');
+    await new Promise<void>((resolve) => {
+      const t = setTimeout(() => {
+        proc.kill('SIGKILL');
+        resolve();
+      }, 1000);
+      proc.once('exit', () => {
+        clearTimeout(t);
+        resolve();
+      });
+    });
+  }
+
+  /** Subscribe to live transitions. Returns an unsubscribe function. */
+  onTransition(fn: (t: DeviceTransition) => void): () => void {
+    this.subscribers.push(fn);
+    return () => {
+      const i = this.subscribers.indexOf(fn);
+      if (i >= 0) this.subscribers.splice(i, 1);
+    };
+  }
+
+  /** Most recent N transitions, newest first. */
+  getRecent(limit = 32): DeviceTransition[] {
+    return this.ring.slice(-limit).reverse();
+  }
+
+  /**
+   * Last transition for a specific serial, or null if we've never seen it.
+   * Used by ensureDevice's enriched error to answer "where did the device go?"
+   */
+  getLastSeen(serial: string): DeviceTransition | null {
+    for (let i = this.ring.length - 1; i >= 0; i--) {
+      if (this.ring[i].serial === serial) return this.ring[i];
+    }
+    return null;
+  }
+
+  /** Last detach (new_state=null) for any serial — useful when no device is currently attached. */
+  getMostRecentDetach(): DeviceTransition | null {
+    for (let i = this.ring.length - 1; i >= 0; i--) {
+      if (this.ring[i].new_state === null) return this.ring[i];
+    }
+    return null;
+  }
+
+  private spawn(): void {
+    log.info({ adb: this.adbPath }, 'starting device observer');
+    const proc = spawn(this.adbPath, ['track-devices'], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    this.proc = proc;
+
+    proc.stdout.on('data', (chunk: Buffer) => this.handleChunk(chunk));
+    proc.stderr.on('data', (chunk: Buffer) => {
+      const text = chunk.toString('utf8').trim();
+      if (text) log.warn({ stderr: text }, 'adb track-devices stderr');
+    });
+    proc.on('error', (err) => log.warn({ err }, 'adb track-devices spawn error'));
+    proc.on('exit', (code, signal) => {
+      this.proc = null;
+      this.decoder = new FrameDecoder();
+      if (this.stopping) return;
+      log.warn({ code, signal }, 'adb track-devices exited; scheduling restart');
+      this.restartTimer = setTimeout(() => {
+        this.restartTimer = null;
+        this.backoffMs = Math.min(this.backoffMs * 2, MAX_BACKOFF_MS);
+        this.spawn();
+      }, this.backoffMs);
+    });
+
+    // Reset backoff once we've successfully read the first frame (in handleChunk).
+  }
+
+  private handleChunk(chunk: Buffer): void {
+    const frames = this.decoder.push(chunk);
+    if (frames.length === 0) return;
+    this.backoffMs = RESTART_BACKOFF_MS;
+
+    for (const frame of frames) {
+      const next = parseTrackDevicesPayload(frame);
+      const ts = new Date();
+      const transitions = diffSnapshots(this.prev, next, ts);
+      this.prev = next;
+      for (const t of transitions) this.emit(t);
+    }
+  }
+
+  private emit(t: DeviceTransition): void {
+    this.ring.push(t);
+    if (this.ring.length > this.ringCapacity) this.ring.shift();
+
+    log.info(
+      { serial: t.serial, prev_state: t.prev_state, new_state: t.new_state },
+      'device transition'
+    );
+
+    const traceId = getTraceId();
+    void recordDeviceEvent({
+      trace_id: traceId ?? null,
+      layer: 'adb',
+      serial: t.serial,
+      state: t.new_state,
+      raw: { prev_state: t.prev_state, new_state: t.new_state },
+      occurred_at: t.ts,
+    });
+
+    for (const sub of this.subscribers) {
+      try {
+        sub(t);
+      } catch (err) {
+        log.warn({ err }, 'device transition subscriber threw');
+      }
+    }
+  }
+}

--- a/src/adb/device-observer.ts
+++ b/src/adb/device-observer.ts
@@ -194,6 +194,14 @@ export class DeviceObserver {
   }
 
   private spawn(): void {
+    // Guard against two races:
+    //   1. `stop()` flips `stopping=true` and clearTimeout's the restart timer,
+    //      but a timer that has already fired sits queued in the event loop and
+    //      its callback would still call us.
+    //   2. `start()` is called while a restart is pending (proc is null because
+    //      the subprocess died); the pending timer would then race a second spawn.
+    // Re-checking here closes both.
+    if (this.stopping || this.proc) return;
     log.info({ adb: this.adbPath }, 'starting device observer');
     const proc = spawn(this.adbPath, ['track-devices'], {
       stdio: ['ignore', 'pipe', 'pipe'],

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { DeviceManager } from './adb/device-manager.js';
+import { DeviceObserver } from './adb/device-observer.js';
 import { createMcpServer } from './server.js';
 import { UpstreamProxy, parseUpstreamConfig } from './mcp/upstream-proxy.js';
 import { logger } from './log/logger.js';
@@ -12,11 +13,14 @@ import { closePool } from './db/pool.js';
 const log = logger.child({ component: 'server' });
 
 const deviceManager = new DeviceManager();
+const deviceObserver = new DeviceObserver(process.env.ADB_PATH);
+deviceManager.setObserver(deviceObserver);
 const upstreamProxy = new UpstreamProxy();
 const { server: mcpServer, nativeToolNames } = createMcpServer(deviceManager, upstreamProxy);
 
 const shutdown = async () => {
   log.info('shutting down');
+  await deviceObserver.stop().catch(() => {});
   await upstreamProxy.closeAll().catch(() => {});
   await closePool();
   process.exit(0);
@@ -112,6 +116,7 @@ async function start(): Promise<void> {
   });
 
   await initDevice();
+  deviceObserver.start();
   await initUpstreamProxy();
   installCallRecording(mcpServer, upstreamProxy);
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -89,6 +89,28 @@ export function createMcpServer(
   );
 
   mcpServer.tool(
+    'device_event_log',
+    'Recent device-attach/detach/state-change transitions observed by the built-in `adb track-devices` listener. Useful when a tool just failed with "No Android devices connected" — the log answers when the device left and what state it was in. The observer also writes each transition to the `device_events` table when DATABASE_URL is set.',
+    {
+      limit: z.number().optional().default(32).describe('Max transitions to return (newest first, default 32)'),
+      serial: z.string().optional().describe('Filter to a specific serial'),
+    },
+    async ({ limit, serial }) => {
+      const observer = deviceManager.getObserver();
+      if (!observer) {
+        return {
+          content: [{ type: 'text', text: JSON.stringify({ events: [], note: 'Device observer is not attached to this server' }, null, 2) }],
+        };
+      }
+      let events = observer.getRecent(limit);
+      if (serial) events = events.filter(e => e.serial === serial);
+      return {
+        content: [{ type: 'text', text: JSON.stringify({ count: events.length, events }, null, 2) }],
+      };
+    }
+  );
+
+  mcpServer.tool(
     'device_info',
     'Get detailed information about the selected Android device',
     {},

--- a/tests/unit/device-observer.test.mjs
+++ b/tests/unit/device-observer.test.mjs
@@ -1,0 +1,159 @@
+/**
+ * Unit tests for src/adb/device-observer.ts pure helpers + the framer.
+ *
+ * Run with: npm run test:unit
+ * Requires: npm run build
+ *
+ * Subprocess + DB integration is verified manually with a real device — see
+ * the PR's "End-to-end verification" section.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  parseTrackDevicesPayload,
+  diffSnapshots,
+  FrameDecoder,
+} from '../../dist/adb/device-observer.js';
+
+// ============ parseTrackDevicesPayload ============
+
+test('parse: empty string → no devices', () => {
+  assert.deepEqual(parseTrackDevicesPayload(''), []);
+});
+
+test('parse: single device line', () => {
+  assert.deepEqual(parseTrackDevicesPayload('R5CR12ATMCB\tdevice\n'), [
+    { serial: 'R5CR12ATMCB', state: 'device' },
+  ]);
+});
+
+test('parse: multiple devices', () => {
+  const payload = 'R5CR12ATMCB\tdevice\nemulator-5554\tdevice\n';
+  assert.deepEqual(parseTrackDevicesPayload(payload), [
+    { serial: 'R5CR12ATMCB', state: 'device' },
+    { serial: 'emulator-5554', state: 'device' },
+  ]);
+});
+
+test('parse: handles unauthorized + offline + recovery states', () => {
+  const payload = 'A\tunauthorized\nB\toffline\nC\trecovery\n';
+  assert.deepEqual(parseTrackDevicesPayload(payload), [
+    { serial: 'A', state: 'unauthorized' },
+    { serial: 'B', state: 'offline' },
+    { serial: 'C', state: 'recovery' },
+  ]);
+});
+
+test('parse: skips lines without a tab', () => {
+  assert.deepEqual(parseTrackDevicesPayload('garbage\nA\tdevice\n'), [
+    { serial: 'A', state: 'device' },
+  ]);
+});
+
+test('parse: tolerates trailing whitespace', () => {
+  assert.deepEqual(parseTrackDevicesPayload('A\tdevice  \n'), [
+    { serial: 'A', state: 'device' },
+  ]);
+});
+
+// ============ diffSnapshots ============
+
+const ts = new Date('2026-05-03T03:00:00Z');
+
+test('diff: identical snapshots → no transitions', () => {
+  const s = [{ serial: 'A', state: 'device' }];
+  assert.deepEqual(diffSnapshots(s, s, ts), []);
+});
+
+test('diff: new device appearing', () => {
+  const out = diffSnapshots([], [{ serial: 'A', state: 'device' }], ts);
+  assert.deepEqual(out, [
+    { serial: 'A', prev_state: null, new_state: 'device', ts },
+  ]);
+});
+
+test('diff: device disappearing', () => {
+  const out = diffSnapshots([{ serial: 'A', state: 'device' }], [], ts);
+  assert.deepEqual(out, [
+    { serial: 'A', prev_state: 'device', new_state: null, ts },
+  ]);
+});
+
+test('diff: state change is one transition', () => {
+  const out = diffSnapshots(
+    [{ serial: 'A', state: 'unauthorized' }],
+    [{ serial: 'A', state: 'device' }],
+    ts
+  );
+  assert.deepEqual(out, [
+    { serial: 'A', prev_state: 'unauthorized', new_state: 'device', ts },
+  ]);
+});
+
+test('diff: simultaneous add + remove + change', () => {
+  const prev = [
+    { serial: 'A', state: 'device' },
+    { serial: 'B', state: 'unauthorized' },
+  ];
+  const next = [
+    { serial: 'B', state: 'device' },
+    { serial: 'C', state: 'device' },
+  ];
+  const out = diffSnapshots(prev, next, ts);
+  // Order: present-in-next (changed B, new C), then absent-in-next (gone A).
+  assert.deepEqual(out, [
+    { serial: 'B', prev_state: 'unauthorized', new_state: 'device', ts },
+    { serial: 'C', prev_state: null, new_state: 'device', ts },
+    { serial: 'A', prev_state: 'device', new_state: null, ts },
+  ]);
+});
+
+// ============ FrameDecoder ============
+
+function encode(payload) {
+  const len = Buffer.byteLength(payload, 'utf8').toString(16).padStart(4, '0');
+  return Buffer.concat([Buffer.from(len, 'ascii'), Buffer.from(payload, 'utf8')]);
+}
+
+test('framer: decodes a complete single frame', () => {
+  const fd = new FrameDecoder();
+  const out = fd.push(encode('R5CR12ATMCB\tdevice\n'));
+  assert.deepEqual(out, ['R5CR12ATMCB\tdevice\n']);
+});
+
+test('framer: decodes multiple frames in one chunk', () => {
+  const fd = new FrameDecoder();
+  const out = fd.push(Buffer.concat([encode('A\tdevice\n'), encode('B\toffline\n')]));
+  assert.deepEqual(out, ['A\tdevice\n', 'B\toffline\n']);
+});
+
+test('framer: handles partial reads (length prefix split)', () => {
+  const fd = new FrameDecoder();
+  const enc = encode('A\tdevice\n');
+  // Split mid-prefix.
+  assert.deepEqual(fd.push(enc.subarray(0, 2)), []);
+  assert.deepEqual(fd.push(enc.subarray(2)), ['A\tdevice\n']);
+});
+
+test('framer: handles partial reads (payload split)', () => {
+  const fd = new FrameDecoder();
+  const enc = encode('A\tdevice\n');
+  // Split mid-payload.
+  assert.deepEqual(fd.push(enc.subarray(0, 7)), []);
+  assert.deepEqual(fd.push(enc.subarray(7)), ['A\tdevice\n']);
+});
+
+test('framer: handles empty payload (no devices)', () => {
+  const fd = new FrameDecoder();
+  const out = fd.push(Buffer.from('0000', 'ascii'));
+  assert.deepEqual(out, ['']);
+});
+
+test('framer: drops corrupt non-hex prefix and resyncs on next chunk', () => {
+  const fd = new FrameDecoder();
+  // Corrupt — non-hex chars in the prefix slot.
+  fd.push(Buffer.from('zzzz', 'ascii'));
+  // After the drop, a clean frame should decode normally.
+  const out = fd.push(encode('A\tdevice\n'));
+  assert.deepEqual(out, ['A\tdevice\n']);
+});


### PR DESCRIPTION
## Summary

Wires up the `adb track-devices` subscription #49 asked for. Transitions land in `device_events` (when `DATABASE_URL` is set), in an in-memory ring, and — critically — in the "No Android devices connected" error message itself, which now names the last serial, the prior state, the timestamp, and a hint pointing at the most likely cause.

Closes #49.

## The pain (recap)

From #49: when a device disappears mid-session, every tool returns a flat *"No Android devices connected. Please connect a device with USB debugging enabled."* That tells the agent *nothing* about whether the device left 2 seconds ago or 2 hours ago, what its last-known state was, or whether the disconnect was a flaky cable vs. RSA revocation vs. emulator death. The reporter had to fall back to host-side probing (`lsusb`, `pgrep emulator`, `adb kill-server`, etc.) just to guess at which class of failure happened.

## What's in

- **`src/adb/device-observer.ts`** — `DeviceObserver` class. Spawns `adb track-devices`, decodes the length-prefixed stream, diffs successive snapshots into per-device transitions, records to `device_events`, keeps the last 64 in a ring, exposes `onTransition` / `getRecent` / `getLastSeen` / `getMostRecentDetach`. Subprocess death triggers exponential-backoff restart (1s → 30s cap), so `adb kill-server` doesn't permanently break the observer. Pure helpers (`parseTrackDevicesPayload`, `diffSnapshots`, `FrameDecoder`) are exported for unit testing.
- **`src/adb/device-manager.ts`** — `setObserver` / `getObserver` accessors. `ensureDeviceSelected` formats an enriched error using the observer's most-recent detach:
  > *"No Android devices connected. ... Last seen: R5CR12ATMCB left 'device' state 47s ago (at 2026-05-03T05:14:23Z). Hint: depending on the prior state — 'device' suggests physical disconnect, USB autosuspend, or device sleep; 'unauthorized' suggests RSA revocation; 'offline' suggests adb-server confusion or emulator death. Use device_event_log for the full transition history."*
- **`src/server.ts`** — new tool `device_event_log` returning the ring buffer. Native count: **30 → 31**.
- **`src/index.ts`** — `DeviceObserver` instantiated at startup, attached to `DeviceManager`, `observer.start()` after `initDevice()`, `observer.stop()` on shutdown.
- **README + CLAUDE.md** — new tool row, count bumps (31 native, 52 with `@playwright/mcp`), Phase 3a entry in the architecture map.

## Tests

- 17 new unit cases (86 total) cover:
  - **Parser**: single/multiple devices, empty payload, various states, no-tab lines, trailing whitespace.
  - **Snapshot differ**: no-op, add, remove, state-change, simultaneous mixed transitions.
  - **Framer**: single/multiple frames in one chunk, partial reads on prefix and payload, empty payload, corrupt-prefix recovery.
- Smoke 13/13 ✅ · Proxy 3/3 ✅ · Unit 86/86 ✅
- Live verification: server start with device attached → `device-observer` log line `prev_state:null,new_state:device` + matching `device_events` row + `device_event_log` tool returns the transition.

## Out of scope (deferred)

- **udev subscription.** Per-USB-controller kernel-level signals (autosuspend, controller resets) live there. `adb track-devices` already covers host-visible state transitions, which is what #49 cared about. udev would help Phase 4 distinguish "USB autosuspend" from "explicit unplug", but that classification is genuinely Phase 4.
- **Structured `DeviceUnavailableError`.** Right now the enriched error is a single human-readable string. Tools that want structured retry decisions can call `device_event_log` directly. A typed error class with extra fields is doable but touches every tool handler — separate PR if anyone needs it.
- **Trace correlation on `device_events`.** Transitions emit outside any tool-call ALS so `device_events.trace_id` is null. Phase 4 will correlate by `(serial, time)` anyway.

## Test plan

- [ ] `npm run test:unit` passes.
- [ ] `cd cicd/tests && npm test -- --suite smoke` passes (no regressions).
- [ ] With a device attached and `DATABASE_URL` set, server start → row in `device_events` with `state=device`, `prev_state=null` in the `raw` JSON.
- [ ] `device_event_log` tool returns the transition.
- [ ] Unplug device → row appears with `state=null` (in `raw`, `new_state=null`).
- [ ] Subsequent tool call → error message includes the last-seen line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)