### PR TITLE
Follow-ups for #55 and #58 (review polish + integration tests)

### DIFF
--- a/src/db/writer.ts
+++ b/src/db/writer.ts
@@ -1,7 +1,29 @@
 import { getPool } from './pool.js';
 import { logger } from '../log/logger.js';
+import type { Attribution } from '../log/attribution.js';
 
 const log = logger.child({ component: 'db.writer' });
+
+/**
+ * Shape of the `tool_calls.error` JSONB column. Two variants — one for
+ * thrown exceptions, one for tools that returned `{ isError: true, ... }`
+ * — both optionally carrying a Phase 4 attribution. Documented here so
+ * Phase 5's query_log and any downstream consumer have a typed reference.
+ */
+export type ToolCallErrorThrown = {
+  source: 'thrown';
+  message: string;
+  name: string;
+  attribution?: Attribution;
+};
+
+export type ToolCallErrorToolResult = {
+  source: 'tool_result';
+  content: unknown;
+  attribution?: Attribution;
+};
+
+export type ToolCallError = ToolCallErrorThrown | ToolCallErrorToolResult;
 
 export interface ToolCallRecord {
   call_id?: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,8 +6,7 @@ import { createMcpServer } from './server.js';
 import { UpstreamProxy, parseUpstreamConfig } from './mcp/upstream-proxy.js';
 import { logger } from './log/logger.js';
 import { installCallRecording } from './log/middleware.js';
-import { parseTraceparent } from './log/traceparent.js';
-import { runWithTraceContext, newTraceContext } from './log/trace-context.js';
+import { runWithTraceContext, establishTraceContext } from './log/trace-context.js';
 import { closePool } from './db/pool.js';
 
 const log = logger.child({ component: 'server' });
@@ -62,16 +61,7 @@ async function start(): Promise<void> {
     // when present, otherwise mint a fresh one. Everything downstream
     // (middleware → tool_calls.trace_id, pino mixin → log lines) reads it
     // from AsyncLocalStorage.
-    const tp = req.header('traceparent');
-    const parsed = parseTraceparent(tp);
-    const ctx = parsed
-      ? {
-          trace_id: parsed.trace_id,
-          parent_id: parsed.parent_id,
-          trace_flags: parsed.trace_flags,
-          sampled: parsed.sampled,
-        }
-      : newTraceContext();
+    const ctx = establishTraceContext(req);
 
     await runWithTraceContext(ctx, async () => {
       try {

--- a/src/log/attribution.ts
+++ b/src/log/attribution.ts
@@ -40,9 +40,18 @@ export interface Attribution {
 const PRE_WINDOW_MS = 5000;
 const POST_WINDOW_MS = 1000;
 
+/**
+ * How many recent events the middleware should pull from the observer
+ * ring before passing them to the classifier. Co-located with the time
+ * window so high-churn scenarios (e.g. an emulator flapping at ~100ms
+ * cadence) don't silently fall outside the count. 64 matches the
+ * default ring capacity in DeviceObserver — exhaustive by construction.
+ */
+export const RECENT_EVENTS_LIMIT = 64;
+
 interface CallWindow {
   started_at: Date;
-  completed_at: Date | null;
+  completed_at: Date;
 }
 
 /**
@@ -59,7 +68,7 @@ export function attributeFailure(
   if (events.length === 0) return null;
 
   const startMs = call.started_at.getTime() - PRE_WINDOW_MS;
-  const endMs = (call.completed_at ?? new Date()).getTime() + POST_WINDOW_MS;
+  const endMs = call.completed_at.getTime() + POST_WINDOW_MS;
 
   // Events are newest-first as returned by DeviceObserver.getRecent.
   const related = events.find((e) => {

--- a/src/log/logger.ts
+++ b/src/log/logger.ts
@@ -13,14 +13,16 @@ const stream =
 // `mixin` runs on every log line and returns extra fields to merge.
 // We use it to inject the active trace context (set by the express layer
 // via runWithTraceContext) so any log emitted while a tool call is
-// in-flight is automatically tagged.
+// in-flight is automatically tagged. Only `trace_id` is emitted —
+// `sampled` is informational and never queried, so dropping it keeps
+// log lines tighter without losing any join key for query_log.
 export const logger: Logger = pino(
   {
     level,
     mixin: () => {
       const ctx = getTraceContext();
       if (!ctx) return {};
-      return { trace_id: ctx.trace_id, sampled: ctx.sampled };
+      return { trace_id: ctx.trace_id };
     },
   },
   stream

--- a/src/log/middleware.ts
+++ b/src/log/middleware.ts
@@ -1,11 +1,10 @@
-import { randomUUID } from 'node:crypto';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { recordToolCall, type ToolCallRecord } from '../db/writer.js';
 import { redactArgs } from './redact.js';
-import { attributeFailure, type RelatedEvent } from './attribution.js';
+import { attributeFailure, RECENT_EVENTS_LIMIT, type RelatedEvent } from './attribution.js';
 import { logger } from './logger.js';
-import { getTraceId } from './trace-context.js';
+import { getTraceId, newTraceContext } from './trace-context.js';
 import type { UpstreamProxy } from '../mcp/upstream-proxy.js';
 
 const log = logger.child({ component: 'middleware' });
@@ -42,9 +41,10 @@ export function buildRecordingHandler(
     const startedAt = new Date();
     // Trace id comes from the ALS-stored context (set by the express layer
     // from incoming traceparent or freshly generated). Falls back to a
-    // randomUUID only when called outside any HTTP request — primarily a
-    // unit-test convenience.
-    const traceId = getTraceId() ?? randomUUID();
+    // freshly-minted W3C-format trace id when called outside any HTTP
+    // request — primarily a unit-test convenience. Format matches
+    // newTraceContext so rows from both paths look identical in queries.
+    const traceId = getTraceId() ?? newTraceContext().trace_id;
 
     let result: unknown;
     let errorPayload: Record<string, unknown> | undefined;
@@ -80,7 +80,7 @@ export function buildRecordingHandler(
       // genuinely related event in the failure window; tool-internal errors
       // (bad args, timeouts, etc.) leave the column unset.
       if (errorPayload && observer) {
-        const events = observer.getRecent(32);
+        const events = observer.getRecent(RECENT_EVENTS_LIMIT);
         const attribution = attributeFailure(
           { started_at: startedAt, completed_at: completedAt },
           events
@@ -114,7 +114,8 @@ export function buildRecordingHandler(
 export function installCallRecording(
   mcpServer: McpServer,
   proxy?: UpstreamProxy,
-  observer?: RecentEventsSource
+  observer?: RecentEventsSource,
+  recorder: Recorder = recordToolCall
 ): void {
   const server = mcpServer.server;
   const handlers = (server as any)._requestHandlers as Map<string, ToolsCallHandler>;
@@ -126,7 +127,7 @@ export function installCallRecording(
   }
   server.setRequestHandler(
     CallToolRequestSchema,
-    buildRecordingHandler(original, proxy, recordToolCall, observer)
+    buildRecordingHandler(original, proxy, recorder, observer)
   );
 }
 /* eslint-enable @typescript-eslint/no-explicit-any */

--- a/src/log/trace-context.ts
+++ b/src/log/trace-context.ts
@@ -1,5 +1,6 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { randomBytes } from 'node:crypto';
+import { parseTraceparent } from './traceparent.js';
 
 /**
  * Per-request trace context, propagated via AsyncLocalStorage so deep callees
@@ -13,8 +14,18 @@ import { randomBytes } from 'node:crypto';
  */
 export interface TraceContext {
   trace_id: string;
-  parent_id: string | null;
+  /**
+   * W3C parent-span-id (16 hex chars, see traceparent spec).
+   * NOT to be confused with `tool_calls.parent_call_id` in the schema, which
+   * is the parent *tool call*'s UUID — a different concept entirely.
+   */
+  parent_span_id: string | null;
   trace_flags: string;
+  /**
+   * W3C sampling flag, parsed from `trace_flags`. We always record regardless
+   * — sampled is informational only, kept on the context so future export to
+   * an OTel collector preserves the upstream caller's decision.
+   */
   sampled: boolean;
 }
 
@@ -35,12 +46,34 @@ export function getTraceId(): string | undefined {
 /**
  * Build a fresh trace context — used when no traceparent header is present.
  * trace_id is 32 hex chars (W3C format, also accepted by Postgres uuid type).
+ *
+ * `sampled` is always true on freshly-minted contexts: this server is the
+ * trace origin in that case, so there's no upstream sampling decision to
+ * honor. The flag is informational; we always record.
  */
 export function newTraceContext(): TraceContext {
   return {
     trace_id: randomBytes(16).toString('hex'),
-    parent_id: null,
+    parent_span_id: null,
     trace_flags: '01',
     sampled: true,
+  };
+}
+
+/**
+ * Build the per-request trace context from an incoming HTTP request.
+ * Honors a valid `traceparent` header when present, otherwise mints a
+ * fresh context. Exported (rather than living inline in src/index.ts) so
+ * the express → ALS wiring has a unit-testable seam.
+ */
+export function establishTraceContext(req: { header(name: string): string | undefined }): TraceContext {
+  const tp = req.header('traceparent');
+  const parsed = parseTraceparent(tp);
+  if (!parsed) return newTraceContext();
+  return {
+    trace_id: parsed.trace_id,
+    parent_span_id: parsed.parent_id,
+    trace_flags: parsed.trace_flags,
+    sampled: parsed.sampled,
   };
 }

--- a/tests/unit/attribution.test.mjs
+++ b/tests/unit/attribution.test.mjs
@@ -33,6 +33,26 @@ test('attribution: event before window → null', () => {
   assert.equal(attributeFailure(call, events), null);
 });
 
+test('attribution: event exactly at the pre-window edge classifies (inclusive)', () => {
+  // PRE_WINDOW_MS is 5000; spec is `>= startMs && <= endMs` (inclusive).
+  const tsExactEdge = new Date(tsCallStart.getTime() - 5000);
+  const events = [
+    { serial: 'A', prev_state: 'device', new_state: null, ts: tsExactEdge },
+  ];
+  assert.equal(
+    attributeFailure(call, events)?.classification,
+    'physical_disconnect'
+  );
+});
+
+test('attribution: 1ms past the pre-window edge → null', () => {
+  const tsJustOutside = new Date(tsCallStart.getTime() - 5001);
+  const events = [
+    { serial: 'A', prev_state: 'device', new_state: null, ts: tsJustOutside },
+  ];
+  assert.equal(attributeFailure(call, events), null);
+});
+
 test('attribution: event in pre-window classifies', () => {
   const events = [
     { serial: 'A', prev_state: 'device', new_state: null, ts: tsInWindow },

--- a/tests/unit/integration.test.mjs
+++ b/tests/unit/integration.test.mjs
@@ -1,0 +1,143 @@
+/**
+ * Integration tests that close the seams flagged in #55 and #58: the
+ * unit suite covers the pure parser / ALS / classifier / middleware
+ * builder in isolation, but nothing exercised the *composition* —
+ * the wrap that `installCallRecording` does on a live McpServer, with
+ * the trace context flowing through from `runWithTraceContext`. A
+ * regression where the wiring drops one of those pieces would have
+ * been silent before.
+ *
+ * These tests stand up a real McpServer, register a fake tool, install
+ * the recording layer with a captured recorder, dispatch a call through
+ * the SDK's internal request-handler map, and assert the recorded row.
+ *
+ * Note on failure modes: when a tool's handler throws, the SDK catches
+ * it and returns `{ isError: true, content: [{ type:'text', text }] }`.
+ * Our middleware sees a normal result with `isError === true`, not a
+ * thrown exception — so failed-call rows always have
+ * `error.source === 'tool_result'` regardless of whether the underlying
+ * handler threw or returned the failure shape. The 'thrown' branch
+ * fires for higher-level errors (proxy network failures, unknown tool
+ * names) which aren't reachable from this seam-level test.
+ *
+ * Run with: npm run test:unit
+ * Requires: npm run build
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { installCallRecording } from '../../dist/log/middleware.js';
+import { runWithTraceContext } from '../../dist/log/trace-context.js';
+
+function dispatchHandler(server) {
+  // The wrapped handler installCallRecording sets is stored on the inner
+  // Server's private _requestHandlers map. We grab it directly so the test
+  // doesn't depend on JSON-RPC framing.
+  return server.server._requestHandlers.get('tools/call');
+}
+
+function callRequest(name, args = {}) {
+  return { method: 'tools/call', params: { name, arguments: args } };
+}
+
+const ctxFromHeader = {
+  trace_id: '0af7651916cd43dd8448eb211c80319c',
+  parent_span_id: 'b7ad6b7169203331',
+  trace_flags: '01',
+  sampled: true,
+};
+
+test('integration: trace_id from ALS flows through installCallRecording → recorder', async () => {
+  const recorded = [];
+  const server = new McpServer({ name: 'test', version: '1.0.0' });
+  server.tool('echo', 'echo', {}, async () => ({ content: [{ type: 'text', text: 'ok' }] }));
+
+  installCallRecording(server, undefined, undefined, async (c) => recorded.push(c));
+
+  await runWithTraceContext(ctxFromHeader, () =>
+    dispatchHandler(server)(callRequest('echo'), {})
+  );
+
+  assert.equal(recorded.length, 1);
+  assert.equal(recorded[0].trace_id, ctxFromHeader.trace_id);
+  assert.equal(recorded[0].tool_name, 'echo');
+  assert.equal(recorded[0].surface, 'native');
+});
+
+test('integration: missing ALS context → fallback trace_id is W3C 32-hex', async () => {
+  const recorded = [];
+  const server = new McpServer({ name: 'test', version: '1.0.0' });
+  server.tool('echo', 'echo', {}, async () => ({ content: [{ type: 'text', text: 'ok' }] }));
+
+  installCallRecording(server, undefined, undefined, async (c) => recorded.push(c));
+
+  // No runWithTraceContext wrap — middleware should mint a fallback id.
+  await dispatchHandler(server)(callRequest('echo'), {});
+
+  assert.match(recorded[0].trace_id, /^[0-9a-f]{32}$/);
+});
+
+test('integration: failing tool + observer → attribution attached', async () => {
+  const recorded = [];
+  const server = new McpServer({ name: 'test', version: '1.0.0' });
+  // The SDK catches this throw and returns { isError: true, ... }, so the
+  // middleware sees a tool_result-shaped failure. That's the realistic path.
+  server.tool('failing', 'fails', {}, async () => {
+    throw new Error('simulated handler failure');
+  });
+
+  const observer = {
+    getRecent: () => [
+      { serial: 'A', prev_state: 'device', new_state: null, ts: new Date() },
+    ],
+  };
+
+  installCallRecording(server, undefined, observer, async (c) => recorded.push(c));
+
+  const result = await dispatchHandler(server)(callRequest('failing'), {});
+  assert.equal(result.isError, true);
+  assert.equal(recorded.length, 1);
+
+  const err = recorded[0].error;
+  assert.equal(err.source, 'tool_result');
+  assert.equal(err.attribution.classification, 'physical_disconnect');
+  assert.equal(err.attribution.related_event.serial, 'A');
+});
+
+test('integration: no observer → no attribution even on failure', async () => {
+  const recorded = [];
+  const server = new McpServer({ name: 'test', version: '1.0.0' });
+  server.tool('failing', 'fails', {}, async () => {
+    throw new Error('boom');
+  });
+
+  installCallRecording(server, undefined, undefined, async (c) => recorded.push(c));
+
+  await dispatchHandler(server)(callRequest('failing'), {});
+
+  assert.equal(recorded[0].error.source, 'tool_result');
+  assert.equal(recorded[0].error.attribution, undefined);
+});
+
+test('integration: trace_id and attribution co-exist on a failed call', async () => {
+  const recorded = [];
+  const server = new McpServer({ name: 'test', version: '1.0.0' });
+  server.tool('failing', 'fails', {}, async () => {
+    throw new Error('boom');
+  });
+
+  const observer = {
+    getRecent: () => [
+      { serial: 'A', prev_state: 'unauthorized', new_state: null, ts: new Date() },
+    ],
+  };
+
+  installCallRecording(server, undefined, observer, async (c) => recorded.push(c));
+
+  await runWithTraceContext(ctxFromHeader, () =>
+    dispatchHandler(server)(callRequest('failing'), {})
+  );
+
+  assert.equal(recorded[0].trace_id, ctxFromHeader.trace_id);
+  assert.equal(recorded[0].error.attribution.classification, 'rsa_revoked');
+});

--- a/tests/unit/trace-context.test.mjs
+++ b/tests/unit/trace-context.test.mjs
@@ -10,18 +10,20 @@ import {
   runWithTraceContext,
   getTraceContext,
   getTraceId,
+  newTraceContext,
+  establishTraceContext,
 } from '../../dist/log/trace-context.js';
 
 const ctxA = {
   trace_id: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-  parent_id: '1111111111111111',
+  parent_span_id: '1111111111111111',
   trace_flags: '01',
   sampled: true,
 };
 
 const ctxB = {
   trace_id: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
-  parent_id: '2222222222222222',
+  parent_span_id: '2222222222222222',
   trace_flags: '00',
   sampled: false,
 };
@@ -71,4 +73,63 @@ test('trace-context: nested runs shadow then restore', () => {
     // After the inner run, outer ctx is back.
     assert.equal(getTraceId(), ctxA.trace_id);
   });
+});
+
+// ============ newTraceContext ============
+
+test('newTraceContext: trace_id is 32 hex chars (W3C format)', () => {
+  const ctx = newTraceContext();
+  assert.match(ctx.trace_id, /^[0-9a-f]{32}$/);
+});
+
+test('newTraceContext: parent_span_id is null on a freshly-minted context', () => {
+  assert.equal(newTraceContext().parent_span_id, null);
+});
+
+test('newTraceContext: always sampled (server is the trace origin)', () => {
+  const ctx = newTraceContext();
+  assert.equal(ctx.sampled, true);
+  assert.equal(ctx.trace_flags, '01');
+});
+
+test('newTraceContext: produces a new trace_id each call', () => {
+  const a = newTraceContext().trace_id;
+  const b = newTraceContext().trace_id;
+  assert.notEqual(a, b);
+});
+
+// ============ establishTraceContext ============
+
+const VALID_TP = '00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01';
+
+test('establishTraceContext: honors a valid traceparent header', () => {
+  const req = { header: (n) => (n === 'traceparent' ? VALID_TP : undefined) };
+  const ctx = establishTraceContext(req);
+  assert.equal(ctx.trace_id, '0af7651916cd43dd8448eb211c80319c');
+  assert.equal(ctx.parent_span_id, 'b7ad6b7169203331');
+  assert.equal(ctx.trace_flags, '01');
+  assert.equal(ctx.sampled, true);
+});
+
+test('establishTraceContext: missing header → fresh context', () => {
+  const req = { header: () => undefined };
+  const ctx = establishTraceContext(req);
+  assert.match(ctx.trace_id, /^[0-9a-f]{32}$/);
+  assert.equal(ctx.parent_span_id, null);
+});
+
+test('establishTraceContext: malformed header → fresh context', () => {
+  const req = { header: () => 'garbage' };
+  const ctx = establishTraceContext(req);
+  // Did not adopt the bogus value; minted fresh.
+  assert.match(ctx.trace_id, /^[0-9a-f]{32}$/);
+  assert.notEqual(ctx.trace_id, 'garbage');
+});
+
+test('establishTraceContext: sampled=false from upstream is preserved', () => {
+  const tp = '00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-00';
+  const req = { header: () => tp };
+  const ctx = establishTraceContext(req);
+  assert.equal(ctx.sampled, false);
+  assert.equal(ctx.trace_flags, '00');
 });


### PR DESCRIPTION
## Summary

Cleanup PR addressing the polish + coverage gaps surfaced in the self-reviews of #54 (Phase 1) and #57 (Phase 4). No behavior change beyond field renames, one log-line shrink, and the new integration tests. Single PR because the items overlap (same files, shared seam-regression concern).

Refs #51, #55, #58. Closes the actionable items in #55 and #58.

## Phase 1 follow-ups (#55)

- **`TraceContext.parent_id` → `parent_span_id`** — disambiguates from `tool_calls.parent_call_id` in the schema, which is the parent *tool call* UUID (different concept). Doc comment on the field.
- **Always-sampled semantics documented** — `newTraceContext` doc explains *we are the trace origin when minting a fresh context, so there's no upstream sampling decision to honor.* `sampled` is informational; we always record.
- **Pino mixin drops `sampled`** — only `trace_id` is emitted. Less per-line overhead, no query key lost (sampled was never queried).
- **Uniform fallback trace_id format** — middleware fallback was `randomUUID()` (dashed); now `newTraceContext().trace_id` (32-hex). Rows from both paths look identical.
- **`establishTraceContext(req)`** extracted from `src/index.ts` so the express → ALS wiring has a unit-testable seam.

## Phase 4 follow-ups (#58)

- **`RECENT_EVENTS_LIMIT` exported from `attribution.ts` (=64)**, imported by middleware. Co-located with `PRE_WINDOW_MS` / `POST_WINDOW_MS` so high-churn scenarios don't silently fall outside the count. 64 matches `DeviceObserver` default ring capacity — exhaustive by construction.
- **`CallWindow.completed_at` tightened to `Date`** (was `Date | null`). Dead `?? new Date()` fallback removed — middleware always passes a real `Date`.
- **`ToolCallError` type added** in `src/db/writer.ts` documenting the JSONB shape: `{ source: 'thrown', message, name, attribution? } | { source: 'tool_result', content, attribution? }`. Phase 5's `query_log` will need this.
- **Window-edge boundary tests** — exact `start - 5000ms` matches (inclusive); `start - 5001ms` doesn't.

## Coverage gap closed (both issues)

- **`tests/unit/integration.test.mjs`** — 5 new tests stand up a real `McpServer`, register fake tools, call `installCallRecording` with a custom recorder, dispatch through the SDK's `_requestHandlers` map, and assert `trace_id` + `attribution` land. Closes the "regression to a silently-empty path" risk both issues flagged.
- **`installCallRecording` now takes an optional `recorder` param** so the integration tests can intercept what gets written without needing Postgres.

## Side note from writing the tests

The SDK catches thrown errors inside per-tool handlers and converts them to `{ isError: true, content: [...] }`. Our middleware therefore sees a tool-result-shaped failure regardless of whether the underlying handler threw or returned the failure shape. The `'thrown'` source branch only fires for higher-level errors (proxy network failures, unknown tool names) which aren't reachable from this seam-level test. Documented in the test file header so the next reader doesn't waste time wondering why `assert.rejects` doesn't fire.

## Tests

- **119/119 unit** (15 new) ✅
- **Smoke 13/13** ✅
- **Proxy 3/3** ✅

## Test plan

- [ ] `npm run test:unit` — 119 cases pass.
- [ ] `cd cicd/tests && npm test -- --suite smoke` passes.
- [ ] `npm test -- --suite proxy` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)