### PR TITLE
fix(sms): anchor date parsing on trailing epoch, not first match (#82)

### DIFF
--- a/src/adb/sms-commands.ts
+++ b/src/adb/sms-commands.ts
@@ -169,22 +169,30 @@ export type SmsWaitForOtpResult =
  * Bodies can legitimately contain commas, so we anchor on the known column
  * names instead of splitting on `, `. Assumes the projection order
  * address,body,date — the same order our query passes.
+ *
+ * `date` is the final column and its value is a numeric epoch, so we anchor on
+ * the LAST `, date=<digits>` (end of row) rather than the first occurrence — a
+ * body that itself contains `, date=` would otherwise truncate the message and
+ * drop the row to a NaN timestamp (#82).
+ *
+ * Exported for unit testing.
  */
-function parseContentQuery(stdout: string): SmsMessage[] {
+export function parseContentQuery(stdout: string): SmsMessage[] {
   const messages: SmsMessage[] = [];
   for (const line of stdout.split('\n')) {
     if (!line.trimStart().startsWith('Row:')) continue;
 
     const addressIdx = line.indexOf('address=');
     const bodyIdx = line.indexOf(', body=');
-    const dateIdx = line.indexOf(', date=');
-    if (addressIdx === -1 || bodyIdx === -1 || dateIdx === -1) continue;
+    // The real date delimiter is the trailing numeric one, not the first match.
+    const dateMatch = line.match(/, date=(\d+)\s*$/);
+    if (addressIdx === -1 || bodyIdx === -1 || !dateMatch) continue;
+    const dateIdx = line.lastIndexOf(', date=');
     if (!(addressIdx < bodyIdx && bodyIdx < dateIdx)) continue;
 
     const sender = line.slice(addressIdx + 'address='.length, bodyIdx).trim();
     const body = line.slice(bodyIdx + ', body='.length, dateIdx);
-    const dateStr = line.slice(dateIdx + ', date='.length).split(/[,\s]/)[0];
-    const timestamp = parseInt(dateStr, 10);
+    const timestamp = parseInt(dateMatch[1], 10);
 
     if (!sender || isNaN(timestamp)) continue;
     messages.push({ sender, body, timestamp });

--- a/tests/unit/sms-parse.test.mjs
+++ b/tests/unit/sms-parse.test.mjs
@@ -1,0 +1,66 @@
+/**
+ * Unit tests for SMS content-query parsing (#82).
+ *
+ * The old parser used the FIRST `, date=` as the column delimiter, so a body
+ * containing `, date=` truncated the message and dropped the row (NaN date).
+ * parseContentQuery now anchors on the trailing numeric `date=<epoch>`.
+ *
+ * Run with: npm run test:unit  (after npm run build)
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseContentQuery } from '../../dist/adb/sms-commands.js';
+
+test('parses a normal row', () => {
+  const out = 'Row: 0 address=AlertBank, body=Your code is 123456, date=1633000000000';
+  const [m] = parseContentQuery(out);
+  assert.equal(m.sender, 'AlertBank');
+  assert.equal(m.body, 'Your code is 123456');
+  assert.equal(m.timestamp, 1633000000000);
+});
+
+test('body containing ", date=" is preserved (the #82 bug)', () => {
+  const out =
+    'Row: 0 address=Bank, body=Confirm transfer of $50, date=tomorrow, date=1633000000000';
+  const msgs = parseContentQuery(out);
+  assert.equal(msgs.length, 1, 'row must not be dropped');
+  assert.equal(msgs[0].body, 'Confirm transfer of $50, date=tomorrow');
+  assert.equal(msgs[0].timestamp, 1633000000000);
+});
+
+test('body containing commas is preserved', () => {
+  const out = 'Row: 1 address=+123, body=Hi, there, your code: 9988, date=1700000000000';
+  const [m] = parseContentQuery(out);
+  assert.equal(m.body, 'Hi, there, your code: 9988');
+  assert.equal(m.timestamp, 1700000000000);
+});
+
+test('body ending in a date-like number still parses', () => {
+  const out = 'Row: 2 address=Svc, body=Meeting at 1900, date=1755555555000';
+  const [m] = parseContentQuery(out);
+  assert.equal(m.body, 'Meeting at 1900');
+  assert.equal(m.timestamp, 1755555555000);
+});
+
+test('multiple rows', () => {
+  const out = [
+    'Row: 0 address=A, body=one, date=1000',
+    'Row: 1 address=B, body=two, date=2000',
+  ].join('\n');
+  const msgs = parseContentQuery(out);
+  assert.equal(msgs.length, 2);
+  assert.deepEqual(msgs.map(m => m.body), ['one', 'two']);
+});
+
+test('skips malformed / non-Row / non-numeric-date lines', () => {
+  const out = [
+    'Some header line',
+    'Row: 0 address=A, body=no date column here',
+    'Row: 1 address=B, body=bad, date=notanumber',
+    'Row: 2 address=C, body=good, date=42',
+  ].join('\n');
+  const msgs = parseContentQuery(out);
+  assert.equal(msgs.length, 1);
+  assert.equal(msgs[0].body, 'good');
+  assert.equal(msgs[0].timestamp, 42);
+});


### PR DESCRIPTION
## Summary
`parseContentQuery` used the **first** `, date=` as the column delimiter. A body containing `, date=` (e.g. `"Confirm transfer of $50, date=tomorrow"`) shifted the delimiter into the message text → truncated body + NaN timestamp → the row was silently **dropped** (an OTP message could vanish).

`date` is the final column with a numeric-epoch value, so anchor on the trailing `, date=<digits>` (end of row) and take the body as everything between `, body=` and that final delimiter.

Closes #82

## Test plan
- [x] `npm run test:unit` — 180 pass (+6), incl. the exact failure case (`body=...$50, date=tomorrow, date=<epoch>` → full body preserved, correct timestamp), comma-in-body, body-ending-in-digits, multi-row, malformed-skip
- [x] Live: real device SMS rows still parse (sender + epoch + body)

Generated with [Claude Code](https://claude.com/claude-code)