### PR TITLE
Add host setup + server lifecycle Make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,77 @@
-.PHONY: up down restart logs psql migrate migrate-down test test-unit build clean
+.PHONY: up down restart logs psql migrate migrate-down test test-unit build clean \
+        doctor adb devices serve serve-stop serve-restart setup help
 
 COMPOSE ?= docker compose
 PSQL_USER ?= mcp
 PSQL_DB ?= android_wifi_mcp
+PORT ?= 3000
+
+# Bare `make` prints help rather than starting the Postgres stack.
+.DEFAULT_GOAL := help
+
+help:
+	@echo "Host setup / server lifecycle:"
+	@echo "  make doctor        preflight: node, adb, device, build, server"
+	@echo "  make adb           install adb (Fedora/dnf: android-tools)"
+	@echo "  make devices       list connected adb devices"
+	@echo "  make serve         start the MCP backend (foreground, :$(PORT))"
+	@echo "  make serve-stop    stop the running backend"
+	@echo "  make serve-restart restart the backend"
+	@echo "  make setup         ensure adb + build, then run doctor"
+	@echo ""
+	@echo "Logging stack (Postgres):"
+	@echo "  make up / down / restart / logs / psql / migrate"
+	@echo ""
+	@echo "Build / test:"
+	@echo "  make build / test / test-unit / clean"
+
+# ---- Host setup & server lifecycle -----------------------------------------
+
+doctor:
+	@echo "android-wifi-mcp host preflight"
+	@echo "-------------------------------"
+	@printf "node          : "; command -v node >/dev/null 2>&1 && node -v || echo "MISSING"
+	@printf "npm           : "; command -v npm  >/dev/null 2>&1 && npm -v  || echo "MISSING"
+	@printf "adb           : "; command -v adb  >/dev/null 2>&1 && (adb version | head -1) || echo "MISSING        -> make adb"
+	@printf "node_modules  : "; [ -d node_modules ] && echo "present" || echo "MISSING        -> npm install"
+	@printf "dist build    : "; [ -f dist/index.js ] && echo "present" || echo "MISSING        -> make build"
+	@printf "device        : "; if command -v adb >/dev/null 2>&1; then \
+		d=$$(adb devices | awk 'NR>1 && NF>=2'); \
+		ready=$$(printf '%s\n' "$$d" | awk '$$2=="device"' | grep -c .); \
+		if [ -z "$$d" ]; then echo "none connected -> plug in phone, enable USB debugging"; \
+		elif [ "$$ready" -gt 0 ]; then echo "$$ready ready"; \
+		elif printf '%s\n' "$$d" | grep -q unauthorized; then echo "UNAUTHORIZED   -> tap Allow on the phone RSA prompt"; \
+		else echo "attached but not ready ($$(printf '%s\n' "$$d" | awk '{print $$2}' | sort -u | tr '\n' ' ')) -> check cable/USB mode"; fi; \
+	else echo "skipped (no adb)"; fi
+	@printf "server :$(PORT)   : "; curl -fsS http://localhost:$(PORT)/health >/dev/null 2>&1 && echo "up" || echo "down           -> make serve"
+
+adb:
+	@command -v dnf >/dev/null 2>&1 || { echo "make adb targets dnf (Fedora). On other distros install Android platform-tools manually and put adb on PATH."; exit 1; }
+	sudo dnf install -y android-tools
+	@adb version | head -1
+
+devices:
+	@command -v adb >/dev/null 2>&1 || { echo "adb not found -> make adb"; exit 1; }
+	adb devices
+
+serve:
+	@command -v adb >/dev/null 2>&1 || echo "warning: adb not on PATH — server will start but device tools will fail (make adb)"
+	PORT=$(PORT) npm start
+
+serve-stop:
+	PORT=$(PORT) npm run stop
+
+serve-restart:
+	PORT=$(PORT) npm run restart
+
+setup:
+	@command -v adb >/dev/null 2>&1 || $(MAKE) adb
+	$(MAKE) build
+	@$(MAKE) doctor
+	@echo ""
+	@echo "Next: make serve   (then reconnect the MCP client)"
+
+# ---- Logging stack (Postgres) ----------------------------------------------
 
 up:
 	$(COMPOSE) up -d


### PR DESCRIPTION
## Summary
- Add `make` targets so the Makefile owns first-run host setup and the MCP backend lifecycle, not just the Postgres logging stack.
- `doctor` (preflight: node, adb, device state, build, server health), `adb` (install android-tools on Fedora, guarded for non-dnf hosts), `devices`, `serve` / `serve-stop` / `serve-restart`, `setup`, and `help`.
- `.DEFAULT_GOAL := help` so bare `make` prints the target index instead of starting Postgres (previously bare `make` ran `up`).
- `doctor`'s device check distinguishes ready-count / `unauthorized` / none / other attached-but-not-ready states.

Motivation: the MCP failed to connect because the backend wasn't running and `adb` wasn't installed; nothing in the Makefile covered that path. These targets make the setup reproducible and self-diagnosing.

Not issue-tracked (`feature/` branch per repo convention for non-issue work).

## Test plan
- [x] `make help` / bare `make` prints target index (default goal)
- [x] `make doctor` reports accurate host state (adb, `1 ready` device, server up)
- [x] `make -n` parses every new target cleanly
- [x] All 11 original `.PHONY` targets retained
- [ ] `make adb` on a fresh Fedora host installs `/usr/bin/adb`
- [ ] `make adb` on a non-dnf host fails with the guard message

Generated with [Claude Code](https://claude.com/claude-code)