### PR TITLE
fix: detect captive portal via Android verdict, not curl (#76)

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ Enterprise WiFi (802.1X/EAP) requires a companion Android app because the `cmd w
 | `network_ping` | Ping a host from the device |
 | `network_dns_lookup` | Perform DNS lookup |
 | `network_check_internet` | Check internet connectivity |
-| `network_check_captive` | Check for captive portal |
+| `network_check_captive` | Detect captive portal via Android's connectivity verdict (open/captive/unknown) |
 | `network_interface_info` | Get IP, gateway, DNS info |
 
 ### SMS / OTP

--- a/cicd/tests/testcases/smoke/TC-SMK-014.yml
+++ b/cicd/tests/testcases/smoke/TC-SMK-014.yml
@@ -1,0 +1,24 @@
+id: TC-SMK-014
+name: network_check_captive returns an Android-sourced tri-state verdict
+suite: smoke
+tags: [smoke, network, captive]
+priority: 14
+timeout: 60000
+dependencies: []
+
+steps:
+  - name: Check captive portal status
+    command: npx tsx cicd/tests/src/mcp-client.ts network_check_captive '{}'
+    expectPatterns:
+      - "status.*(open|captive|unknown)"
+    rejectPatterns:
+      - "isError"
+      - "Failed to check captive portal"
+
+criteria: |
+  Verify network_check_captive reads Android's own connectivity verdict
+  (dumpsys connectivity) instead of the removed curl probe (#76).
+  - Returns a tri-state `status` of open / captive / unknown
+  - Never the old "Failed to check captive portal" false negative, which
+    fired on every network because modern Android ships no HTTP client
+  - On the smoke device (validated internet) the expected status is `open`

--- a/src/network/network-check.ts
+++ b/src/network/network-check.ts
@@ -151,60 +151,54 @@ export class NetworkCheck {
   }
 
   /**
-   * Check for captive portal
+   * Check for a captive portal using Android's own network validation.
+   *
+   * The previous implementation shelled out to `curl`, but modern Android
+   * images ship no HTTP client (no curl/wget — only ping/nc/toybox). Every
+   * call therefore failed with exit 127 and returned a false `isCaptive:false`
+   * on *every* network, captive or not (#76). Instead we read the verdict that
+   * Android's ConnectivityService already computed — the same one that raises
+   * the "Sign in to Wi-Fi network" notification — from `dumpsys connectivity`.
    */
   async checkCaptivePortal(): Promise<CaptivePortalResult> {
-    // Android's captive portal detection URL
-    const captiveCheckUrl = 'http://connectivitycheck.gstatic.com/generate_204';
-
-    const result = await this.adb.shell(
-      `curl -s -o /dev/null -w "%{http_code}\\n%{redirect_url}" --connect-timeout 5 --max-time 10 -L "${captiveCheckUrl}"`
-    );
-
-    if (!result.success) {
+    const dump = await this.adb.shell('dumpsys connectivity');
+    if (!dump.success) {
       return {
         isCaptive: false,
-        error: 'Failed to check captive portal',
+        status: 'unknown',
+        error: 'Failed to read connectivity state (dumpsys connectivity)',
       };
     }
 
-    const lines = result.stdout.trim().split('\n');
-    const httpCode = parseInt(lines[0], 10);
-    const redirectUrl = lines[1] || '';
-
-    // 204 = No captive portal
-    if (httpCode === 204) {
+    const agentLine = findActiveWifiAgentLine(dump.stdout);
+    if (agentLine === null) {
       return {
         isCaptive: false,
+        status: 'unknown',
+        error: 'No connected Wi-Fi network found',
       };
     }
 
-    // 301/302 with redirect = Captive portal
-    if ((httpCode === 301 || httpCode === 302) && redirectUrl) {
+    const caps = parseCapabilities(agentLine);
+
+    if (caps.includes('CAPTIVE_PORTAL')) {
       return {
         isCaptive: true,
-        portalUrl: redirectUrl,
+        status: 'captive',
+        portalUrl: extractPortalUrl(agentLine),
       };
     }
 
-    // 200 with different content = Captive portal serving a page
-    if (httpCode === 200) {
-      // Get actual content to see if it's a portal
-      const contentResult = await this.adb.shell(
-        `curl -s --connect-timeout 5 --max-time 10 "${captiveCheckUrl}" | head -c 200`
-      );
-
-      if (contentResult.success && contentResult.stdout.length > 0) {
-        // If we got content, it's likely a captive portal
-        return {
-          isCaptive: true,
-          portalUrl: captiveCheckUrl,
-        };
-      }
+    if (caps.includes('VALIDATED')) {
+      return { isCaptive: false, status: 'open' };
     }
 
+    // Connected but neither captive nor validated yet — partial/limbo. Report
+    // 'unknown' rather than 'open' so callers don't read it as a clean pass.
     return {
       isCaptive: false,
+      status: 'unknown',
+      error: 'Network connected but not yet validated (no captive-portal flag)',
     };
   }
 
@@ -255,4 +249,64 @@ export class NetworkCheck {
 
     return result;
   }
+}
+
+/**
+ * Find the `NetworkAgentInfo` line for the device's Wi-Fi network in
+ * `dumpsys connectivity` output (each agent prints on one line). Prefers the
+ * agent whose id matches the `Active default network: N` header — important
+ * when several networks are briefly connected at once, e.g. during a Wi-Fi
+ * handover (the captive→post-auth transition this tool exists for) or a
+ * primary + restricted/guest pair, where the *first* WIFI agent is not
+ * necessarily the one carrying the live verdict. Falls back to the first
+ * connected Wi-Fi agent (covers the case where the default network is
+ * cellular because Wi-Fi failed validation). Returns null if none found.
+ *
+ * Pure function — exported for unit testing.
+ */
+export function findActiveWifiAgentLine(dump: string): string | null {
+  const lines = dump.split('\n');
+  const isConnectedWifi = (line: string): boolean =>
+    line.includes('NetworkAgentInfo') && /ni\{WIFI CONNECTED/.test(line);
+
+  const def = dump.match(/Active default network:\s*(\d+)/);
+  if (def) {
+    const marker = `NetworkAgentInfo{network{${def[1]}}`;
+    for (const line of lines) {
+      if (line.includes(marker) && isConnectedWifi(line)) return line;
+    }
+  }
+  for (const line of lines) {
+    if (isConnectedWifi(line)) return line;
+  }
+  return null;
+}
+
+/**
+ * Parse the NetworkCapabilities token list out of a NetworkAgentInfo line,
+ * e.g. `... nc{[ ... Capabilities: NOT_METERED&INTERNET&VALIDATED&... ]}`.
+ * Returns the tokens split on `&` so callers match exactly (a substring test
+ * would conflate a token with a longer one). Empty array if none found.
+ *
+ * Pure function — exported for unit testing.
+ */
+export function parseCapabilities(agentLine: string): string[] {
+  const m = agentLine.match(/Capabilities:\s*([A-Za-z_&]+)/);
+  return m ? m[1].split('&') : [];
+}
+
+/**
+ * Best-effort extraction of a captive-portal URL from a single
+ * NetworkAgentInfo line (Android exposes it via CaptivePortalData when
+ * present). Scoped to the agent line — not the whole dump — so it can't pick
+ * up an unrelated URL elsewhere in the output. Returns undefined when no URL
+ * is advertised, which is common since many portals only redirect.
+ *
+ * Pure function — exported for unit testing.
+ */
+export function extractPortalUrl(agentLine: string): string | undefined {
+  const m = agentLine.match(
+    /(?:userPortalUrl|CaptivePortalApiUrl|venueInfoUrl|redirectUrl)=([^\s,}\]]+)/
+  );
+  return m && m[1] && m[1] !== 'null' ? m[1] : undefined;
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -778,7 +778,7 @@ export function createMcpServer(
 
   mcpServer.tool(
     'network_check_captive',
-    'Check for captive portal on the device',
+    "Detect captive portal via Android's connectivity verdict (open/captive/unknown)",
     {},
     async () => {
       await ensureDevice();

--- a/src/types.ts
+++ b/src/types.ts
@@ -111,6 +111,13 @@ export interface ConnectivityResult {
 
 export interface CaptivePortalResult {
   isCaptive: boolean;
+  /**
+   * Tri-state verdict. `captive` = portal detected, `open` = network validated
+   * (real internet), `unknown` = could not determine (connected-but-unvalidated,
+   * or the verdict was unreadable). Distinguishing `unknown` from `open` keeps a
+   * probe failure from masquerading as a clean negative (#76).
+   */
+  status: 'captive' | 'open' | 'unknown';
   portalUrl?: string;
   error?: string;
 }

--- a/tests/unit/captive-portal.test.mjs
+++ b/tests/unit/captive-portal.test.mjs
@@ -1,0 +1,142 @@
+/**
+ * Unit tests for captive-portal detection (#76).
+ *
+ * The old curl-based probe always failed on modern Android (no HTTP client),
+ * returning a false `isCaptive:false`. checkCaptivePortal now reads Android's
+ * own verdict from `dumpsys connectivity`. These tests cover the pure parsers
+ * and the tri-state result against a fake AdbClient — no device needed.
+ *
+ * Run with: npm run test:unit
+ * Requires: npm run build (imports from dist/)
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  NetworkCheck,
+  findActiveWifiAgentLine,
+  parseCapabilities,
+  extractPortalUrl,
+} from '../../dist/network/network-check.js';
+
+// A trimmed but faithful NetworkAgentInfo line as emitted by a real Pixel 8.
+const VALIDATED_DUMP = `
+Active default network: 113
+NetworkAgentInfo{network{113}  handle{488737001485}  ni{WIFI CONNECTED extra: }  nc{[ Transports: WIFI Capabilities: NOT_METERED&INTERNET&NOT_RESTRICTED&TRUSTED&NOT_VPN&VALIDATED&NOT_ROAMING&FOREGROUND&NOT_CONGESTED ]} }
+`;
+
+const CAPTIVE_DUMP = `
+Active default network: 120
+NetworkAgentInfo{network{120}  handle{1}  ni{WIFI CONNECTED extra: }  nc{[ Transports: WIFI Capabilities: INTERNET&NOT_RESTRICTED&TRUSTED&NOT_VPN&CAPTIVE_PORTAL&NOT_ROAMING ]}  lp{ CaptivePortalData{ userPortalUrl=https://portal.example.com/login?x=1 isCaptive=true } } }
+`;
+
+const UNVALIDATED_DUMP = `
+Active default network: 121
+NetworkAgentInfo{network{121}  ni{WIFI CONNECTED extra: }  nc{[ Transports: WIFI Capabilities: INTERNET&NOT_RESTRICTED&TRUSTED&NOT_VPN ]} }
+`;
+
+const NO_WIFI_DUMP = `
+Active default network: 50
+NetworkAgentInfo{network{50}  ni{MOBILE CONNECTED extra: }  nc{[ Transports: CELLULAR Capabilities: INTERNET&VALIDATED ]} }
+`;
+
+// Two WIFI agents connected at once (handover / guest+primary). The FIRST line
+// is a restricted captive agent; the DEFAULT network (113) is the validated
+// one. A first-match parser would wrongly report captive (#76 review, Bug 4).
+const TWO_WIFI_DUMP = `
+Active default network: 113
+NetworkAgentInfo{network{120}  ni{WIFI CONNECTED extra: }  nc{[ Transports: WIFI Capabilities: INTERNET&CAPTIVE_PORTAL ]} }
+NetworkAgentInfo{network{113}  ni{WIFI CONNECTED extra: }  nc{[ Transports: WIFI Capabilities: INTERNET&VALIDATED ]} }
+`;
+
+function ok(stdout) {
+  return { success: true, stdout, stderr: '', exitCode: 0 };
+}
+
+class FakeAdbClient {
+  constructor(dumpStdout, dumpSucceeds = true) {
+    this.dumpStdout = dumpStdout;
+    this.dumpSucceeds = dumpSucceeds;
+  }
+  async shell(command) {
+    if (command.includes('dumpsys connectivity')) {
+      return this.dumpSucceeds
+        ? ok(this.dumpStdout)
+        : { success: false, stdout: '', stderr: 'failed', exitCode: 1 };
+    }
+    return ok('');
+  }
+}
+
+test('findActiveWifiAgentLine: returns the connected WIFI agent line', () => {
+  const line = findActiveWifiAgentLine(VALIDATED_DUMP);
+  assert.ok(line.includes('network{113}'));
+});
+
+test('findActiveWifiAgentLine: prefers the default network over the first WIFI agent', () => {
+  const line = findActiveWifiAgentLine(TWO_WIFI_DUMP);
+  assert.ok(line.includes('network{113}'), 'should pick default net 113, not first agent 120');
+  assert.ok(!line.includes('network{120}'));
+});
+
+test('findActiveWifiAgentLine: null when no connected WIFI network', () => {
+  assert.equal(findActiveWifiAgentLine(NO_WIFI_DUMP), null);
+  assert.equal(findActiveWifiAgentLine(''), null);
+});
+
+test('parseCapabilities: splits tokens, exact membership (no substring traps)', () => {
+  const caps = parseCapabilities(findActiveWifiAgentLine(VALIDATED_DUMP));
+  assert.ok(caps.includes('VALIDATED'));
+  assert.ok(!caps.includes('CAPTIVE_PORTAL'));
+  assert.deepEqual(parseCapabilities('no caps here'), []);
+});
+
+test('extractPortalUrl: reads CaptivePortalData URL, undefined otherwise', () => {
+  assert.equal(
+    extractPortalUrl(findActiveWifiAgentLine(CAPTIVE_DUMP)),
+    'https://portal.example.com/login?x=1'
+  );
+  assert.equal(extractPortalUrl(findActiveWifiAgentLine(VALIDATED_DUMP)), undefined);
+});
+
+test('checkCaptivePortal: validated network -> open', async () => {
+  const nc = new NetworkCheck(new FakeAdbClient(VALIDATED_DUMP));
+  const r = await nc.checkCaptivePortal();
+  assert.equal(r.status, 'open');
+  assert.equal(r.isCaptive, false);
+});
+
+test('checkCaptivePortal: captive network -> captive + portalUrl', async () => {
+  const nc = new NetworkCheck(new FakeAdbClient(CAPTIVE_DUMP));
+  const r = await nc.checkCaptivePortal();
+  assert.equal(r.status, 'captive');
+  assert.equal(r.isCaptive, true);
+  assert.equal(r.portalUrl, 'https://portal.example.com/login?x=1');
+});
+
+test('checkCaptivePortal: two WIFI agents -> reads the default (validated) one', async () => {
+  const nc = new NetworkCheck(new FakeAdbClient(TWO_WIFI_DUMP));
+  const r = await nc.checkCaptivePortal();
+  assert.equal(r.status, 'open');
+  assert.equal(r.isCaptive, false);
+});
+
+test('checkCaptivePortal: connected-but-unvalidated -> unknown (not a clean negative)', async () => {
+  const nc = new NetworkCheck(new FakeAdbClient(UNVALIDATED_DUMP));
+  const r = await nc.checkCaptivePortal();
+  assert.equal(r.status, 'unknown');
+  assert.equal(r.isCaptive, false);
+});
+
+test('checkCaptivePortal: no wifi network -> unknown with error', async () => {
+  const nc = new NetworkCheck(new FakeAdbClient(NO_WIFI_DUMP));
+  const r = await nc.checkCaptivePortal();
+  assert.equal(r.status, 'unknown');
+  assert.match(r.error, /No connected Wi-Fi/);
+});
+
+test('checkCaptivePortal: dumpsys failure -> unknown, never a false open', async () => {
+  const nc = new NetworkCheck(new FakeAdbClient('', false));
+  const r = await nc.checkCaptivePortal();
+  assert.equal(r.status, 'unknown');
+  assert.equal(r.isCaptive, false);
+});


### PR DESCRIPTION
## Summary
- `network_check_captive` shelled out to `curl`, but modern Android ships **no HTTP client** (curl/wget absent — only ping/nc/toybox). Every call failed with exit 127 and returned a false `isCaptive:false, error:"Failed to check captive portal"` on *every* network — the issue caught it on a captive network, but the cause was the missing binary, not DNS blocking.
- Now reads the verdict Android already computed (the one that raises the "Sign in to Wi-Fi network" notification) from `dumpsys connectivity`. Result is tri-state (`open`/`captive`/`unknown`) so a non-determination can't masquerade as a clean negative.
- Parser hardened via code review: selects the agent named by `Active default network: N` (correct during Wi-Fi handover / guest+primary), exact token matching, portal-URL extraction scoped to the agent line.

Fixes #76

## Test plan
- [x] `npm run test:unit` — 160 pass, incl. the two-Wi-Fi default-selection case
- [x] TC-SMK-014 runs the tool end-to-end on a live device
- [x] Parser re-verified against real `dumpsys connectivity` (picks default-net 113 → `open`, where the old curl path returned the false negative)
- [ ] Reviewer: confirm on a genuinely captive network that `status: captive` + `portalUrl` populate

Generated with [Claude Code](https://claude.com/claude-code)