### PR TITLE
chore(mcp): register the full 3-MCP test composition in .mcp.json

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -6,6 +6,22 @@
         "bin/android-wifi-shim.mjs",
         "http://localhost:3000/mcp"
       ]
+    },
+    "mobile-next": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@mobilenext/mobile-mcp@latest"
+      ]
+    },
+    "playwright-android": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@playwright/mcp@latest",
+        "--cdp-endpoint",
+        "http://localhost:9222"
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary
- `.mcp.json` only registered `android-wifi`. The phone-side QA flows (captive portals, OS UI) need the documented three cooperating servers (`docs/integrations/canary-cdp.md`):
  - **android-wifi** (this project) — via the stdio shim → HTTP backend
  - **mobile-next** ([mobile-mcp](https://github.com/mobile-next/mobile-mcp)) — OS UI
  - **playwright-android** (`@playwright/mcp --cdp-endpoint http://localhost:9222`) — device DOM
- Keeps android-wifi on the **shim**, not the doc's stale `node dist/index.js --stdio` (stdio was removed in #51 Phase 0a).

## Notes
- To actually test with it: the android-wifi backend must be running on `:3000` (`make serve`), and `playwright-android` needs the CDP bridge (`adb forward tcp:9222 localabstract:chrome_devtools_remote`) before `browser_*` calls; it registers fine without it and lazy-connects.
- Follow-up (separate): `canary-cdp.md:19,29` still document android-wifi as `node dist/index.js --stdio` — a stale-doc fix to do alongside #78.

## Test plan
- [x] `.mcp.json` is valid JSON registering all three servers
- [ ] Reviewer: restart the session and confirm all three MCPs connect and tools appear

Generated with [Claude Code](https://claude.com/claude-code)