### PR TITLE
fix(wifi_connect): poll for L2 association instead of single 3 s sleep

### DIFF
--- a/src/adb/wifi-commands.ts
+++ b/src/adb/wifi-commands.ts
@@ -180,18 +180,27 @@ export class WifiCommands {
       };
     }
 
-    // Wait for connection to establish
-    await new Promise(resolve => setTimeout(resolve, 3000));
+    // Poll for L2 association. `cmd wifi connect-network` returns before
+    // the supplicant has converged, so a single fixed sleep + check
+    // false-negatived on slow associations (DFS scan, marginal RSSI). See #65.
+    const VERIFY_TIMEOUT_MS = 10_000;
+    const POLL_INTERVAL_MS = 500;
+    const deadline = Date.now() + VERIFY_TIMEOUT_MS;
 
-    // Verify connection by checking actual status
-    const status = await this.getStatus();
-    const connected = status.connected && status.ssid === ssid;
-
-    return {
-      success: connected,
-      ssid,
-      error: connected ? undefined : 'Failed to verify connection',
-    };
+    while (true) {
+      const status = await this.getStatus();
+      if (status.connected && status.ssid === ssid) {
+        return { success: true, ssid };
+      }
+      if (Date.now() >= deadline) {
+        return {
+          success: false,
+          ssid,
+          error: 'Failed to verify connection',
+        };
+      }
+      await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL_MS));
+    }
   }
 
   /**

--- a/src/adb/wifi-commands.ts
+++ b/src/adb/wifi-commands.ts
@@ -182,16 +182,49 @@ export class WifiCommands {
 
     // Poll for L2 association. `cmd wifi connect-network` returns before
     // the supplicant has converged, so a single fixed sleep + check
-    // false-negatived on slow associations (DFS scan, marginal RSSI). See #65.
+    // false-negatived on slow associations. See #65.
+    //
+    // Early-bail: once we've seen the supplicant move through an active
+    // state and then settle in a terminal state for two consecutive polls,
+    // the attempt has failed (wrong password, AP rejection, handshake
+    // timeout) — return the supplicant state in the error so the agent
+    // can distinguish failure modes without waiting out the full deadline.
+    // Falls back to the time-based deadline when supplicantState can't
+    // be parsed (older Android variants).
     const VERIFY_TIMEOUT_MS = 10_000;
     const POLL_INTERVAL_MS = 500;
+    const TERMINAL_DEBOUNCE = 2;
+    const TERMINAL_STATES = new Set(['DISCONNECTED', 'INACTIVE', 'INTERFACE_DISABLED']);
     const deadline = Date.now() + VERIFY_TIMEOUT_MS;
+
+    let sawActive = false;
+    let terminalStreak = 0;
 
     while (true) {
       const status = await this.getStatus();
       if (status.connected && status.ssid === ssid) {
         return { success: true, ssid };
       }
+
+      const s = status.supplicantState;
+      if (s) {
+        if (TERMINAL_STATES.has(s)) {
+          if (sawActive) {
+            terminalStreak++;
+            if (terminalStreak >= TERMINAL_DEBOUNCE) {
+              return {
+                success: false,
+                ssid,
+                error: `Connection failed (supplicant state: ${s})`,
+              };
+            }
+          }
+        } else {
+          sawActive = true;
+          terminalStreak = 0;
+        }
+      }
+
       if (Date.now() >= deadline) {
         return {
           success: false,
@@ -356,6 +389,13 @@ export class WifiCommands {
     const freqMatch = dumpsys.match(/Frequency:\s*(\d+)/i);
     if (freqMatch) {
       status.frequency = parseInt(freqMatch[1], 10);
+    }
+
+    // Extract supplicant state from mWifiInfo. Used by connect() for
+    // early-bail when an attempt settles in a terminal state.
+    const suppMatch = dumpsys.match(/Supplicant state:\s*(\w+)/i);
+    if (suppMatch) {
+      status.supplicantState = suppMatch[1];
     }
 
     // L2 association requires more than the radio reporting CONNECTED.

--- a/tests/unit/wifi-connect-verify.test.mjs
+++ b/tests/unit/wifi-connect-verify.test.mjs
@@ -1,0 +1,83 @@
+/**
+ * Unit tests for wifi_connect association verification (#65).
+ *
+ * connect() used a single 3s sleep + one status check, false-negativing slow
+ * associations (measured 4.8–8.6s on a Pixel 8). It now polls getStatus until
+ * the target SSID is reported, with an early-bail when the supplicant settles
+ * in a terminal state after having been active.
+ *
+ * These cover the bail *mechanism* (terminal-after-active → fail), not a
+ * guarantee that every device failure fast-fails: on real hardware a wrong
+ * password can sit in ASSOCIATING past the deadline and fall back to the
+ * timeout result (see #65 follow-up). The deadline is the backstop.
+ *
+ * Drives connect() against a fake AdbClient that serves a scripted sequence of
+ * `dumpsys wifi` snapshots. Success/bail paths resolve well before the 10s
+ * deadline, so the tests stay fast.
+ *
+ * Run with: npm run test:unit  (after npm run build)
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { WifiCommands } from '../../dist/adb/wifi-commands.js';
+
+const ok = stdout => ({ success: true, stdout, stderr: '', exitCode: 0 });
+
+// dumpsys-grep snapshots that getStatus() parses.
+const ASSOCIATING = 'mWifiInfo SSID: "<unknown ssid>", RSSI: -127, Supplicant state: ASSOCIATING';
+const CONNECTED = 'mWifiInfo SSID: "TestNet", RSSI: -45, Supplicant state: COMPLETED';
+const DISCONNECTED = 'mWifiInfo SSID: "<unknown ssid>", RSSI: -127, Supplicant state: DISCONNECTED';
+
+class FakeAdb {
+  constructor(dumpsysSeq) {
+    this.seq = dumpsysSeq;
+    this.calls = [];
+  }
+  async shell(cmd) {
+    this.calls.push(cmd);
+    if (cmd.includes('connect-network')) return ok(''); // accepted, no error keywords
+    if (cmd.includes('dumpsys wifi')) {
+      return ok(this.seq.length > 1 ? this.seq.shift() : this.seq[0]);
+    }
+    if (cmd.includes('cmd wifi status')) return ok('Wifi is enabled');
+    return ok('');
+  }
+}
+
+test('succeeds once the target SSID is reported (slow association)', async () => {
+  const wifi = new WifiCommands(new FakeAdb([ASSOCIATING, CONNECTED]));
+  const r = await wifi.connect('TestNet', 'open');
+  assert.equal(r.success, true);
+  assert.equal(r.ssid, 'TestNet');
+});
+
+test('early-bails with the supplicant state once it settles terminal after being active', async () => {
+  // Mechanism check: active (ASSOCIATING) then a sustained terminal state →
+  // fail fast with the state in the error. (Real auth failures don't always
+  // present this way within the deadline — see the file header.)
+  const wifi = new WifiCommands(new FakeAdb([ASSOCIATING, DISCONNECTED, DISCONNECTED]));
+  const r = await wifi.connect('TestNet', 'wpa2', 'somepass');
+  assert.equal(r.success, false);
+  assert.match(r.error, /supplicant state: DISCONNECTED/);
+});
+
+test('does NOT bail on an initial DISCONNECTED before any active state', async () => {
+  // Pre-association DISCONNECTED must not be treated as a failure; once the
+  // SSID shows up the connect still succeeds.
+  const wifi = new WifiCommands(new FakeAdb([DISCONNECTED, DISCONNECTED, CONNECTED]));
+  const r = await wifi.connect('TestNet', 'open');
+  assert.equal(r.success, true);
+});
+
+test('reports stdout errors from connect-network immediately', async () => {
+  const adb = new FakeAdb([CONNECTED]);
+  adb.shell = async cmd => {
+    adb.calls.push(cmd);
+    if (cmd.includes('connect-network')) return ok('Error: unknown network');
+    return ok('');
+  };
+  const wifi = new WifiCommands(adb);
+  const r = await wifi.connect('TestNet', 'open');
+  assert.equal(r.success, false);
+  assert.match(r.error, /unknown network/i);
+});


### PR DESCRIPTION
## Summary
The owner's #65 branch, rebased onto current `main`, with the missing test added.

- **Core fix (verified):** `WifiCommands.connect()` polled a single fixed 3s then checked once, false-negativing slow associations (measured 4.8–8.6s on a Pixel 8). It now polls `getStatus()` (immediate check, then every 500ms, 10s budget) and returns as soon as the target SSID is reported. Same L2-only verify semantic. Live-verified: a cold connect now returns `success:true` at ~3.2s where the old code reported failure.
- **Early-bail (best-effort):** on a terminal supplicant state after being active, fail fast with the state in the error. **Caveat, verified on hardware:** a real auth failure can sit in `ASSOCIATING` past the deadline, so the early-bail is currently inert for that case and falls back to the (correct) timeout result. Tracked in #91.
- Adds the unit test the branch lacked (poll-success / bail-mechanism / sawActive gate / stdout error), with an honest header about the deadline fallback.

Closes #65

## Test plan
- [x] `npm run test:unit` — 187 pass
- [x] Live: slow association → `success:true` ~3.2s (old 3s-sleep would have failed)
- [x] Live: wrong-password supplicant trace captured → informs #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)