### PR TITLE
docs(mcp): add .mcp.example + remote-client connect guide

### DIFF
--- a/.mcp.example
+++ b/.mcp.example
@@ -1,0 +1,42 @@
+{
+  "_README": [
+    "Template for connecting a client to the android-wifi MCP server.",
+    "Copy the android-wifi entry into your client's .mcp.json and replace",
+    "<SERVER_LAN_IP> with the server host's reachable IP (e.g. 192.168.6.147),",
+    "or 'localhost' if the client runs on the server host itself.",
+    "",
+    "The server binds 0.0.0.0 on port 3000 (override with HOST/PORT); a remote client",
+    "must be on the same subnet / routable to the host, with the port open in the host",
+    "firewall.",
+    "",
+    "Pick the entry for your client (the example below is B, the codeless Claude Code one):",
+    "",
+    "A) Native-HTTP clients (Zed, Cursor, ...): NO bridge, NO repo needed — use the URL:",
+    "     { \"android-wifi\": { \"url\": \"http://<SERVER_LAN_IP>:3000/mcp\" } }",
+    "   or:  claude mcp add --transport http android-wifi http://<SERVER_LAN_IP>:3000/mcp",
+    "",
+    "B) Claude Code / stdio-only clients: Claude Code's HTTP client crashes against",
+    "   Streamable HTTP (issue #7), so bridge stdio<->HTTP with the published 'mcp-remote'",
+    "   adapter via npx (the entry below). This needs NO copy of this repo — just Node/npx.",
+    "   --allow-http is REQUIRED for a plain-HTTP (non-TLS) LAN server; mcp-remote refuses",
+    "   any non-localhost URL without it. Drop --allow-http only when the URL is localhost.",
+    "",
+    "C) Client that DOES have this repo checked out (local dev): the bundled stdio shim",
+    "   also works — see .mcp.json:  node bin/android-wifi-shim.mjs http://localhost:3000/mcp",
+    "",
+    "mobile-next / playwright-android are separate, client-local servers and playwright's",
+    "CDP :9222 bridge lives on the USB-connected host, so a remote client usually",
+    "registers android-wifi only."
+  ],
+  "mcpServers": {
+    "android-wifi": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote",
+        "http://<SERVER_LAN_IP>:3000/mcp",
+        "--allow-http"
+      ]
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -156,6 +156,22 @@ If you didn't install globally:
 claude mcp add --transport stdio android-wifi node /path/to/android-wifi-mcp/bin/android-wifi-shim.mjs http://localhost:3000/mcp
 ```
 
+#### Remote clients (client on a different machine, without this repo)
+
+The bundled shim above needs this repo present, and `localhost` only works when the client runs **on the server host**. From another machine — with no copy of this repo — use the host's LAN IP and a codeless bridge. The server binds `0.0.0.0` (override with `HOST`) and you must open its port (default 3000) in the host firewall:
+
+- **Native-HTTP clients (Zed, Cursor, …)** — no bridge, no repo; register the URL directly:
+  ```bash
+  claude mcp add --transport http android-wifi http://<SERVER_LAN_IP>:3000/mcp
+  ```
+- **Claude Code / stdio-only clients** — its HTTP client crashes against Streamable HTTP (issue #7), so bridge stdio↔HTTP with the published [`mcp-remote`](https://www.npmjs.com/package/mcp-remote) adapter via `npx` (no repo needed):
+  ```bash
+  claude mcp add --transport stdio android-wifi -- npx -y mcp-remote http://<SERVER_LAN_IP>:3000/mcp --allow-http
+  ```
+  The `--allow-http` flag is **required** for a plain-HTTP (non-TLS) LAN server — `mcp-remote` otherwise refuses any non-`localhost` URL ("Non-HTTPS URLs are only allowed for localhost or when --allow-http flag is provided"). Omit it only when the URL is `localhost`. (Verified against this server.)
+
+The remote and the server must share a subnet (or have a route to each other). See [`.mcp.example`](.mcp.example) for the copy-and-edit JSON config.
+
 ### 5. Setup Enterprise WiFi (Optional)
 
 Skip this section if you only need WPA2/WPA3 personal networks.


### PR DESCRIPTION
## Summary
Remote MCP clients couldn't connect, for two avoidable reasons:
- The bundled stdio shim (`node bin/android-wifi-shim.mjs`) needs **this repo present** — a remote client doesn't have it.
- The tracked `.mcp.json` hardcodes `http://localhost:3000/mcp` — only valid when the client runs **on the server host**.

Adds **`.mcp.example`** (copy-and-edit template) and a README **"Remote clients"** section with the codeless paths:
- **Native-HTTP clients (Zed/Cursor):** `claude mcp add --transport http android-wifi http://<SERVER_LAN_IP>:3000/mcp`
- **Claude Code / stdio-only:** `npx -y mcp-remote http://<SERVER_LAN_IP>:3000/mcp --allow-http` (published adapter, no repo needed)

The server already binds `0.0.0.0` and the host firewall has 3000 open, so no server change is needed.

## Verified against the running server
- `mcp-remote` → `localhost`: connects over plain HTTP, no flag.
- `mcp-remote` → LAN IP `192.168.6.147` without `--allow-http`: **refused** ("Non-HTTPS URLs are only allowed for localhost or when --allow-http flag is provided").
- `mcp-remote` → LAN IP **with** `--allow-http`: `Proxy established successfully`.

So `--allow-http` is required for a plain-HTTP LAN server — documented exactly.

Generated with [Claude Code](https://claude.com/claude-code)