### PR TITLE
fix(adb): redact secrets from adb error text — never echo the command (#81)

### DIFF
--- a/src/adb/adb-client.ts
+++ b/src/adb/adb-client.ts
@@ -38,12 +38,15 @@ export class AdbClient {
         exitCode: 0,
       };
     } catch (error: unknown) {
-      const err = error as { stdout?: string; stderr?: string; code?: number; message?: string };
+      const err = error as ExecError;
       return {
         success: false,
         stdout: err.stdout?.trim() || '',
-        stderr: err.stderr?.trim() || err.message || 'Unknown error',
-        exitCode: err.code || 1,
+        // Never fall back to err.message: for a timeout Node sets it to
+        // "Command failed: <full command>", leaking secret args (Wi-Fi
+        // password, EAP credentials) into stderr and tool_calls.error (#81).
+        stderr: formatAdbError(err, timeout),
+        exitCode: err.code ?? 1,
       };
     }
   }
@@ -222,7 +225,8 @@ export class AdbClient {
 
       const timer = setTimeout(() => {
         proc.kill('SIGKILL');
-        reject(new Error(`adb ${args.join(' ')} timed out after ${timeout}ms`));
+        // Don't echo args — keep secret-bearing commands out of error text (#81).
+        reject(new Error(`adb command timed out after ${timeout}ms`));
       }, timeout);
 
       proc.stdout.on('data', (chunk: Buffer) => chunks.push(chunk));
@@ -242,4 +246,36 @@ export class AdbClient {
       });
     });
   }
+}
+
+/** Shape of the error object child_process rejects with (execFile). */
+interface ExecError {
+  stdout?: string;
+  stderr?: string;
+  code?: number;
+  message?: string;
+  killed?: boolean;
+  signal?: string;
+}
+
+/**
+ * Build a safe error string for a failed `adb` invocation.
+ *
+ * Critically it NEVER returns Node's `err.message`: for a timeout that is
+ * `Command failed: <full command>`, which would leak secret args (Wi-Fi
+ * password, EAP credentials) into `AdbResult.stderr` and from there into
+ * surfaced errors and the `tool_calls.error` log column (#81). The command's
+ * own `stderr` (device output — no command line) is safe to pass through;
+ * otherwise we return a generic message.
+ *
+ * Pure function — exported for unit testing.
+ */
+export function formatAdbError(err: ExecError, timeoutMs: number): string {
+  if (err.killed || err.signal) {
+    return `adb command timed out after ${timeoutMs}ms`;
+  }
+  const stderr = err.stderr?.trim();
+  if (stderr) return stderr;
+  if (err.code !== undefined) return `adb command failed (exit ${err.code})`;
+  return 'adb command failed';
 }

--- a/tests/unit/adb-error-redaction.test.mjs
+++ b/tests/unit/adb-error-redaction.test.mjs
@@ -1,0 +1,50 @@
+/**
+ * Unit tests for adb error redaction (#81).
+ *
+ * AdbClient.exec() used to fall back to Node's err.message on failure, which
+ * for a timeout is `Command failed: <full command>` — leaking secret args
+ * (Wi-Fi password, EAP creds) into AdbResult.stderr and tool_calls.error.
+ * formatAdbError() must never echo the command.
+ *
+ * Run with: npm run test:unit  (after npm run build)
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { formatAdbError } from '../../dist/adb/adb-client.js';
+
+const SECRET = 'hunter2';
+// What child_process rejects with when `adb ... connect-network '<ssid>' wpa2 '<pw>'` times out.
+const TIMEOUT_ERR = {
+  killed: true,
+  signal: 'SIGTERM',
+  stdout: '',
+  stderr: '',
+  message: `Command failed: adb -s 38301FDJH00CYN shell cmd wifi connect-network 'MySSID' wpa2 '${SECRET}'`,
+};
+
+test('formatAdbError: timeout message omits the command (no password leak)', () => {
+  const msg = formatAdbError(TIMEOUT_ERR, 30000);
+  assert.equal(msg, 'adb command timed out after 30000ms');
+  assert.ok(!msg.includes(SECRET), 'must not leak the password');
+  assert.ok(!msg.includes('connect-network'), 'must not echo the command');
+});
+
+test('formatAdbError: never returns err.message even when stderr is empty', () => {
+  const msg = formatAdbError(
+    { message: "Command failed: adb ... 'topsecret'", stderr: '', code: 7 },
+    5000
+  );
+  assert.ok(!msg.includes('topsecret'), 'must not leak via the exit path either');
+  assert.equal(msg, 'adb command failed (exit 7)');
+});
+
+test('formatAdbError: passes through device stderr (no command line) when present', () => {
+  assert.equal(
+    formatAdbError({ stderr: "error: device '38301FDJH00CYN' not found", code: 1 }, 30000),
+    "error: device '38301FDJH00CYN' not found"
+  );
+});
+
+test('formatAdbError: generic message on a bare failure with no detail', () => {
+  assert.equal(formatAdbError({}, 30000), 'adb command failed');
+});


### PR DESCRIPTION
## Summary
`AdbClient.exec()` fell back to Node's `err.message` on failure. For a timeout that is `Command failed: <full command>`, so a `wifi_connect` / `wifi_connect_enterprise` timeout placed the **cleartext password** (an arg of the shell command) into `AdbResult.stderr` — and from there into surfaced errors and the `tool_calls.error` log column.

Fixed at the source with a pure **`formatAdbError()`** that never returns `err.message`:
- timeout → `adb command timed out after Nms`
- else the command's own `stderr` (device output — contains no command line)
- else a generic `adb command failed (exit N)`

`execBinary`'s timeout text no longer echoes args either.

Closes #81

## Scope note
`wifi-commands.connect()` already discarded `stderr`, so this closes a **latent** leak at the source and hardens *all* secret-bearing commands (e.g. enterprise EAP credentials) and any future caller — rather than a currently-bleeding path. Fix kept at the `exec()` layer (right altitude) instead of per-tool redaction.

## Test plan
- [x] `npm run test:unit` — 174 pass (+4 asserting redaction, incl. the empty-stderr exit path)
- [x] Live on a Pixel 8: a timeout on `echo SECRET_TOKEN_xyz; sleep 5` returns `"adb command timed out after 600ms"` — no secret, no command (pre-fix it returned the full command line)
- [ ] Reviewer: confirm useful device errors (e.g. "device not found") still surface via `stderr`

Generated with [Claude Code](https://claude.com/claude-code)