### PR TITLE
fix(network): modernize network-check for modern-Android primitives (#80)

### DIFF
--- a/src/adb/wifi-commands.ts
+++ b/src/adb/wifi-commands.ts
@@ -1,4 +1,5 @@
 import { AdbClient } from './adb-client.js';
+import { parseRouteGet } from '../network/network-check.js';
 import {
   ScanResult,
   SavedNetwork,
@@ -359,15 +360,16 @@ export class WifiCommands {
   }
 
   /**
-   * Get IP address via alternative method
+   * Get the device's current IPv4 address via the routing table, derived from
+   * the active interface rather than a hardcoded `wlan0` (devices vary —
+   * e.g. Pixel 8 uses wlan1). `ip route get` yields the source IP directly.
    */
   async getIpAddress(): Promise<string | null> {
-    const result = await this.adb.shell('ip addr show wlan0 | grep "inet "');
+    const result = await this.adb.shell('ip route get 8.8.8.8');
     if (!result.success) {
       return null;
     }
 
-    const match = result.stdout.match(/inet\s+([0-9.]+)/);
-    return match ? match[1] : null;
+    return parseRouteGet(result.stdout).ipAddress ?? null;
   }
 }

--- a/src/network/network-check.ts
+++ b/src/network/network-check.ts
@@ -17,7 +17,7 @@ export class NetworkCheck {
    * Ping a host from the device
    */
   async ping(host: string, count: number = 4): Promise<PingResult> {
-    const result = await this.adb.shell(`ping -c ${count} -W 5 ${host}`);
+    const result = await this.adb.shell(`ping -c ${count} -W 5 ${shQuote(host)}`);
 
     const pingResult: PingResult = {
       host,
@@ -46,56 +46,23 @@ export class NetworkCheck {
   }
 
   /**
-   * Perform DNS lookup from the device
+   * Resolve a hostname from the device.
+   *
+   * Modern Android ships no `nslookup`/`getent` (only ping/nc/toybox), so the
+   * old multi-tool fallback chain always fell through to ping anyway. We resolve
+   * directly with `ping -c 1`, which prints the resolved address as
+   * `PING host (1.2.3.4)`. IPv4 only, matching the prior behavior.
    */
   async dnsLookup(hostname: string): Promise<DnsResult> {
-    // Try nslookup first
-    let result = await this.adb.shell(`nslookup ${hostname}`);
-
     const dnsResult: DnsResult = {
       hostname,
       addresses: [],
     };
 
-    if (result.success) {
-      // Parse nslookup output
-      const lines = result.stdout.split('\n');
-      let inAnswer = false;
-
-      for (const line of lines) {
-        if (line.includes('Name:')) {
-          inAnswer = true;
-        }
-        if (inAnswer) {
-          const addrMatch = line.match(/Address(?:\s+\d)?:\s*([0-9.]+|[0-9a-f:]+)/i);
-          if (addrMatch && !addrMatch[1].includes(':')) {
-            // Skip IPv6 for now, just get IPv4
-            dnsResult.addresses.push(addrMatch[1]);
-          }
-        }
-      }
-    }
-
-    // If nslookup didn't work, try getent
-    if (dnsResult.addresses.length === 0) {
-      result = await this.adb.shell(`getent hosts ${hostname}`);
-      if (result.success) {
-        const match = result.stdout.match(/^([0-9.]+)/);
-        if (match) {
-          dnsResult.addresses.push(match[1]);
-        }
-      }
-    }
-
-    // If still no results, try ping with count 1 to get IP
-    if (dnsResult.addresses.length === 0) {
-      result = await this.adb.shell(`ping -c 1 ${hostname}`);
-      if (result.success) {
-        const match = result.stdout.match(/\(([0-9.]+)\)/);
-        if (match) {
-          dnsResult.addresses.push(match[1]);
-        }
-      }
+    const result = await this.adb.shell(`ping -c 1 -W 2 ${shQuote(hostname)}`);
+    const match = result.stdout.match(/\(([0-9.]+)\)/);
+    if (match) {
+      dnsResult.addresses.push(match[1]);
     }
 
     if (dnsResult.addresses.length === 0) {
@@ -106,35 +73,28 @@ export class NetworkCheck {
   }
 
   /**
-   * Check internet connectivity
+   * Check internet connectivity.
+   *
+   * The old implementation probed HTTP endpoints with `curl`, which doesn't
+   * exist on modern Android (it only ever worked via the ping fallback). We
+   * prefer Android's own `VALIDATED` verdict — the result of its connectivity
+   * validation, the same signal #76 uses for captive detection — and fall back
+   * to a `ping` when no validated Wi-Fi network is present.
    */
   async checkInternet(): Promise<ConnectivityResult> {
-    const testUrls = [
-      { url: 'https://www.google.com/generate_204', expected: 204 },
-      { url: 'https://connectivitycheck.gstatic.com/generate_204', expected: 204 },
-      { url: 'https://www.cloudflare.com/cdn-cgi/trace', expected: 200 },
-    ];
-
-    for (const test of testUrls) {
-      const startTime = Date.now();
-      const result = await this.adb.shell(
-        `curl -s -o /dev/null -w "%{http_code}" --connect-timeout 5 --max-time 10 "${test.url}"`
-      );
-      const latency = Date.now() - startTime;
-
-      if (result.success) {
-        const httpCode = parseInt(result.stdout.trim(), 10);
-        if (httpCode === test.expected || (httpCode >= 200 && httpCode < 400)) {
-          return {
-            hasInternet: true,
-            latency,
-            endpoint: test.url,
-          };
-        }
+    const dump = await this.adb.shell('dumpsys connectivity');
+    if (dump.success) {
+      const agentLine = findActiveWifiAgentLine(dump.stdout);
+      if (agentLine && parseCapabilities(agentLine).includes('VALIDATED')) {
+        return {
+          hasInternet: true,
+          endpoint: 'android-connectivity (VALIDATED)',
+        };
       }
     }
 
-    // Try a simple ping as fallback
+    // Fallback: a network without VALIDATED (or non-Wi-Fi) may still reach the
+    // internet — confirm with a ping.
     const pingResult = await this.ping('8.8.8.8', 1);
     if (pingResult.alive) {
       return {
@@ -146,7 +106,7 @@ export class NetworkCheck {
 
     return {
       hasInternet: false,
-      error: 'Failed to reach any internet endpoints',
+      error: 'No VALIDATED network and 8.8.8.8 is unreachable',
     };
   }
 
@@ -203,7 +163,14 @@ export class NetworkCheck {
   }
 
   /**
-   * Get network interface information
+   * Get network interface information.
+   *
+   * The old version hardcoded `wlan0` (DOWN on devices that use `wlan1`) and
+   * read DNS from `getprop net.dns*` (empty on modern Android), so it returned
+   * nothing useful. We read the active Wi-Fi network's LinkProperties from
+   * `dumpsys connectivity` (one call → interface, IPv4, gateway, DNS) and fall
+   * back to the routing table (`ip route get 8.8.8.8`) to fill any gaps or
+   * cover the no-Wi-Fi-agent case.
    */
   async getInterfaceInfo(): Promise<{
     interface: string;
@@ -217,38 +184,45 @@ export class NetworkCheck {
       gateway?: string;
       dns?: string[];
     } = {
-      interface: 'wlan0',
+      interface: 'unknown',
     };
 
-    // Get IP address
-    const ipResult = await this.adb.shell('ip addr show wlan0 | grep "inet "');
-    if (ipResult.success) {
-      const match = ipResult.stdout.match(/inet\s+([0-9.]+)/);
-      if (match) {
-        result.ipAddress = match[1];
-      }
+    const dump = await this.adb.shell('dumpsys connectivity');
+    const agentLine = dump.success ? findActiveWifiAgentLine(dump.stdout) : null;
+    if (agentLine) {
+      const iface = parseInterfaceName(agentLine);
+      if (iface) result.interface = iface;
+      const ip = parseIpv4LinkAddress(agentLine);
+      if (ip) result.ipAddress = ip;
+      const gw = parseGateway(agentLine);
+      if (gw) result.gateway = gw;
+      const dns = parseDnsAddresses(agentLine);
+      if (dns.length > 0) result.dns = dns;
     }
 
-    // Get gateway
-    const gwResult = await this.adb.shell('ip route | grep default');
-    if (gwResult.success) {
-      const match = gwResult.stdout.match(/via\s+([0-9.]+)/);
-      if (match) {
-        result.gateway = match[1];
-      }
-    }
-
-    // Get DNS servers
-    const dnsResult = await this.adb.shell('getprop net.dns1 && getprop net.dns2');
-    if (dnsResult.success) {
-      const dnsServers = dnsResult.stdout.split('\n').filter(line => line.trim());
-      if (dnsServers.length > 0) {
-        result.dns = dnsServers;
+    // Fill gaps from the routing table. `ip route get 8.8.8.8` resolves the
+    // outgoing route (dev/src/via) regardless of whether the target is
+    // reachable, so it works pre-auth and on non-wlan0 interfaces.
+    if (result.interface === 'unknown' || !result.ipAddress || !result.gateway) {
+      const route = await this.adb.shell('ip route get 8.8.8.8');
+      if (route.success) {
+        const r = parseRouteGet(route.stdout);
+        if (result.interface === 'unknown' && r.interface) result.interface = r.interface;
+        if (!result.ipAddress && r.ipAddress) result.ipAddress = r.ipAddress;
+        if (!result.gateway && r.gateway) result.gateway = r.gateway;
       }
     }
 
     return result;
   }
+}
+
+/**
+ * Single-quote a string for safe interpolation into a device `adb shell`
+ * command (the host side uses execFile, but the device runs the string in sh).
+ */
+function shQuote(s: string): string {
+  return `'${s.replace(/'/g, "'\\''")}'`;
 }
 
 /**
@@ -309,4 +283,79 @@ export function extractPortalUrl(agentLine: string): string | undefined {
     /(?:userPortalUrl|CaptivePortalApiUrl|venueInfoUrl|redirectUrl)=([^\s,}\]]+)/
   );
   return m && m[1] && m[1] !== 'null' ? m[1] : undefined;
+}
+
+/**
+ * Parse the interface name from a NetworkAgentInfo line's LinkProperties,
+ * e.g. `lp{{InterfaceName: wlan1 LinkAddresses: [...] ...}}`. Undefined if absent.
+ *
+ * Pure function — exported for unit testing.
+ */
+export function parseInterfaceName(agentLine: string): string | undefined {
+  const m = agentLine.match(/InterfaceName:\s*(\S+)/);
+  return m ? m[1] : undefined;
+}
+
+/**
+ * Pick the IPv4 address out of `LinkAddresses: [ fe80::.../64,192.168.6.133/24 ]`.
+ * Skips IPv6 entries. Undefined if no IPv4 link address is present.
+ *
+ * Pure function — exported for unit testing.
+ */
+export function parseIpv4LinkAddress(agentLine: string): string | undefined {
+  const block = agentLine.match(/LinkAddresses:\s*\[([^\]]*)\]/);
+  if (!block) return undefined;
+  for (const addr of block[1].split(',')) {
+    const v4 = addr.trim().match(/^(\d{1,3}(?:\.\d{1,3}){3})\/\d+$/);
+    if (v4) return v4[1];
+  }
+  return undefined;
+}
+
+/**
+ * Parse `DnsAddresses: [ /192.168.6.1, /8.8.8.8 ]` into a list of IPv4 strings
+ * (leading `/` stripped, IPv6 skipped). Empty array if absent.
+ *
+ * Pure function — exported for unit testing.
+ */
+export function parseDnsAddresses(agentLine: string): string[] {
+  const block = agentLine.match(/DnsAddresses:\s*\[([^\]]*)\]/);
+  if (!block) return [];
+  return block[1]
+    .split(',')
+    .map(s => s.trim().replace(/^\//, ''))
+    .filter(s => /^\d{1,3}(?:\.\d{1,3}){3}$/.test(s));
+}
+
+/**
+ * Parse the gateway from a LinkProperties `ServerAddress: /192.168.6.1`.
+ * Undefined if absent.
+ *
+ * Pure function — exported for unit testing.
+ */
+export function parseGateway(agentLine: string): string | undefined {
+  const m = agentLine.match(/ServerAddress:\s*\/?(\d{1,3}(?:\.\d{1,3}){3})/);
+  return m ? m[1] : undefined;
+}
+
+/**
+ * Parse `ip route get 8.8.8.8` output, e.g.
+ * `8.8.8.8 via 192.168.6.1 dev wlan1 table 1048 src 192.168.6.133 uid 2000`.
+ * Returns whichever of interface/ipAddress/gateway are present.
+ *
+ * Pure function — exported for unit testing.
+ */
+export function parseRouteGet(output: string): {
+  interface?: string;
+  ipAddress?: string;
+  gateway?: string;
+} {
+  const res: { interface?: string; ipAddress?: string; gateway?: string } = {};
+  const dev = output.match(/\bdev\s+(\S+)/);
+  if (dev) res.interface = dev[1];
+  const src = output.match(/\bsrc\s+(\d{1,3}(?:\.\d{1,3}){3})/);
+  if (src) res.ipAddress = src[1];
+  const via = output.match(/\bvia\s+(\d{1,3}(?:\.\d{1,3}){3})/);
+  if (via) res.gateway = via[1];
+  return res;
 }

--- a/tests/unit/network-interface.test.mjs
+++ b/tests/unit/network-interface.test.mjs
@@ -1,0 +1,135 @@
+/**
+ * Unit tests for the modern-Android network parsers (#80).
+ *
+ * The old network-check shelled out to curl/nslookup/getent and read a
+ * hardcoded `wlan0` + `getprop net.dns*` — all dead on modern Android. These
+ * cover the replacement parsers that read `dumpsys connectivity` LinkProperties
+ * and `ip route get`, plus the rewritten methods against a fake AdbClient.
+ *
+ * Run with: npm run test:unit  (after npm run build)
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  NetworkCheck,
+  parseInterfaceName,
+  parseIpv4LinkAddress,
+  parseDnsAddresses,
+  parseGateway,
+  parseRouteGet,
+} from '../../dist/network/network-check.js';
+
+// Real Pixel 8 active-WIFI NetworkAgentInfo line (trimmed), incl. the lp{} block.
+const AGENT_LINE =
+  'NetworkAgentInfo{network{113}  ni{WIFI CONNECTED extra: }  nc{[ Transports: WIFI Capabilities: NOT_METERED&INTERNET&NOT_VPN&VALIDATED ]}  lp{{InterfaceName: wlan1 LinkAddresses: [ fe80::4484:80ff:fe8d:80c9/64,192.168.6.133/24 ] DnsAddresses: [ /192.168.6.1 ] Domains: localdomain MTU: 0 ServerAddress: /192.168.6.1 Routes: [ 0.0.0.0/0 -> 192.168.6.1 wlan1 mtu 0 ]}} }';
+
+const VALIDATED_DUMP = `\nActive default network: 113\n${AGENT_LINE}\n`;
+
+const ROUTE_GET =
+  '8.8.8.8 via 192.168.6.1 dev wlan1 table 1048 src 192.168.6.133 uid 2000 \n    cache ';
+
+function ok(stdout) {
+  return { success: true, stdout, stderr: '', exitCode: 0 };
+}
+function fail() {
+  return { success: false, stdout: '', stderr: 'err', exitCode: 1 };
+}
+
+// --- pure parsers ---
+
+test('parseInterfaceName: reads InterfaceName (wlan1, not the hardcoded wlan0)', () => {
+  assert.equal(parseInterfaceName(AGENT_LINE), 'wlan1');
+  assert.equal(parseInterfaceName('no lp here'), undefined);
+});
+
+test('parseIpv4LinkAddress: picks the IPv4 address, skips IPv6', () => {
+  assert.equal(parseIpv4LinkAddress(AGENT_LINE), '192.168.6.133');
+  assert.equal(parseIpv4LinkAddress('LinkAddresses: [ fe80::1/64 ]'), undefined);
+});
+
+test('parseDnsAddresses: strips leading slash, IPv4 only', () => {
+  assert.deepEqual(parseDnsAddresses(AGENT_LINE), ['192.168.6.1']);
+  assert.deepEqual(
+    parseDnsAddresses('DnsAddresses: [ /1.1.1.1, /2606:4700::1111, /8.8.8.8 ]'),
+    ['1.1.1.1', '8.8.8.8']
+  );
+  assert.deepEqual(parseDnsAddresses('no dns'), []);
+});
+
+test('parseGateway: reads ServerAddress', () => {
+  assert.equal(parseGateway(AGENT_LINE), '192.168.6.1');
+  assert.equal(parseGateway('no server'), undefined);
+});
+
+test('parseRouteGet: extracts dev/src/via', () => {
+  assert.deepEqual(parseRouteGet(ROUTE_GET), {
+    interface: 'wlan1',
+    ipAddress: '192.168.6.133',
+    gateway: '192.168.6.1',
+  });
+  assert.deepEqual(parseRouteGet('unreachable'), {});
+});
+
+// --- methods against a fake AdbClient ---
+
+class FakeAdb {
+  constructor(handlers) {
+    this.handlers = handlers;
+    this.calls = [];
+  }
+  async shell(command) {
+    this.calls.push(command);
+    for (const [needle, resp] of this.handlers) {
+      if (command.includes(needle)) return resp;
+    }
+    return ok('');
+  }
+}
+
+test('getInterfaceInfo: reads iface/ip/gw/dns from dumpsys LinkProperties', async () => {
+  const nc = new NetworkCheck(new FakeAdb([['dumpsys connectivity', ok(VALIDATED_DUMP)]]));
+  const info = await nc.getInterfaceInfo();
+  assert.equal(info.interface, 'wlan1');
+  assert.equal(info.ipAddress, '192.168.6.133');
+  assert.equal(info.gateway, '192.168.6.1');
+  assert.deepEqual(info.dns, ['192.168.6.1']);
+});
+
+test('getInterfaceInfo: falls back to ip route get when no Wi-Fi agent', async () => {
+  const nc = new NetworkCheck(
+    new FakeAdb([
+      ['dumpsys connectivity', ok('Active default network: 50\n(no wifi)\n')],
+      ['ip route get', ok(ROUTE_GET)],
+    ])
+  );
+  const info = await nc.getInterfaceInfo();
+  assert.equal(info.interface, 'wlan1');
+  assert.equal(info.ipAddress, '192.168.6.133');
+  assert.equal(info.gateway, '192.168.6.1');
+});
+
+test('checkInternet: VALIDATED network -> hasInternet true, no curl', async () => {
+  const adb = new FakeAdb([['dumpsys connectivity', ok(VALIDATED_DUMP)]]);
+  const nc = new NetworkCheck(adb);
+  const r = await nc.checkInternet();
+  assert.equal(r.hasInternet, true);
+  assert.match(r.endpoint, /VALIDATED/);
+  assert.ok(!adb.calls.some(c => c.includes('curl')), 'must not shell out to curl');
+});
+
+test('dnsLookup: resolves via ping output, quotes the hostname', async () => {
+  const adb = new FakeAdb([['ping', ok('PING ex.com (93.184.216.34) 56(84) bytes')]]);
+  const nc = new NetworkCheck(adb);
+  const r = await nc.dnsLookup('ex.com');
+  assert.deepEqual(r.addresses, ['93.184.216.34']);
+  assert.ok(adb.calls.some(c => c.includes("'ex.com'")), 'hostname should be single-quoted');
+  assert.ok(!adb.calls.some(c => c.includes('nslookup')), 'must not use nslookup');
+});
+
+test('dnsLookup: shell-metachar hostname stays quoted (no injection)', async () => {
+  const adb = new FakeAdb([['ping', ok('')]]);
+  const nc = new NetworkCheck(adb);
+  await nc.dnsLookup('a.com; reboot');
+  const call = adb.calls.find(c => c.includes('ping'));
+  assert.ok(call.includes("'a.com; reboot'"), 'metachars must be inside single quotes');
+});


### PR DESCRIPTION
## Summary
`network-check.ts` assumed a Linux-like device environment modern Android (Pixel 8 / Android 14+) doesn't provide. #76 fixed only the captive path; this fixes the rest:
- **`getInterfaceInfo`** — hardcoded `wlan0` (DOWN; device is on `wlan1`) + `getprop net.dns*` (empty on modern Android) returned nothing. Now reads the active Wi-Fi network's LinkProperties from `dumpsys connectivity` (interface, IPv4, gateway, DNS), with `ip route get 8.8.8.8` to fill gaps / cover the no-Wi-Fi case.
- **`checkInternet`** — `curl` probes (curl absent on device) → Android's `VALIDATED` verdict (same signal #76 uses) + ping fallback.
- **`dnsLookup`** — `nslookup`/`getent` (absent) → `ping -c 1` resolve.
- **`wifi-commands.getIpAddress`** — same hardcoded `wlan0` → shared `parseRouteGet`.
- Hardening: single-quote the host in `ping`/`dnsLookup` (device-shell injection).

New exported pure parsers (unit-tested): `parseInterfaceName`, `parseIpv4LinkAddress`, `parseDnsAddresses`, `parseGateway`, `parseRouteGet`.

Closes #80

## Test plan
- [x] `npm run test:unit` — 170 pass (+10 new, incl. injection-quoting + no-Wi-Fi fallback)
- [x] Live on a Pixel 8 — **validated** net: `getInterfaceInfo` → `{wlan1, 192.168.6.133, gw, dns}` (was empty), `dnsLookup` resolves, `checkInternet` true
- [x] Live on a **captive** net (lab session expired mid-test): `checkInternet` correctly `false`, `checkCaptivePortal` → `captive` (also confirms #76 live)
- [ ] Reviewer: confirm on a wlan0 device that detection still works

Generated with [Claude Code](https://claude.com/claude-code)