### PR TITLE
fix(host): udev rule + make target for non-root adb access

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
 .PHONY: up down restart logs psql migrate migrate-down test test-unit build clean \
-        doctor adb devices serve serve-stop serve-restart setup help
+        doctor adb devices udev serve serve-stop serve-restart setup help
 
 COMPOSE ?= docker compose
 PSQL_USER ?= mcp
 PSQL_DB ?= android_wifi_mcp
 PORT ?= 3000
+UDEV_RULE ?= /etc/udev/rules.d/51-android-wifi-mcp.rules
 
 # Bare `make` prints help rather than starting the Postgres stack.
 .DEFAULT_GOAL := help
@@ -13,6 +14,7 @@ help:
 	@echo "Host setup / server lifecycle:"
 	@echo "  make doctor        preflight: node, adb, device, build, server"
 	@echo "  make adb           install adb (Fedora/dnf: android-tools)"
+	@echo "  make udev          install udev rule for non-root adb access (Linux)"
 	@echo "  make devices       list connected adb devices"
 	@echo "  make serve         start the MCP backend (foreground, :$(PORT))"
 	@echo "  make serve-stop    stop the running backend"
@@ -40,6 +42,7 @@ doctor:
 		ready=$$(printf '%s\n' "$$d" | awk '$$2=="device"' | grep -c .); \
 		if [ -z "$$d" ]; then echo "none connected -> plug in phone, enable USB debugging"; \
 		elif [ "$$ready" -gt 0 ]; then echo "$$ready ready"; \
+		elif printf '%s\n' "$$d" | grep -q "no permissions"; then echo "NO PERMISSIONS -> make udev (install Android udev rule)"; \
 		elif printf '%s\n' "$$d" | grep -q unauthorized; then echo "UNAUTHORIZED   -> tap Allow on the phone RSA prompt"; \
 		else echo "attached but not ready ($$(printf '%s\n' "$$d" | awk '{print $$2}' | sort -u | tr '\n' ' ')) -> check cable/USB mode"; fi; \
 	else echo "skipped (no adb)"; fi
@@ -49,6 +52,15 @@ adb:
 	@command -v dnf >/dev/null 2>&1 || { echo "make adb targets dnf (Fedora). On other distros install Android platform-tools manually and put adb on PATH."; exit 1; }
 	sudo dnf install -y android-tools
 	@adb version | head -1
+
+udev:
+	@command -v udevadm >/dev/null 2>&1 || { echo "udevadm not found — this target is Linux-only (udev). On other OSes adb permissions are handled differently."; exit 1; }
+	sudo install -m 0644 setup/udev/51-android-wifi-mcp.rules $(UDEV_RULE)
+	sudo udevadm control --reload-rules
+	sudo udevadm trigger --subsystem-match=usb --action=add
+	@echo "Installed $(UDEV_RULE). Re-applied to currently attached devices."
+	@command -v adb >/dev/null 2>&1 && { adb kill-server >/dev/null 2>&1 || true; adb start-server >/dev/null 2>&1 || true; } || true
+	@$(MAKE) --no-print-directory doctor | grep '^device' || true
 
 devices:
 	@command -v adb >/dev/null 2>&1 || { echo "adb not found -> make adb"; exit 1; }

--- a/README.md
+++ b/README.md
@@ -93,6 +93,19 @@ adb devices
 
 You should see your device listed as "device" (not "unauthorized" or "offline").
 
+**Linux: if adb reports `no permissions`** — the device node is owned by root and
+your user can't open it. This is common when the server runs headless or as a
+service (no active local seat, so systemd-logind's `uaccess` ACL never applies).
+Install the bundled udev rule once:
+
+```bash
+make udev          # installs setup/udev/51-android-wifi-mcp.rules, reloads, re-triggers
+```
+
+The rule matches the ADB USB interface, so it covers any Android device and
+persists across replug/reboot. Without it a one-off `chmod` works but reverts on
+the next replug (the device node number changes).
+
 ### 3. Install and Run MCP Server
 
 ```bash

--- a/setup/udev/51-android-wifi-mcp.rules
+++ b/setup/udev/51-android-wifi-mcp.rules
@@ -1,0 +1,17 @@
+# android-wifi-mcp: non-root adb access for any Android device.
+#
+# Matches the ADB USB interface (bInterfaceClass=ff, bInterfaceSubClass=42,
+# bInterfaceProtocol=01 — encoded by udev as ":ff4201:") instead of a vendor ID,
+# so it applies to every vendor (Pixel, Samsung, etc.) with no list to maintain.
+#
+# Why this exists: when the MCP backend runs headless or as a service — its
+# intended "persistent backend" deployment — there is no active local seat, so
+# systemd-logind's uaccess ACL never grants the user access and adb reports
+# "no permissions". MODE=0666 guarantees access regardless of seat or group.
+#
+# Stricter alternative for multi-user hosts: replace MODE="0666" with
+#   MODE="0660", GROUP="plugdev"
+# and add the adb user to the plugdev group (newgrp / re-login to take effect).
+#
+# Install with `make udev` (copies this file to /etc/udev/rules.d/ and reloads).
+SUBSYSTEM=="usb", ENV{ID_USB_INTERFACES}=="*:ff4201:*", MODE="0666", TAG+="uaccess"


### PR DESCRIPTION
## Summary
- Modern Android device nodes are root-owned. When the MCP backend runs headless or as a service there's no active local seat, so systemd-logind's `uaccess` ACL never applies and adb reports **`no permissions`** (distinct from the RSA `unauthorized` prompt). A one-off `chmod` works but reverts on the next replug/reboot (the device-node number changes).
- Adds `setup/udev/51-android-wifi-mcp.rules` — matches the **ADB USB interface** (`:ff4201:`), so it's vendor-agnostic (any Android device) — plus a `make udev` target to install/reload/trigger it. `make doctor` now detects the `no permissions` state and points at `make udev`. README gets a short Linux note.

## Why this (not just docs)
We hit this live: an 18h outage that ended in `no permissions`. This is the project's intended deployment (a persistent/headless backend), so the rule is a real setup step, not optional polish.

## Test plan
- [x] `udevadm test /sys/bus/usb/devices/1-7` confirms the rule fires on device-add and sets `MODE=0666` → access persists across replug/reboot
- [x] `make udev` installs + reports `device: 1 ready`; `make help`/`make doctor` parse cleanly
- [ ] Reviewer: confirm on a fresh headless host that adb works after replug without a manual chmod

Generated with [Claude Code](https://claude.com/claude-code)