### PR TITLE
Add dev-workflow commands + project MCP config

### DIFF
--- a/.claude/commands/dev-workflow/dw-create-pr.md
+++ b/.claude/commands/dev-workflow/dw-create-pr.md
@@ -1,0 +1,97 @@
+# Create a Pull Request
+
+```
+Push branch and open a pull request with issue linkage.
+
+Issue number: {{input}}
+
+## PURPOSE
+
+Creates a pull request for the current branch, linking it to the GitHub Issue
+via "Fixes #N" for auto-closure. Updates issue labels to reflect PR status.
+
+---
+
+## WORKFLOW
+
+    /dw-create-pr 27
+        │
+        ├─► Step 1: Verify Readiness
+        │   - Confirm you're on the correct branch (issue-<N>-<slug>)
+        │   - Run: git status — check for uncommitted changes
+        │   - Review the branch's commits against the repo's default branch —
+        │     derive it, don't hardcode `main` (gh repo view --json
+        │     defaultBranchRef -q .defaultBranchRef.name):
+        │     git log --oneline <default>..HEAD
+        │   - If no argument given, infer issue number from branch name
+        │   - Run: gh issue view <N> — check if title contains [STORY-XXX]
+        │
+        ├─► Step 2: Push Branch
+        │   - Run: git push -u origin $(git branch --show-current)
+        │
+        ├─► Step 3: Create PR
+        │   - Title: short, imperative, under 70 characters
+        │   - Body must include "Fixes #N" or "Closes #N"
+        │   - Use this template:
+        │
+        │       gh pr create --title "<title>" --body "$(cat <<'EOF'
+        │       ## Summary
+        │       <1-3 bullet points>
+        │
+        │       Fixes #<issue-number>
+        │       (if linked to story: "Part of STORY-XXX")
+        │
+        │       ## Test plan
+        │       - [ ] ...
+        │
+        │       Generated with [Claude Code](https://claude.com/claude-code)
+        │       EOF
+        │       )"
+        │
+        ├─► Step 4: Update Issue Labels
+        │   - Run: gh issue edit <N> --remove-label "status:in-progress" \
+        │          --add-label "status:needs-review"
+        │   - Comment on issue:
+        │     gh issue comment <N> --body "PR #<PR> created. Summary: <what changed>"
+        │
+        ├─► Step 5: Update Story File (if linked)
+        │   - If the issue title contains [STORY-XXX]:
+        │     update docs/stories/STORY-XXX.md status to reflect PR is open
+        │   - Skip silently if no story link or docs/stories/ doesn't exist
+        │
+        └─► Step 6: Report
+            - Show the PR URL to the user
+            - Stop here — don't auto-advance. The PR now waits for a HUMAN to
+              review and test it. Merge with /dw-merge <PR> only once a human is
+              satisfied. (The change's substance was already gated locally by
+              /dw-review-implement before the PR.)
+
+---
+
+## EXAMPLE
+
+    /dw-create-pr 27
+
+**Agent verifies, pushes, creates PR:**
+
+    $ git status
+    $ git log --oneline <default-branch>..HEAD
+    $ git push -u origin issue-27-release-notes
+    $ gh pr create --title "Add release notes generator command" --body "..."
+    $ gh issue edit 27 --remove-label "status:in-progress" --add-label "status:needs-review"
+    $ gh issue comment 27 --body "PR #30 created."
+
+**Output:**
+
+    PR #30 created: https://github.com/owner/repo/pull/30
+    A human reviews + tests it; merge with /dw-merge 30 when satisfied.
+
+---
+
+## API Notes
+
+- Uses `gh` CLI for PR and issue operations
+- `Fixes #N` in PR body auto-closes the issue when PR is merged
+- Copy relevant labels from the issue to the PR if needed
+- If branch is already pushed, the push step is a no-op
+```

--- a/.claude/commands/dev-workflow/dw-implement.md
+++ b/.claude/commands/dev-workflow/dw-implement.md
@@ -1,0 +1,123 @@
+# Implement a GitHub Issue
+
+```
+Start work on a GitHub Issue — create branch, implement, and track progress.
+
+Issue number: {{input}}
+
+## PURPOSE
+
+Picks up a GitHub Issue and drives it through implementation. Creates a feature
+branch, tracks status via labels and comments, handles failures transparently,
+and prepares for PR creation when done.
+
+---
+
+## WORKFLOW
+
+    /dw-implement 27
+        │
+        ├─► Step 1: Understand the Issue
+        │   - Run: gh issue view <N>
+        │   - Read acceptance criteria, technical notes, dependencies
+        │   - Check labels — type and priority should already be set
+        │   - Check for linked/blocking issues
+        │   - If the issue body links a plan ("Part of #<plan>"), read that plan
+        │     issue — its Approach is the agreed checkpoint to build from, so a fresh
+        │     session resumes without re-deriving it: gh issue view <plan>
+        │   - If issue title contains [STORY-XXX], read docs/stories/STORY-XXX.md
+        │     for full context (the user story and the need it serves)
+        │   - If anything is unclear, ask the user before starting
+        │
+        ├─► Step 2: Create Branch
+        │   - Branch name: issue-<N>-<short-slug>
+        │     Example: issue-27-release-notes
+        │   - Branch from the repo's default branch — derive it, don't hardcode
+        │     `main` (e.g. gh repo view --json defaultBranchRef -q
+        │     .defaultBranchRef.name); check it out and pull, then:
+        │     git checkout -b issue-<N>-<slug>
+        │   - Comment on issue:
+        │     gh issue comment <N> --body "Starting work on branch \`issue-<N>-<slug>\`"
+        │   - Add status label:
+        │     gh issue edit <N> --add-label "status:in-progress"
+        │
+        ├─► Step 3: Implement
+        │   - Make the changes based on acceptance criteria
+        │   - Build and test using the project's standard tooling
+        │     (Makefile, test framework, CI pipeline — whatever the project uses)
+        │   - Commit incrementally with clear messages
+        │
+        ├─► Step 4a: On Success
+        │   - Comment on issue:
+        │     gh issue comment <N> --body "Implementation complete, tests passing. Ready for PR."
+        │   - Progress is recorded on the issue, not the story — the story stays the
+        │     stable statement of the need
+        │   - Proceed to /dw-review-implement to gate the changes before the PR
+        │
+        ├─► Step 4b: On Failure
+        │   - Do NOT silently retry — update the issue:
+        │     gh issue comment <N> --body "Build/test failure: <what failed, error, root cause>"
+        │   - If blocked, add label:
+        │     gh issue edit <N> --add-label "status:blocked"
+        │   - Investigate, fix, update issue:
+        │     gh issue comment <N> --body "Applied fix: <what changed>. Retesting."
+        │   - Remove blocked label after unblocking:
+        │     gh issue edit <N> --remove-label "status:blocked"
+        │   - If stuck after 2-3 attempts, comment blockers and ask the user
+        │
+        └─► Step 4c: On Partial Fix
+            - Comment: what was fixed, what remains, blockers
+            - If the partial fix is independently useful: run /dw-review-implement,
+              then a human reviews + tests before a PR is opened (/dw-create-pr)
+            - Create follow-up issues for remaining work
+
+---
+
+## ISSUE CROSS-REFERENCES
+
+Use these patterns in issue comments and PR bodies:
+- **Parent/child**: "Part of #N" or "Parent: #N"
+- **Dependencies**: "Depends on #N", "Blocked by #N"
+- **Related**: "Related to #N"
+
+GitHub auto-creates backlinks when issues reference each other.
+
+---
+
+## EXAMPLE
+
+    /dw-implement 27
+
+**Agent reads issue #27, creates branch, implements:**
+
+    $ gh issue view 27
+    $ git checkout -b issue-27-release-notes   # from the repo's default branch
+    $ gh issue comment 27 --body "Starting work on branch `issue-27-release-notes`"
+    $ gh issue edit 27 --add-label "status:in-progress"
+
+    ... (implementation work) ...
+
+    $ gh issue comment 27 --body "Implementation complete, tests passing. Ready for PR."
+
+**Next step:** /dw-review-implement 27 (local gate). Then a human reviews + tests
+before a PR is opened (/dw-create-pr 27) — the workflow doesn't auto-advance to a PR.
+
+---
+
+## KEY PRINCIPLE
+
+The issue is the single source of truth. Anyone reading it should see the full
+history — start, failures, fixes, and resolution.
+
+---
+
+## API Notes
+
+- Uses `gh` CLI for issue operations
+- Branch naming convention: `issue-<number>-<short-slug>`
+- Always comment on the issue before and after implementation
+- Label management: `status:in-progress` while working, `status:blocked` if stuck
+- For a planned task, the linked plan issue (`Part of #<plan>`) holds the agreed
+  approach — the checkpoint a fresh session resumes from (see
+  `.claude/rules/dev-workflow.md`)
+```

--- a/.claude/commands/dev-workflow/dw-merge.md
+++ b/.claude/commands/dev-workflow/dw-merge.md
@@ -1,0 +1,91 @@
+# Merge a Pull Request
+
+```
+Merge an approved pull request and clean up.
+
+PR number: {{input}}
+
+## PURPOSE
+
+Merges an approved PR, deletes the remote branch, cleans up local branches
+and issue labels. The linked issue auto-closes via "Fixes #N" in the PR body.
+
+---
+
+## WORKFLOW
+
+    /dw-merge 30
+        │
+        ├─► Step 1: Verify Ready to Merge
+        │   - Run: gh pr view <PR> --json mergeStateStatus,headRefName,reviewDecision
+        │   - Must be mergeable (no conflicts)
+        │   - Run: gh pr checks <PR> — any CI checks must pass (if applicable)
+        │   - The merge gate is HUMAN review + test, not a GitHub approval. On a
+        │     solo repo GitHub blocks self-approval, so do NOT require
+        │     reviewDecision=APPROVED. Before merging, confirm a human has reviewed
+        │     and tested the change (its substance was gated by /dw-review-implement
+        │     before the PR). If not yet reviewed/tested, stop and say so.
+        │
+        ├─► Step 2: Identify Linked Issue and Story
+        │   - Read PR body for "Fixes #N" or "Closes #N"
+        │   - Note the issue number for label cleanup
+        │   - Check if PR body or issue title contains [STORY-XXX] or "Part of STORY-XXX"
+        │
+        ├─► Step 3: Merge
+        │   - Run: gh pr merge <PR> --merge --delete-branch
+        │   - Uses --merge (not squash/rebase) to preserve commit history
+        │   - --delete-branch cleans up the remote branch
+        │
+        ├─► Step 4: Clean Up Issue Labels
+        │   - Run: gh issue edit <N> --remove-label "status:needs-review"
+        │   - Issue auto-closes via "Fixes #N" — no manual close needed
+        │
+        ├─► Step 5: Update Story File (if linked)
+        │   - If linked to STORY-XXX and docs/stories/STORY-XXX.md exists:
+        │     • Check off completed acceptance criteria for this task
+        │     • If all story tasks are closed, mark story status as Completed
+        │   - Skip silently if no story link or docs/stories/ doesn't exist
+        │
+        ├─► Step 6: Clean Up Local Branch
+        │   - Switch to the repo's default branch and pull — derive it, don't
+        │     hardcode `main` (gh repo view --json defaultBranchRef -q
+        │     .defaultBranchRef.name): git checkout <default> && git pull
+        │   - Run: git branch -d <branch-name>
+        │
+        └─► Step 7: Report
+            - Confirm merge to the user
+            - Show the merged PR URL
+            - If story has remaining open tasks, suggest: /dw-implement <next-issue>
+            - If story is complete, mention it
+            - Mention any follow-up issues if applicable
+
+---
+
+## EXAMPLE
+
+    /dw-merge 30
+
+**Agent verifies, merges, cleans up:**
+
+    $ gh pr view 30 --json mergeStateStatus,headRefName,reviewDecision  # mergeable? (don't gate on self-approval)
+    $ gh pr checks 30
+    $ gh pr merge 30 --merge --delete-branch
+    $ gh issue edit 27 --remove-label "status:needs-review"
+    $ git checkout <default-branch> && git pull
+    $ git branch -d issue-27-release-notes
+
+**Output:**
+
+    PR #30 merged: https://github.com/owner/repo/pull/30
+    Issue #27 auto-closed.
+    Branch issue-27-release-notes deleted (local + remote).
+
+---
+
+## API Notes
+
+- Uses `gh` CLI for PR and issue operations
+- `--merge` preserves full commit history (use `--squash` only if the project convention requires it)
+- `--delete-branch` removes the remote branch; `git branch -d` removes the local one
+- If PR is not approved or CI fails, report the blocker instead of merging
+```

--- a/.claude/commands/dev-workflow/dw-plan.md
+++ b/.claude/commands/dev-workflow/dw-plan.md
@@ -1,0 +1,135 @@
+# Plan Development Work into a Plan Issue
+
+```
+Research a story and write the plan — the agreed approach — as ONE GitHub plan
+issue, then stop for human review.
+
+Target: a STORY-XXX (or a raw request).
+
+## PURPOSE
+
+The front of the dev-workflow's build half: turn a story's *need* into an agreed
+*approach*, captured as a durable, reviewable **plan issue** before any task issue is
+opened. It researches against the repo (conventions, prior issues) so the plan is
+grounded, writes one plan issue, and **stops** — a human reviews the plan on GitHub,
+then `/dw-tasks` decomposes it. The plan issue is the parent of the task issues and the
+checkpoint a fresh session resumes from. See `.claude/rules/dev-workflow.md`.
+
+Fits in the dev-workflow:
+
+    dw-story → dw-review-story → dw-plan → [human reviews the plan issue]
+             → dw-tasks → dw-review-tasks → dw-implement → …
+
+This command produces the plan only. It does NOT create task issues — that is `/dw-tasks`.
+
+---
+
+## WORKFLOW
+
+    /dw-plan STORY-003
+        │
+        ├─► Step 1: Read the need (and right-size)
+        │   - If a STORY-XXX: read docs/stories/STORY-XXX.md (the need + "Success Looks Like").
+        │   - If a raw request: restate the need in a sentence.
+        │   - RIGHT-SIZE: if the work is trivial — a one-line change or a single,
+        │     obvious task — skip planning. Say so and hand off straight to
+        │     /dw-tasks (or a lone issue). The plan stage is for non-trivial stories.
+        │
+        ├─► Step 2: Research (ground the approach)
+        │   - Investigate the repo so the plan reflects it, not generic advice:
+        │     • conventions — CLAUDE.md, .claude/rules/, neighbouring code patterns
+        │     • prior art — gh issue list --state all --limit 50 ; related stories
+        │   - Note the approach, the commands/files it will touch, and open questions.
+        │
+        ├─► Step 3: Check for an existing plan
+        │   - Run: gh issue list --search "[STORY-XXX] Plan" --state all
+        │   - If a plan issue already exists, report and ask how to proceed (extend it,
+        │     not duplicate).
+        │
+        ├─► Step 4: Ensure labels (idempotent)
+        │   - plan           (color: #5319e7) — The approach for a story, before tasks
+        │   - priority:high / priority:medium / priority:low (as in /dw-tasks)
+        │   - Use: gh label create "<name>" --color "<hex>" --description "<desc>" --force
+        │
+        ├─► Step 5: Write ONE plan issue
+        │   - Title: [STORY-XXX] Plan   (raw request: "Plan: <short need>")
+        │   - Body: the template below — approach, acceptance criteria, the
+        │     commands/files it expects to touch, open questions.
+        │   - Labels: plan + priority. Link the story: "Part of STORY-XXX".
+        │
+        ├─► Step 6: Record on the story (if a STORY-XXX)
+        │   - Update docs/stories/STORY-XXX.md Status with the plan issue number:
+        │     - Plan: #<plan>
+        │
+        └─► Step 7: Hand off — stop for human review
+            - Show the plan issue URL.
+            - STOP. The plan now waits for a HUMAN to read, comment, and approve it on
+              GitHub. Do NOT create task issues and do NOT auto-advance.
+            - Once a human is satisfied: /dw-tasks STORY-XXX breaks the plan into tasks.
+
+---
+
+## PLAN ISSUE BODY TEMPLATE
+
+    ## Context
+    Part of [STORY-XXX](../docs/stories/STORY-XXX.md) — <the need, one line>.
+
+    ## Approach
+    <How we'll meet the need — the agreed shape of the work, grounded in the repo.>
+
+    ## Acceptance Criteria
+    - [ ] <observable outcome that means the story is delivered>
+
+    ## Touches
+    - <commands / files / areas the work is expected to change>
+
+    ## Open Questions
+    - <what's still unresolved — settled as the tasks are worked>
+
+---
+
+## EXAMPLE
+
+    /dw-plan STORY-003
+
+**Agent reads the story, researches, writes one plan issue:**
+
+    $ cat docs/stories/STORY-003.md
+    $ gh issue list --state all --limit 50
+    $ gh issue list --search "[STORY-003] Plan" --state all
+    $ gh label create "plan" --color "5319e7" --description "The approach for a story, before tasks" --force
+    $ gh issue create --label "plan" --label "priority:high" \
+        --title "[STORY-003] Plan" \
+        --body "## Context
+    Part of STORY-003 — validate inbound payloads.
+    ## Approach
+    ...
+    ## Acceptance Criteria
+    - [ ] ...
+    ## Touches
+    - ...
+    ## Open Questions
+    - ..."
+
+**Story file updated:**
+
+    ## Status
+    - Created: 2026-04-01
+    - Plan: #28
+
+**Output:**
+
+    Plan issue #28 created: https://github.com/owner/repo/issues/28
+    A human reviews + approves it; then /dw-tasks STORY-003 breaks it into tasks.
+
+---
+
+## API Notes
+
+- Uses `gh` CLI — must be authenticated (`gh auth status`)
+- Labels use `--force` so existing labels are updated, not duplicated
+- One plan issue per story — check for duplicates before creating
+- The plan issue is the parent of the task issues; the story records the need, the plan
+  records the approach, the task issues carry the how (see .claude/rules/dev-workflow.md)
+- Trivial work skips this command — go straight to /dw-tasks
+```

--- a/.claude/commands/dev-workflow/dw-review-implement.md
+++ b/.claude/commands/dev-workflow/dw-review-implement.md
@@ -1,0 +1,87 @@
+# Review an Implementation
+
+```
+Review the changes an issue was implemented with — do they deliver the issue, and
+do they stay surgical rather than sprawling beyond it?
+
+Issue number: {{input}}
+
+## PURPOSE
+
+Quality-gates the work done by `/dw-implement` before it becomes a PR. Checks that
+the changes on the branch **deliver the issue** (every "Done When" is actually
+satisfied) and stay **surgical** (every changed line traces to the issue — no scope
+creep, dead code, or debug leftovers) while **fitting the project**. Fixes small
+findings on the branch in place, or hands back to `/dw-implement` if the approach is
+wrong.
+
+Fits between `/dw-implement` (does the work) and `/dw-create-pr` (opens the PR):
+
+    … → dw-implement → dw-review-implement → dw-create-pr → …
+
+---
+
+## WORKFLOW
+
+    /dw-review-implement 27
+        │
+        ├─► Step 1: Gather
+        │   - Run: gh issue view <N> (the Goal + "Done When")
+        │   - If the title contains [STORY-XXX], read docs/stories/STORY-XXX.md
+        │     for the need behind the issue
+        │   - See what changed on the branch, against the repo's default branch:
+        │     git diff <default>...HEAD   (derive <default>, don't hardcode `main`)
+        │   - If there are no changes, report and stop (run /dw-implement first)
+        │
+        ├─► Step 2: Delivers the issue
+        │   - [ ] Every "Done When" box is actually satisfied by the changes —
+        │         observable, not asserted. Confirm by running the project's
+        │         standard tooling (build / test / render — whatever /dw-implement
+        │         used), not by reading the diff alone
+        │   - [ ] Nothing the issue asked for is missing or stubbed out
+        │   - [ ] The changes match the issue's Goal, not a different problem
+        │
+        ├─► Step 3: Surgical
+        │   - [ ] Every changed line traces to this issue — no unrelated refactors,
+        │         "improvements", or reformatting of adjacent code
+        │   - [ ] No scope creep beyond the issue's Goal (extra features, speculative
+        │         abstractions, config nobody asked for)
+        │   - [ ] No dead code, commented-out blocks, debug prints, or leftover TODOs
+        │   - [ ] Now-unused imports/vars/files the change created are removed
+        │
+        ├─► Step 4: Fits the project
+        │   - [ ] Matches the project's conventions and existing patterns/style
+        │   - [ ] Core stays target-agnostic — no vendor names/coupling leaked in
+        │         (vendor specifics belong in a profile)
+        │   - [ ] Markdown stays the source of truth; cross-references resolve to
+        │         files that exist
+        │   - [ ] The issue records the work (start / fixes / result) per /dw-implement
+        │
+        ├─► Step 5: Decision
+        │   - PASS: delivers the issue, surgical, fits → ready for a HUMAN to
+        │     review + test, then open a PR (/dw-create-pr <N>) — don't auto-advance
+        │   - REVISE: specific findings — fix on the branch, smallest blast radius
+        │     first (remove leaked scope, fill a gap, tighten); commit
+        │   - HAND BACK: the approach is wrong (wrong design, misread the issue) →
+        │     comment the issue and route back to /dw-implement
+        │
+        └─► Step 6: Report
+            - Per finding: the exact file:line + the smallest fix
+            - A delivery verdict against the issue's "Done When"
+            - The issue link + suggested next step
+
+---
+
+## API Notes
+
+- Uses `gh` to read the issue; reads the branch diff with `git` — read-mostly
+- Reviews the local implementation result before it becomes a PR — pairs with
+  /dw-implement the way /dw-review-tasks pairs /dw-tasks
+- This is the substance gate (delivers + surgical), run on the local diff before
+  the PR — there is no separate PR-review command. PR mechanics (linkage, labels)
+  are handled by /dw-create-pr and /dw-merge, and a human reviews + tests the PR
+  before merge.
+- Surgical-change bar mirrors the project's CLAUDE.md (every changed line traces to
+  the request; clean up only your own orphans)
+- When fixing, change only what a finding points to — don't rewrite sound work
+```

--- a/.claude/commands/dev-workflow/dw-review-pr.md
+++ b/.claude/commands/dev-workflow/dw-review-pr.md
@@ -1,0 +1,127 @@
+# Review a Pull Request
+
+```
+Review a pull request using a structured checklist.
+
+PR number: {{input}}
+
+## PURPOSE
+
+Reviews a pull request against a structured checklist covering issue linkage,
+code quality, test coverage, and documentation. Approves or requests changes.
+
+---
+
+## WORKFLOW
+
+    /dw-review-pr 30
+        │
+        ├─► Step 1: Read the PR
+        │   - Run: gh pr view <PR>
+        │   - Run: gh pr diff <PR>
+        │   - Run: gh pr checks <PR>
+        │
+        ├─► Step 2: Review Checklist
+        │
+        │   Issue Linkage:
+        │   - [ ] PR body contains "Fixes #N" or "Closes #N"
+        │   - [ ] PR title is clear and under 70 characters
+        │   - [ ] Labels match the linked issue
+        │
+        │   Code Quality:
+        │   - [ ] Changes match the issue's acceptance criteria
+        │   - [ ] No unnecessary changes beyond what was requested
+        │   - [ ] No security vulnerabilities (injection, hardcoded secrets)
+        │   - [ ] No debug/temporary code left in
+        │
+        │   Project-Type Checks (detect and apply relevant items):
+        │   - Detect project type by scanning for markers:
+        │     • src/mcpServer.ts or @modelcontextprotocol/sdk → MCP server
+        │     • package.json with react/next → Frontend
+        │     • Dockerfile or docker-compose.yml → Containerized
+        │     • pyproject.toml or setup.py → Python
+        │     • go.mod → Go
+        │
+        │   IF MCP server:
+        │   - [ ] Service function follows existing patterns in services/
+        │   - [ ] Tool registered with clear description (REQUIRED/PREREQUISITE refs)
+        │   - [ ] Async operations use standard retry/polling pattern
+        │   IF Frontend:
+        │   - [ ] No console.log left in production code
+        │   - [ ] Components follow existing patterns
+        │   IF Containerized:
+        │   - [ ] Dockerfile follows best practices (multi-stage, non-root)
+        │   - [ ] No secrets in image layers
+        │   IF Python:
+        │   - [ ] Type hints on public functions
+        │   - [ ] No bare except clauses
+        │   IF Go:
+        │   - [ ] Errors are checked, not discarded
+        │   - [ ] No goroutine leaks (context cancellation handled)
+        │   (Skip this section silently if no project type detected)
+        │
+        │   Test Coverage (adaptive — detect what the project uses):
+        │   - Detect CI: .github/workflows/, .gitlab-ci.yml, Jenkinsfile, .circleci/
+        │   - Detect test infra: cicd/tests/, tests/, __tests__/, *_test.go, *.robot
+        │
+        │   IF CI exists:
+        │   - [ ] CI pipeline passed (run: gh pr checks <PR>)
+        │   - [ ] New or updated test files match the scope of changes
+        │   - [ ] No test regressions in CI output
+        │   IF no CI:
+        │   - [ ] Manual test plan present in PR body or docs/test-plans/
+        │   - [ ] Test steps are specific and verifiable
+        │   - (Informational) Note: project has no CI — see /dw-test-design
+        │
+        │   Documentation:
+        │   - [ ] Comments added where logic isn't self-evident
+        │   - [ ] No unnecessary comments or docstrings
+        │
+        ├─► Step 3: Decision
+        │   - Approve: all checks pass → proceed to /dw-merge
+        │   - Request changes: specific feedback → back to /dw-implement
+        │
+        └─► Step 4: Submit Review
+            - Check if you are the PR author (GitHub blocks self-approval)
+            - If NOT the author:
+              gh pr review <PR> --approve --body "LGTM"
+            - If you ARE the author (self-review):
+              gh pr comment <PR> --body "Self-review complete. Checklist passes. Ready to merge."
+            - To request changes:
+              gh pr review <PR> --request-changes --body "<specific feedback>"
+
+---
+
+## EXAMPLE
+
+    /dw-review-pr 30
+
+**Agent reads PR, runs checklist:**
+
+    $ gh pr view 30
+    $ gh pr diff 30
+    $ gh pr checks 30
+
+**Checklist result:**
+
+    ✓ Issue linkage — Fixes #27 present
+    ✓ Title — "Add release notes generator command" (42 chars)
+    ✓ Code quality — Changes match acceptance criteria
+    ✓ No security issues
+    ✓ Tests — N/A (markdown-only change)
+
+    $ gh pr review 30 --approve --body "LGTM"
+
+**Output:**
+
+    PR #30 approved. Next: /dw-merge 30
+
+---
+
+## API Notes
+
+- Uses `gh` CLI for PR operations
+- GitHub blocks self-approval — use comment instead if you authored the PR
+- If CI checks are failing, investigate before approving
+- Always read the full diff, not just the PR description
+```

--- a/.claude/commands/dev-workflow/dw-review-story.md
+++ b/.claude/commands/dev-workflow/dw-review-story.md
@@ -1,0 +1,96 @@
+# Review a User Story
+
+```
+Review a story for completeness and ensure it stays a goal document, not a spec.
+
+Story ID: {{input}}
+
+## PURPOSE
+
+Quality-gates a story written by `/dw-story` before it becomes work. Checks two
+things: the story is **complete** (every goal section is present and substantive),
+and it is a **goal document, not a spec** (it states the need and the outcome, and
+leaves the *how* to the GitHub issue). Reports findings and revises the story, or
+hands it back to `/dw-story` if the need itself is unclear.
+
+---
+
+## WORKFLOW
+
+    /dw-review-story STORY-001
+        │
+        ├─► Step 1: Read the Story
+        │   - If no story ID provided, list files in docs/stories/ and ask user to pick
+        │   - Read docs/stories/STORY-XXX.md
+        │   - If the story file doesn't exist, report and stop
+        │
+        ├─► Step 2: Completeness Checklist
+        │   - [ ] Title is specific (not a placeholder like "[Title]")
+        │   - [ ] User Story has a real role, action, AND benefit — the "so that"
+        │         is a genuine benefit, not a restatement of the action
+        │   - [ ] The Need explains the problem behind the request (the why), in the
+        │         user's terms — not how it will be built
+        │   - [ ] Success Looks Like lists outcomes someone could actually observe
+        │   - [ ] Open Questions captures what's genuinely unresolved (or says
+        │         "none known" — empty-because-skipped is a finding)
+        │   - [ ] Status has a Created date
+        │
+        ├─► Step 3: Goal-not-Spec Checklist
+        │   - [ ] No implementation detail in the body — no specific files, APIs,
+        │         frameworks, data shapes, or step-by-step "how"
+        │   - [ ] Success Looks Like describes observable user-facing results, not
+        │         implementation steps ("the project shows the stories", not "parse
+        │         markdown with X and render with Y")
+        │   - [ ] The technical / uncertain "how" lives in Open Questions, deferred
+        │         to the issue — it is not asserted as decided in the body
+        │   - [ ] No acceptance-criteria checklist acting as a build spec
+        │   - [ ] The whole story is decidable by someone who won't implement it
+        │
+        ├─► Step 4: Decision
+        │   - PASS: both checklists clear → report ✓ and suggest /dw-tasks STORY-XXX
+        │   - REVISE: list each finding with the exact line, then fix in place —
+        │     remove leaked spec, fill missing sections, reword success into outcomes
+        │   - HAND BACK: if the *need* itself is unclear or wrong (not just the
+        │     wording), stop and route to /dw-story to re-capture it with the user
+        │
+        └─► Step 5: Report
+            - Print the verdict (PASS / REVISED / HAND BACK) and the findings
+            - Print the path to the story and the suggested next step
+
+---
+
+## EXAMPLE
+
+    /dw-review-story STORY-001
+
+**Agent reads the story, runs both checklists:**
+
+    Completeness:
+    ✓ Title specific — "See the project's stories"
+    ✓ User Story — role + action + benefit all present
+    ✓ The Need — explains why (the project is the face over the markdown source of truth)
+    ✓ Success Looks Like — observable (the project shows stories, reflects changes)
+    ✓ Open Questions — presentation, status, read strategy all deferred
+    ✓ Status — Created date present
+
+    Goal-not-Spec:
+    ✓ No files/APIs/frameworks asserted in the body
+    ✓ Success is outcome-based, not implementation steps
+    ✓ The "how" sits in Open Questions
+    ✓ No build-spec checklist
+
+**Output:**
+
+    PASS — STORY-001 is complete and stays a goal.
+    docs/stories/STORY-001.md
+    Next: /dw-tasks STORY-001 to open the issue where the "how" gets decided.
+
+---
+
+## API Notes
+
+- Reads only the story file — no GitHub calls
+- The story is a goal; the issue is where the *how* and its history live (see
+  docs/stories/README.md)
+- When revising, change only what a finding points to — don't rewrite a sound story
+```

--- a/.claude/commands/dev-workflow/dw-review-tasks.md
+++ b/.claude/commands/dev-workflow/dw-review-tasks.md
@@ -1,0 +1,103 @@
+# Review the Tasks for a Story
+
+```
+Review the GitHub issues a story was broken into — do they cover the story, and does
+each stay a lean goal rather than a frozen spec?
+
+Story ID: {{input}}
+
+## PURPOSE
+
+Quality-gates the issues created by `/dw-tasks` before implementation starts. Checks
+that **together they cover the story**, and that **each is one small, testable job
+that leaves the *how* to develop on the issue** (not front-loaded as a spec). Fixes
+issue bodies / labels / links in place, or sends the breakdown back to `/dw-tasks` if
+it's wrong.
+
+Fits between `/dw-tasks` (creates issues) and `/dw-implement` (works one):
+
+    dw-story → dw-review-story → dw-plan → [human reviews the plan issue]
+             → dw-tasks → dw-review-tasks → dw-implement → …
+
+---
+
+## WORKFLOW
+
+    /dw-review-tasks STORY-001
+        │
+        ├─► Step 1: Gather
+        │   - If no story ID, list docs/stories/ and ask which to review
+        │   - Read docs/stories/STORY-XXX.md (the goal + "Success Looks Like")
+        │   - Find the plan issue (if any): note its number <plan> — none means
+        │     trivial work that skipped the plan stage:
+        │     gh issue list --search "[STORY-XXX] Plan" --label plan --state all
+        │   - List its task issues (the plan issue is the parent, not a task):
+        │     gh issue list --search "[STORY-XXX]" --state all --json number,title,labels,body
+        │   - If no issues exist, report and stop (run /dw-tasks first)
+        │
+        ├─► Step 2: Coverage — the issues vs the story (and plan)
+        │   - [ ] Every item in the story's "Success Looks Like" is covered by an issue
+        │   - [ ] Nothing essential to delivering the story is missing
+        │   - [ ] No issue goes beyond the story's goal — each traces back to the need
+        │   - [ ] When a plan exists: each task links back to it ("Part of #<plan>") —
+        │         flag any task missing the link. No plan → skip (trivial path).
+        │
+        ├─► Step 3: Each issue
+        │   - [ ] One clear job (title + Goal say one thing)
+        │   - [ ] Small enough to finish in a session; independent where it can be
+        │   - [ ] "Done When" is observable — checkable without ambiguity
+        │   - [ ] Body is lean (Context / Goal / Done When); the *how* is NOT frozen in
+        │         — it's left to develop on the issue (research / PoC / comments)
+        │   - [ ] Type + priority labels make sense
+        │
+        ├─► Step 4: Across the set
+        │   - [ ] No two issues substantially duplicate each other
+        │   - [ ] Dependencies/links are sane (no cycles) and the order is buildable
+        │
+        ├─► Step 5: Decision
+        │   - PASS: covers the story + each issue is clean → suggest /dw-implement <first>
+        │   - REVISE: specific fixes — edit the issue body / labels / links in place
+        │     (gh issue edit), or comment what's missing
+        │   - RE-SPLIT: the breakdown itself is wrong (gaps, wrong boundaries, overlap)
+        │     → back to /dw-tasks to re-decompose
+        │
+        └─► Step 6: Report
+            - Per issue: verdict + findings
+            - A coverage verdict against the story
+            - The story path + issue links + suggested next step
+
+---
+
+## EXAMPLE
+
+    /dw-review-tasks STORY-007
+
+**Agent reads the story + its issues, runs the checks:**
+
+    Coverage (vs the story's "Success Looks Like"):
+    ✓ <outcome A>  → #21
+    ✓ <outcome B>  → #22
+    ~ nothing essential missing; no issue exceeds the goal
+
+    Each issue:
+    ✓ #21 one job · Done When observable · lean body (Context / Goal / Done When)
+    ✓ #22 one job · Done When observable · lean body
+
+    Across the set: no overlap; deps are sane and the order is buildable
+
+**Output:**
+
+    PASS — the breakdown covers STORY-007 and each issue stays a goal.
+    Next: /dw-implement 21
+
+(Illustrative — a hypothetical clean breakdown. Real reviews often return REVISE.)
+
+---
+
+## API Notes
+
+- Uses `gh` to read (and, on REVISE, edit) the issues — read-mostly
+- The story is the goal; these issues are the agreed work — keep them lean, the how
+  lives in their comments/history (see docs/stories/README.md)
+- When fixing, change only what a finding points to — don't rewrite a sound breakdown
+```

--- a/.claude/commands/dev-workflow/dw-story.md
+++ b/.claude/commands/dev-workflow/dw-story.md
@@ -1,0 +1,84 @@
+# Create User Story
+
+Create a user story file from user input.
+
+```
+{{input}}
+
+## PURPOSE
+
+Capture the user's **need** as a story file saved to `docs/stories/`. A story is a
+**goal, not a spec** — it states what the user needs and why, and leaves the *how*
+open. Implementation detail (affected files, APIs, design) is worked out later on the
+GitHub issue, not here. See `docs/stories/README.md`.
+
+---
+
+## AGENT WORKFLOW
+
+### Step 1: Determine Story ID
+
+Check `docs/stories/` for existing story files. Generate the next sequential ID:
+- Format: `STORY-XXX` (e.g., STORY-001, STORY-002)
+- If no stories exist, start with STORY-001
+
+### Step 2: Clarify the Need
+
+If the user input is vague, ask questions that sharpen the **need** — not the
+implementation:
+- Who is the user, and what are they trying to achieve?
+- Why does it matter — what's the benefit or the problem behind the request?
+- What would success look like from their point of view?
+
+Do **not** ask about affected files, edge cases, or design here — that gets worked
+out on the issue. If the need is clear enough, proceed directly.
+
+### Step 3: Write Story File
+
+Create `docs/stories/STORY-XXX.md` with this template:
+
+```markdown
+# STORY-XXX: [Title]
+
+## User Story
+
+As a [role],
+I want to [action],
+So that [benefit].
+
+## The Need
+
+[The problem behind the request — what the user is trying to achieve and why, in
+their terms.]
+
+## Success Looks Like
+
+[The outcome that means this is done, described as observable user-facing results —
+not implementation steps.]
+
+## Open Questions
+
+[What still has to be figured out — resolved later on the GitHub issue via research,
+proof of concept, or clarification. The "how" goes here, not above.]
+
+## Status
+
+- Created: [date]
+- Issues: none
+```
+
+### Step 4: Confirm
+
+Show the user the created story and suggest next steps:
+- `/dw-review-story STORY-XXX` to check it's complete and still a goal, not a spec
+- `/dw-plan STORY-XXX` to research the approach and write the plan issue (the agreed
+  *how*), reviewed before it's broken into tasks
+- Trivial / single-task work can skip the plan — `/dw-tasks STORY-XXX` straight away
+- `/qw-plan` to plan what to test (if QA-related)
+
+---
+
+## OUTPUT
+
+The path to the created story file.
+```

--- a/.claude/commands/dev-workflow/dw-tasks.md
+++ b/.claude/commands/dev-workflow/dw-tasks.md
@@ -1,0 +1,135 @@
+# Break a Plan into GitHub Task Issues
+
+```
+Break a reviewed plan (or a story) into GitHub task issues, each linked back to it.
+
+Story ID: {{input}}
+
+## PURPOSE
+
+Reads the reviewed **plan issue** for a story (`[STORY-XXX] Plan`, written by `/dw-plan`)
+and breaks its approach into implementable GitHub task issues, each linking back to the
+plan. When no plan issue exists — trivial work that skipped the plan stage — it falls
+back to breaking the story directly. Updates the story file with the created issue
+numbers. See `.claude/rules/dev-workflow.md`.
+
+Fits in the dev-workflow:
+
+    dw-story → dw-review-story → dw-plan → [human reviews the plan issue]
+             → dw-tasks → dw-review-tasks → dw-implement → …
+
+---
+
+## WORKFLOW
+
+    /dw-tasks STORY-003
+        │
+        ├─► Step 1: Read the plan (or the story)
+        │   - If no story ID provided, list files in docs/stories/ and ask user to pick
+        │   - Read docs/stories/STORY-XXX.md for the need + "Success Looks Like"
+        │   - Find the reviewed plan issue:
+        │     gh issue list --search "[STORY-XXX] Plan" --label plan --state open
+        │     • If found: read it — its Approach + Acceptance Criteria are what you
+        │       break into tasks (the plan is the agreed how). Note its number <plan>.
+        │     • If none: fall back to breaking the story directly (trivial work that
+        │       skipped the plan stage). <plan> is empty.
+        │   - If the story file doesn't exist, report and stop
+        │
+        ├─► Step 2: Break into Tasks
+        │   - Break the plan's approach (or the story, when no plan) into tasks
+        │   - Each task should be:
+        │     • Small — completable in one session
+        │     • Independent — minimal dependencies between tasks
+        │     • Testable — has a clear done condition
+        │   - Detect project type to suggest task breakdown:
+        │     • Check project structure, CLAUDE.md, and existing code patterns
+        │     • Use these to inform sensible task boundaries
+        │   - Present the proposed task list to the user for approval
+        │
+        ├─► Step 3: Check for Duplicates
+        │   - Run: gh issue list --search "[STORY-XXX]" --state all
+        │   - If matching issues exist, report and ask user how to proceed
+        │
+        ├─► Step 4: Create Labels (idempotent)
+        │   - Ensure labels exist (same as /dw-plan):
+        │     • type labels: feature, enhancement, bug, docs
+        │     • priority labels: priority:high, priority:medium, priority:low
+        │     • status labels: status:in-progress, status:needs-review, status:blocked
+        │   - Use: gh label create "<name>" --color "<hex>" --force
+        │
+        ├─► Step 5: Create GitHub Issues
+        │   - One issue per task
+        │   - Title: [STORY-XXX] Task description
+        │   - Body — start lean; the issue grows as the *how* is worked out
+        │     (research, PoC, clarification, fixes) and recorded in comments:
+        │       ## Context
+        │       Part of [STORY-XXX](../docs/stories/STORY-XXX.md) · plan #<plan>
+        │
+        │       ## Goal
+        │       [what this task achieves, from the plan's approach / the story's need]
+        │
+        │       ## Done When
+        │       - [ ] [observable done condition for this task]
+        │   - Labels: type + priority (infer from the plan / story content)
+        │   - Trace back: "Part of #<plan>" in the body links each task to the plan
+        │     issue (GitHub backlinks it). Omit the plan reference when there is none.
+        │
+        ├─► Step 6: Update Story File
+        │   - Update the Status section in docs/stories/STORY-XXX.md:
+        │     ## Status
+        │     - Created: [original date]
+        │     - Issues: #1, #2, #3
+        │
+        └─► Step 7: Report
+            - Show table of created issues:
+              | Issue | Title | Type | Priority |
+            - Suggest implementation order based on dependencies
+            - Suggest: /dw-review-tasks STORY-XXX to gate the breakdown, then
+              /dw-implement <N> to start on the first task
+
+---
+
+## EXAMPLE
+
+    /dw-tasks STORY-003
+
+**Agent reads the plan, breaks it into tasks, creates issues:**
+
+    $ cat docs/stories/STORY-003.md
+    $ gh issue list --search "[STORY-003] Plan" --label plan --state open   # → plan #28
+    $ gh issue list --search "[STORY-003]" --state all                      # dup check
+    $ gh issue create --title "[STORY-003] Add input validation" \
+        --label "enhancement" --label "priority:high" \
+        --body "## Context\nPart of STORY-003 · plan #28\n\n## Goal\n...\n\n## Done When\n- [ ] ..."
+    $ gh issue create --title "[STORY-003] Add error response formatting" \
+        --label "enhancement" --label "priority:medium" \
+        --body "..."
+
+**Story file updated:**
+
+    ## Status
+    - Created: 2026-04-01
+    - Issues: #15, #16
+
+**Output:**
+
+    | Issue | Title                              | Type        | Priority |
+    |-------|------------------------------------|-------------|----------|
+    | #15   | [STORY-003] Add input validation   | enhancement | high     |
+    | #16   | [STORY-003] Add error formatting   | enhancement | medium   |
+
+    Suggested order: #15 → #16
+    Start: /dw-implement 15
+
+---
+
+## API Notes
+
+- Uses `gh` CLI for issue operations
+- Story files live in `docs/stories/STORY-XXX.md` (created by /dw-story)
+- Issue titles use `[STORY-XXX]` prefix for traceability
+- The reviewed plan issue (`[STORY-XXX] Plan`, from /dw-plan) is the source for the
+  breakdown when present, and each task links back to it; no plan → break the story
+- The story file records the need; the issue is the single source of truth for *how*,
+  growing with research, decisions, and fixes as the work proceeds
+```

--- a/.claude/commands/dev-workflow/dw-test-design.md
+++ b/.claude/commands/dev-workflow/dw-test-design.md
@@ -1,0 +1,188 @@
+# Design Tests for a GitHub Issue
+
+```
+Write tests after implementation, adapted to the project's existing test infrastructure.
+
+Issue number: {{input}}
+
+## PURPOSE
+
+After implementation is complete, this command designs and writes tests that verify
+the changes. It detects what test infrastructure the project uses and generates
+tests in the native format. If no test infrastructure exists, it writes a manual
+test checklist and recommends adopting a test framework.
+
+Fits into the dev-workflow chain after /dw-implement and before /dw-create-pr.
+
+---
+
+## WORKFLOW
+
+    /dw-test-design 47
+        │
+        ├─► Step 1: Understand What Was Implemented
+        │   - Run: gh issue view <N>
+        │   - Read the acceptance criteria and technical notes
+        │   - See what changed vs the repo's default branch — derive it, don't
+        │     hardcode `main` (gh repo view --json defaultBranchRef -q
+        │     .defaultBranchRef.name): git log --oneline <default>..HEAD and
+        │     git diff <default> --stat
+        │   - Identify what needs test coverage
+        │
+        ├─► Step 2: Detect Test Infrastructure
+        │   - Scan the project for existing test tooling:
+        │
+        │     Test Frameworks:
+        │     - cicd/tests/testcases/**/*.yml     → test-framework-template (YAML + dual-judge)
+        │     - tests/ + pytest.ini or conftest.py → pytest
+        │     - __tests__/ or *.test.ts/js         → Jest
+        │     - *.spec.ts/js                       → Jest / Vitest / Mocha
+        │     - *.robot                            → Robot Framework
+        │     - *_test.go                          → Go test
+        │     - **/*Test.java or **/*Spec.java     → JUnit / TestNG
+        │     - tests/ + Cargo.toml                → Rust (cargo test)
+        │
+        │     Test Runners (check even if no test files found):
+        │     - package.json → scripts.test        → npm test
+        │     - Makefile → test target             → make test
+        │     - pyproject.toml → [tool.pytest]     → pytest
+        │     - tox.ini                            → tox
+        │
+        │     CI Pipelines:
+        │     - .github/workflows/                 → GitHub Actions
+        │     - .gitlab-ci.yml                     → GitLab CI
+        │     - Jenkinsfile                        → Jenkins
+        │     - .circleci/                         → CircleCI
+        │     - .travis.yml                        → Travis CI
+        │
+        │   - Record findings: which framework, which runner, which CI
+        │
+        ├─► Step 3: Detect Issue Type (for test scope)
+        │   - Read labels from the GitHub issue:
+        │     - feature, epic, story       → Type A: broad coverage
+        │     - bug, defect                → Type B: regression test targeting the fix
+        │     - enhancement, improvement   → Type C: tests for changed behavior
+        │   - If no label matches, infer from issue title and description
+        │
+        ├─► Step 4: Generate Tests
+        │
+        │   ┌─ IF test infrastructure found:
+        │   │  - Write tests in the project's native format
+        │   │  - Place files where the project's existing tests live
+        │   │  - Follow existing naming conventions and patterns
+        │   │  - Run the project's test command to verify tests pass
+        │   │  - Commit test files to the issue branch
+        │   │
+        │   │  Examples by framework:
+        │   │  - test-framework-template → YAML in cicd/tests/testcases/{suite}/
+        │   │  - pytest   → Python test files in tests/
+        │   │  - Jest     → *.test.ts in __tests__/ or co-located
+        │   │  - Go test  → *_test.go alongside source files
+        │   │  - Robot    → *.robot in tests/ or robot/
+        │   │
+        │   └─ IF no test infrastructure found:
+        │      - Write a manual test checklist in the PR body (Step 5 will use it)
+        │      - Format as markdown checklist:
+        │        ## Test Plan
+        │        - [ ] Step 1: description → expected result
+        │        - [ ] Step 2: description → expected result
+        │      - Add a recommendation note:
+        │        > This project has no automated test infrastructure.
+        │        > Consider adopting [test-framework-template](https://github.com/dogkeeper886/test-framework-template)
+        │        > for YAML-driven CI testing with dual-judge verification.
+        │      - Ask the user: "Want me to create a follow-up issue for CI setup?"
+        │        If yes → create issue labeled "enhancement" + "testing"
+        │
+        ├─► Step 5: Report
+        │   - Summarize what was created:
+        │     - Test framework detected (or "none")
+        │     - CI detected (or "none")
+        │     - Files created/modified
+        │     - Test run result (if applicable)
+        │   - If tests were written, show the test run output
+        │   - Suggest: proceed to /dw-create-pr
+        │
+        └─► Step 5b: On Test Failure
+            - If generated tests fail, investigate:
+              - Is the implementation incomplete?
+              - Is the test expectation wrong?
+            - Fix tests or flag implementation gap to the user
+            - Do not proceed to /dw-create-pr with failing tests
+
+---
+
+## EXAMPLE 1: Project with test-framework-template
+
+    /dw-test-design 47
+
+**Agent detects cicd/tests/testcases/ with YAML files:**
+
+    Detected: test-framework-template (YAML + dual-judge)
+    CI: GitHub Actions (.github/workflows/test-pipeline.yml)
+    Issue #47: enhancement → Type C (changed behavior)
+
+**Generates YAML test case:**
+
+    Created: cicd/tests/testcases/integration/TC-INTEGRATION-002.yml
+    Running: npm test -- --suite integration --no-llm
+    Result: 2 tests passed (0 failed)
+
+    Next: /dw-create-pr 47
+
+---
+
+## EXAMPLE 2: Project with pytest
+
+    /dw-test-design 12
+
+**Agent detects tests/ + conftest.py:**
+
+    Detected: pytest (tests/conftest.py found)
+    CI: GitHub Actions (.github/workflows/ci.yml)
+    Issue #12: bug → Type B (regression test)
+
+**Generates pytest file:**
+
+    Created: tests/test_issue_12_login_fix.py
+    Running: pytest tests/test_issue_12_login_fix.py -v
+    Result: 3 tests passed
+
+    Next: /dw-create-pr 12
+
+---
+
+## EXAMPLE 3: Project with no test infrastructure
+
+    /dw-test-design 5
+
+**Agent finds no test framework or CI:**
+
+    Detected: no test framework
+    CI: none
+
+    Wrote manual test checklist (will be included in PR body):
+    ## Test Plan
+    - [ ] Navigate to settings page → form loads without errors
+    - [ ] Change display name → saves and shows success message
+    - [ ] Enter invalid email → shows validation error
+
+    > This project has no automated test infrastructure.
+    > Consider adopting [test-framework-template](https://github.com/dogkeeper886/test-framework-template)
+    > for YAML-driven CI testing with dual-judge verification.
+
+    Create follow-up issue for CI setup? [y/n]
+
+    Next: /dw-create-pr 5
+
+---
+
+## API Notes
+
+- Uses `gh` CLI for issue operations
+- Test detection is file-based — scans project root for known patterns
+- Does not install or configure test frameworks — only generates test files
+  for what already exists
+- When multiple test frameworks coexist, prefer the one closest to the
+  changed files
+- Always run tests locally before committing to catch generation errors
+```

--- a/.claude/rules/dev-workflow.md
+++ b/.claude/rules/dev-workflow.md
@@ -1,0 +1,72 @@
+---
+paths:
+  - "commands/dev-workflow/**/*.md"
+---
+
+# dev-workflow
+
+Turns a need into shipped code. A story states the **need** (a goal, not a spec); a
+**plan issue** states the agreed **approach**; task issues carry the *how* as it's worked
+out. Each producer is paired with a review — no producer ships without one.
+
+## The flow
+
+```
+   docs/stories/STORY-XXX.md
+            │
+   dw-story ───────► dw-review-story    the need — complete, and a goal not a spec
+            │
+            ▼
+   dw-plan ────────► [human reviews the plan issue]   research → ONE plan issue: the approach
+            │                                           (skip for trivial / single-task work)
+            ▼
+   dw-tasks ───────► dw-review-tasks    plan issue → task issues, each "Part of #<plan>"
+            │
+            ▼
+   dw-implement ───► dw-review-implement   build the issue; the plan issue is the
+            │                               checkpoint a fresh session resumes from
+            ▼
+   dw-create-pr ───► [human review + /review]   open the PR
+            │
+            ▼
+   dw-merge          green CI + human review → merge
+```
+
+## The plan issue
+
+The plan is a **GitHub issue**, one per story, labelled `plan`, titled `[STORY-XXX] Plan`.
+Its body holds the researched approach, acceptance criteria, and the commands/files it
+expects to touch. It is the **parent** of the task issues (`dw-tasks` links each task back
+with "Part of #<plan>"), and the durable checkpoint that survives a lost session.
+
+Its review is a **human gate**: a person reads, comments, and approves the issue on GitHub
+before `dw-tasks` decomposes it — no `dw-*` command produces or gates it (mirrors the
+`[human review + /review]` gate before a merge).
+
+## Producer → review pairing
+
+| Producer | Review | Covers |
+|----------|--------|--------|
+| `dw-story`     | `dw-review-story`     | the need: complete, and a goal not a spec |
+| `dw-plan`      | **human review** (the plan issue) | the approach covers the story, before decomposition |
+| `dw-tasks`     | `dw-review-tasks`     | the issues cover the plan; each lean; trace back to the plan |
+| `dw-implement` | `dw-review-implement` | the change delivers the issue, surgical, fits the project |
+| `dw-test-design` | *(verified by running the suite)* | tests pass, native to the framework |
+| `dw-create-pr` | *(human review + `/review`)* | the PR overview before merge |
+| `dw-merge`     | *(is the terminal gate)* | green CI + human review |
+
+No producer ships without a review covering its output.
+
+## Right-size it
+
+The plan stage is for non-trivial stories. A one-line doc change or a single-task story
+**skips `dw-plan`** — `dw-story` hands off straight to `dw-tasks` (or a lone issue). Three
+review passes plus a plan issue on a typo is ritual, not rigor.
+
+## What is reused, not rebuilt
+
+- **The story + issues** are the unit of work — a story in `docs/stories/`, its task
+  issues on GitHub.
+- **GitHub issues** already hold the work; the plan is one too (the parent), so the
+  approach, its review, and its history live where the tasks do — no separate plan store.
+- **CI** is the project's existing checks + human review — the merge gate, not a new pipeline.

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "android-wifi": {
+      "command": "node",
+      "args": [
+        "/home/jack/src/android-wifi-mcp/bin/android-wifi-shim.mjs",
+        "http://localhost:3000/mcp"
+      ]
+    }
+  }
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -3,7 +3,7 @@
     "android-wifi": {
       "command": "node",
       "args": [
-        "/home/jack/src/android-wifi-mcp/bin/android-wifi-shim.mjs",
+        "bin/android-wifi-shim.mjs",
         "http://localhost:3000/mcp"
       ]
     }


### PR DESCRIPTION
## Summary
- **`.mcp.json`** — registers the `android-wifi` backend for Claude Code via the bundled stdio shim (`bin/android-wifi-shim.mjs` → `http://localhost:3000/mcp`), since Claude Code's native HTTP MCP client crashes against the Streamable HTTP server (issue #7).
- **`.claude/commands/dev-workflow/`** — the `dw-*` slash commands (plan / story / tasks / implement / review / create-pr / merge) for the issue→PR workflow.
- **`.claude/rules/dev-workflow.md`** — dev-workflow rule.

Tooling/config only — no runtime code changes.

## Test plan
- [ ] After `npm start`, Claude Code picks up `.mcp.json` and the `android-wifi` server connects (tools/list returns the native tools).
- [ ] `dw-*` slash commands are available in this repo.

Generated with [Claude Code](https://claude.com/claude-code)