### PR TITLE
fix(device): restore caller's device selection in refreshDevices() (#83)

### DIFF
--- a/src/adb/device-manager.ts
+++ b/src/adb/device-manager.ts
@@ -122,6 +122,12 @@ export class DeviceManager {
    * Refresh the list of connected devices
    */
   async refreshDevices(): Promise<Device[]> {
+    // The info-cache loop below selects each newly-seen device to query it,
+    // mutating the active selection as a side effect. Capture the caller's
+    // selection up front and restore it before returning, so refreshDevices()
+    // (and callers like device_list) never silently switch the active device
+    // on a multi-device host (#83).
+    const previousSelection = this.adb.getSelectedDevice();
     const devices = await this.adb.listDevices();
 
     // Update device info cache for connected devices
@@ -145,11 +151,13 @@ export class DeviceManager {
       }
     }
 
-    // Restore previous selection if still valid
-    const currentSelection = this.adb.getSelectedDevice();
-    if (currentSelection && !connectedSerials.has(currentSelection)) {
-      this.adb.selectDevice(null);
-    }
+    // Restore the caller's selection — or clear it if that device is gone, or
+    // if nothing was selected before (don't leak the last-enumerated device).
+    this.adb.selectDevice(
+      previousSelection && connectedSerials.has(previousSelection)
+        ? previousSelection
+        : null
+    );
 
     return devices;
   }

--- a/tests/unit/device-selection.test.mjs
+++ b/tests/unit/device-selection.test.mjs
@@ -1,0 +1,84 @@
+/**
+ * Unit tests for DeviceManager.refreshDevices() selection handling (#83).
+ *
+ * refreshDevices() selects each newly-seen device to query its info. It used
+ * to leave the *last enumerated* device selected, silently switching the
+ * active device out from under the caller (e.g. device_list on a multi-device
+ * host). It must now restore the caller's original selection.
+ *
+ * DeviceManager builds its own AdbClient, but the field is a plain runtime
+ * property, so we inject a fake after construction.
+ *
+ * Run with: npm run test:unit  (after npm run build)
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { DeviceManager } from '../../dist/adb/device-manager.js';
+
+function info(serial) {
+  return {
+    serial,
+    model: 'M',
+    brand: 'B',
+    manufacturer: 'Mfr',
+    androidVersion: '14',
+    sdkVersion: 34,
+    buildId: 'X',
+  };
+}
+
+class FakeAdb {
+  constructor(devices) {
+    this.devices = devices;
+    this.selected = null;
+    this.selectCalls = [];
+  }
+  async listDevices() {
+    return this.devices;
+  }
+  selectDevice(s) {
+    this.selected = s;
+    this.selectCalls.push(s);
+  }
+  getSelectedDevice() {
+    return this.selected;
+  }
+  async getDeviceInfo() {
+    return info(this.selected);
+  }
+}
+
+function managerWith(fake) {
+  const dm = new DeviceManager();
+  dm.adb = fake; // private at the TS level; a plain property at runtime
+  return dm;
+}
+
+test('restores the caller selection after enumerating new devices', async () => {
+  const fake = new FakeAdb([
+    { serial: 'A', state: 'device' },
+    { serial: 'B', state: 'device' },
+  ]);
+  const dm = managerWith(fake);
+  fake.selectDevice('A'); // caller had A selected
+  await dm.refreshDevices();
+  assert.equal(fake.getSelectedDevice(), 'A', 'must restore A, not leak the last-enumerated B');
+});
+
+test('leaves selection null when nothing was selected before', async () => {
+  const fake = new FakeAdb([
+    { serial: 'A', state: 'device' },
+    { serial: 'B', state: 'device' },
+  ]);
+  const dm = managerWith(fake);
+  await dm.refreshDevices();
+  assert.equal(fake.getSelectedDevice(), null, 'must not leave the last-enumerated device selected');
+});
+
+test('clears selection when the selected device has disconnected', async () => {
+  const fake = new FakeAdb([{ serial: 'B', state: 'device' }]);
+  const dm = managerWith(fake);
+  fake.selected = 'A'; // A is no longer present
+  await dm.refreshDevices();
+  assert.equal(fake.getSelectedDevice(), null);
+});


### PR DESCRIPTION
## Summary
`refreshDevices()` selects each newly-seen device to query its `DeviceInfo`, mutating the active selection as a side effect. The old "restore" block only cleared the selection when the (post-loop) selected device was disconnected — it never restored the caller's original selection, leaving the **last enumerated** device active. Since `device_list` calls `refreshDevices()`, listing devices could silently switch which device subsequent tools operate on (multi-device hosts).

Now: capture the selection up front, restore it after the loop (or clear it if that device is gone / nothing was selected before). `ensureDeviceSelected()` selects explicitly after `refreshDevices()`, so its auto-select is unaffected.

Closes #83

## Test plan
- [x] `npm run test:unit` — 183 pass (+3: restore-caller, null-when-none, clear-when-gone; inject a fake AdbClient)
- [x] Live single-device no-regression: device stays selected across `refreshDevices()`
- [ ] Reviewer: confirm on a 2-device host that `device_list` no longer changes the active device

Generated with [Claude Code](https://claude.com/claude-code)