### PR TITLE
fix(scripts): add npm stop + working npm restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ cd android-wifi-mcp
 npm install
 npm run build
 npm start             # HTTP transport on http://localhost:3000
+npm run stop          # Send SIGTERM to whatever is listening on $PORT (default 3000)
+npm restart           # stop + start; use this after `npm run build` to pick up code changes
 ```
 
 The server speaks **Streamable HTTP** (the MCP-spec transport). One process serves all connected MCP clients.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
   "scripts": {
     "build": "tsc",
     "start": "node dist/index.js",
+    "stop": "lsof -ti:${PORT:-3000} | xargs -r kill -TERM",
+    "restart": "npm run stop && sleep 0.5 && npm start",
     "dev": "tsc --watch",
     "test:unit": "node --test 'tests/unit/**/*.test.mjs'",
     "tools:count": "echo \"Native tools registered in src/server.ts: $(grep -c 'mcpServer\\.tool(' src/server.ts)\""


### PR DESCRIPTION
## Summary

- Add `npm run stop` — sends SIGTERM to whatever is listening on `$PORT` (default 3000) via `lsof -ti | xargs -r kill -TERM`.
- Add `npm restart` — `stop` + 0.5 s sleep + `start`. Defining the script explicitly prevents npm from collapsing back to the implicit "stop + start" chain that caused the original bug.
- README updated with both commands next to `npm start`.
- Closes #67.

## Why

Caught while validating #66. `npm restart` had no real effect — with only `start` defined, npm spawned a second `node dist/index.js`, which hit EADDRINUSE on :3000 and died silently. The original server kept running on old code for 52 minutes, and the new behavior under test was never actually exercised.

The existing SIGTERM handler in `src/index.ts:20-29` already drains the device observer, upstream MCP children, and the pg pool, so a polite shutdown was already in place — only the npm-script wiring was missing.

## Out of scope (deferred)

- SIGKILL fallback if SIGTERM hangs. If the drain hangs that's a real bug, not something to paper over with a forced kill.
- Readiness probe after `start` returns. `npm start` exits as soon as the child is exec'd; ideally `restart` would block until `:3000` answers `tools/list`. File separately if it bites.
- pm2 / systemd / PID files. Heavyweight for the current "QA engineer runs it locally" model.

## Test plan

- [x] `npm run stop` against no server: clean exit 0 (verified — `xargs -r` no-ops on empty input).
- [ ] `npm run stop` against running server: process exits, port frees, pino logs show "shutting down".
- [ ] `npm restart` after a code change: confirm new code is live by calling `wifi_status` and asserting the `supplicantState` field appears (added in #66).
- [ ] `npm restart` against no server: starts cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)