### PR TITLE
docs(qa): STORY-001 + remote-stack test docs (TS-01..07)

### DIFF
--- a/docs/stories/README.md
+++ b/docs/stories/README.md
@@ -1,0 +1,36 @@
+# Stories — format contract
+
+A **story** captures a *need*: what a user is trying to achieve and why. It is a
+**goal, not a spec** — the *how* (files, APIs, ports, design) is worked out later on
+the GitHub plan issue (`dw-plan`) and in the test cases, never here.
+
+- One file per story: `docs/stories/STORY-XXX.md` (zero-padded sequential id).
+- Produced by `dw-story`, gated by `dw-review-story`, then fed to `dw-plan` /
+  `dw-tasks` (dev) and/or `qw-plan` (QA).
+
+## Required sections
+
+```markdown
+# STORY-XXX: <title>
+
+## User Story
+As a <role>,
+I want to <action>,
+So that <benefit>.
+
+## The Need
+<the problem behind the request, in the user's terms — what and why>
+
+## Success Looks Like
+<observable, user-facing outcomes that mean it's done — not implementation steps>
+
+## Open Questions
+<what still has to be figured out — resolved later on the issue; the "how" goes here>
+
+## Status
+- Created: <YYYY-MM-DD>
+- Issues: <none | #N …>
+```
+
+**Rule of thumb:** if a line names a file, flag, port, or design choice, it belongs
+in the plan issue or a test case — not the story.

--- a/docs/stories/STORY-001.md
+++ b/docs/stories/STORY-001.md
@@ -1,0 +1,32 @@
+# STORY-001: Drive the phone remotely through the whole MCP stack
+
+## User Story
+
+As a QA engineer whose workstation is **not** the machine wired to the test phone,
+I want to reach the whole MCP stack — `android-wifi`, `android-playwright`, and `mobile-next` — whether my client runs locally (stdio) or on another machine (http),
+So that I can run complete phone QA flows (WiFi, in-browser, and on-device UI) without the phone being plugged into my own machine.
+
+## The Need
+
+Phone QA needs three cooperating MCP servers — one for WiFi/network control, one for the device browser, one for the OS UI. Today they assume the client runs on the **same** machine as the phone: only the WiFi server can be reached across the network, while the browser and UI servers come up on the client's own machine. So a QA engineer working from a different machine can control WiFi but **not** the browser or UI — those land where there is no phone.
+
+The team wants one phone, wired to a shared host, drivable by whoever needs it, from wherever they are — without each person re-improvising the connection.
+
+## Success Looks Like
+
+- A QA engineer on the **same host** still drives all three servers — the existing local (stdio) path keeps working.
+- A QA engineer on a **different machine** connects to all three servers over the network and completes an **end-to-end flow** against the one USB-connected phone: bring up WiFi, drive a page in the device browser, and tap an on-device dialog — all acting on that same phone.
+- Connecting is a **documented, repeatable** setup, not a per-person improvisation.
+
+## Open Questions
+
+- How is the stack exposed **safely** — anyone who can reach it can drive the phone (WiFi, OTPs, screenshots)? (auth / network boundary)
+- How is the stack **started** — one command or per-server, and on which addresses/ports?
+- Does the remote bridge behave the same across all three servers' transports?
+- What happens when **two people** aim at the same phone at once? (shared-device behaviour — relates to #62)
+- Technical approach is tracked in **#94**.
+
+## Status
+
+- Created: 2026-06-25
+- Issues: #94 (technical plan)

--- a/docs/tests/README.md
+++ b/docs/tests/README.md
@@ -1,0 +1,30 @@
+# Test docs — format contract
+
+Each file is one **scenario** (`TS-NN`) from a reviewed `[STORY-XXX] Test Plan`
+issue. Produced by `qw-cases`, gated by `qw-review-cases`, then handed to the
+project's binding + run layer (e.g. bound to `cicd/tests` YAML + MCP tools).
+
+- One file per scenario: `docs/tests/TS-NN-<slug>.md`.
+- A scenario holds one or more **cases** (`TC-NN`), each a **Steps table** of
+  *Action* / *Expected Result* rows.
+- Steps describe **observable outcomes**, not exact commands/strings — a case
+  should survive a reasonable change in how the feature is built. Mark a case
+  **(to-be)** when it depends on work not yet shipped.
+
+## Front-matter
+
+```yaml
+---
+id: TS-NN                 # scenario id
+title: <scenario title>
+namespace: <feature group>
+story: STORY-XXX          # the need this verifies
+story_hash: <sha256 of docs/stories/STORY-XXX.md>   # detects story drift
+plan: <N>                 # the [STORY-XXX] Test Plan issue (scenario source)
+issue: <N>                # related dev issue (the "how"), if any
+status: green             # doc standing: green = current/valid
+---
+```
+
+If `story_hash` no longer matches the story file, the story moved under the
+test — re-check the scenario before trusting it.

--- a/docs/tests/TS-01-local-stdio-stack.md
+++ b/docs/tests/TS-01-local-stdio-stack.md
@@ -1,0 +1,37 @@
+---
+id: TS-01
+title: Local client drives the full stack via stdio
+namespace: remote-stack
+story: STORY-001
+story_hash: 2937da1a558ea87ccb89179849dc3cf225de98f93ebf192f4819db0a3ee1a5a8
+plan: 95
+issue: 94
+status: green
+---
+
+# TS-01: Local client drives the full stack via stdio
+
+**Objective:** On the host wired to the phone, a stdio client reaches all three
+servers and each acts on the device — the existing local path keeps working.
+This is the baseline that must not regress when the http path is added.
+
+## TC-01 — android-wifi over the stdio shim
+
+| Action | Expected Result |
+|---|---|
+| From a client on the host, register `android-wifi` via the bundled stdio shim and list tools | The client connects; the device/WiFi/network tools are present |
+| Call a read-only device tool (e.g. list devices) | Returns the real USB-connected phone, no error |
+
+## TC-02 — android-playwright (local subprocess)
+
+| Action | Expected Result |
+|---|---|
+| With the CDP bridge up, register `android-playwright` locally and list tools | Browser tools are present |
+| Drive one browser action against the device's Chrome | The action takes effect on the device browser |
+
+## TC-03 — mobile-next (local subprocess)
+
+| Action | Expected Result |
+|---|---|
+| Register `mobile-next` locally and list tools | UI tools are present |
+| Drive one on-device UI action | The action takes effect on the device UI |

--- a/docs/tests/TS-02-remote-http-android-wifi.md
+++ b/docs/tests/TS-02-remote-http-android-wifi.md
@@ -1,0 +1,34 @@
+---
+id: TS-02
+title: Remote client reaches android-wifi over http
+namespace: remote-stack
+story: STORY-001
+story_hash: 2937da1a558ea87ccb89179849dc3cf225de98f93ebf192f4819db0a3ee1a5a8
+plan: 95
+issue: 94
+status: green
+---
+
+# TS-02: Remote client reaches android-wifi over http
+
+**Objective:** From a different machine, a client connects to `android-wifi`
+over the network and drives device/WiFi tools against the USB phone.
+
+## TC-01 — connect via the codeless http bridge
+
+| Action | Expected Result |
+|---|---|
+| From another machine on the same network, point a stdio client at the host's `android-wifi` URL through the `mcp-remote` bridge (plain-http allowed) | The bridge connects and the client lists the native tools |
+| (negative) Omit the plain-http allowance | Connection is refused with a clear, actionable message — covered in TS-06 |
+
+## TC-02 — a device call returns the real phone's state
+
+| Action | Expected Result |
+|---|---|
+| Call a read-only device tool (list devices / WiFi status) from the remote client | Returns the state of the **host's** USB phone — the same device the host would see |
+
+## TC-03 — native-HTTP client, no bridge
+
+| Action | Expected Result |
+|---|---|
+| From a client that speaks the http transport natively, register the `android-wifi` URL directly | Connects and lists tools equivalently, without the bridge |

--- a/docs/tests/TS-03-remote-http-browser-ui.md
+++ b/docs/tests/TS-03-remote-http-browser-ui.md
@@ -1,0 +1,37 @@
+---
+id: TS-03
+title: Remote client reaches the browser + UI servers over http
+namespace: remote-stack
+story: STORY-001
+story_hash: 2937da1a558ea87ccb89179849dc3cf225de98f93ebf192f4819db0a3ee1a5a8
+plan: 95
+issue: 94
+status: green
+---
+
+# TS-03: Remote client reaches the browser + UI servers over http
+
+**Objective:** With `android-playwright` and `mobile-next` served over the
+network **from the USB host**, a remote client drives them and they act on the
+one USB phone — not on the client machine. **(to-be — depends on #94 serving
+these two over http.)**
+
+## TC-01 — remote → android-playwright → device browser
+
+| Action | Expected Result |
+|---|---|
+| From another machine, connect to the host-served `android-playwright` and list tools | Browser tools are present |
+| Drive a browser action | It runs against the **host phone's** Chrome, not any browser on the client |
+
+## TC-02 — remote → mobile-next → device UI
+
+| Action | Expected Result |
+|---|---|
+| From another machine, connect to the host-served `mobile-next` and list tools | UI tools are present |
+| Drive a UI action | It runs against the **host phone's** UI |
+
+## TC-03 — effect lands on the USB phone (independent check)
+
+| Action | Expected Result |
+|---|---|
+| After a remote browser/UI action, observe the device independently (e.g. a screenshot or state read via android-wifi) | The observed change matches the action — confirming it landed on the USB phone, not the client |

--- a/docs/tests/TS-04-e2e-remote-flow.md
+++ b/docs/tests/TS-04-e2e-remote-flow.md
@@ -1,0 +1,25 @@
+---
+id: TS-04
+title: End-to-end remote QA flow on one phone
+namespace: remote-stack
+story: STORY-001
+story_hash: 2937da1a558ea87ccb89179849dc3cf225de98f93ebf192f4819db0a3ee1a5a8
+plan: 95
+issue: 94
+status: green
+---
+
+# TS-04: End-to-end remote QA flow on one phone
+
+**Objective:** A single remote client chains all three servers in one flow,
+against the same USB phone — the story's headline outcome. **(to-be — depends
+on #94.)**
+
+## TC-01 — full flow, one operator, one phone
+
+| Action | Expected Result |
+|---|---|
+| From another machine, bring the phone onto a network via `android-wifi` (`wifi_connect`) | The phone associates to the target network |
+| Drive a page in the device browser via `android-playwright` | The page responds in the device's Chrome |
+| Tap an on-device dialog via `mobile-next` | The dialog responds on the device UI |
+| Confirm the whole flow acted on **the same single phone** | Each step's effect is visible on that one device; no step silently hit the client machine |

--- a/docs/tests/TS-05-setup-documented.md
+++ b/docs/tests/TS-05-setup-documented.md
@@ -1,0 +1,33 @@
+---
+id: TS-05
+title: Setup is documented and repeatable
+namespace: remote-stack
+story: STORY-001
+story_hash: 2937da1a558ea87ccb89179849dc3cf225de98f93ebf192f4819db0a3ee1a5a8
+plan: 95
+issue: 94
+status: green
+---
+
+# TS-05: Setup is documented and repeatable
+
+**Objective:** A QA engineer new to the project can stand up local and remote
+access **from the docs alone** — no per-person improvisation.
+
+## TC-01 — local setup from the docs
+
+| Action | Expected Result |
+|---|---|
+| Following only the documented steps, a client on the host connects to all three servers (stdio) | All three connect; no undocumented step was needed |
+
+## TC-02 — remote setup from the docs
+
+| Action | Expected Result |
+|---|---|
+| Following only the documented steps, a client on another machine connects to all three servers (http) and reaches the host phone | All three connect and act on the host phone; no undocumented step was needed |
+
+## TC-03 — docs match reality
+
+| Action | Expected Result |
+|---|---|
+| Run the documented commands verbatim (substituting only the host address) | They work as written — no silent correction, missing flag, or stale name |

--- a/docs/tests/TS-06-failure-exposure.md
+++ b/docs/tests/TS-06-failure-exposure.md
@@ -1,0 +1,33 @@
+---
+id: TS-06
+title: Failure modes and exposure are clear
+namespace: remote-stack
+story: STORY-001
+story_hash: 2937da1a558ea87ccb89179849dc3cf225de98f93ebf192f4819db0a3ee1a5a8
+plan: 95
+issue: 94
+status: green
+---
+
+# TS-06: Failure modes and exposure are clear
+
+**Objective:** Reaching the stack fails **predictably** (a clear error, not a
+hang), and the security exposure of the remote path is understood.
+
+## TC-01 — unreachable host / closed port
+
+| Action | Expected Result |
+|---|---|
+| Point a remote client at a wrong address, or at the host with the port closed in the firewall | A clear connection error within a short bound — not an indefinite hang |
+
+## TC-02 — plain-http without the allowance
+
+| Action | Expected Result |
+|---|---|
+| Point the http bridge at a non-`localhost` plain-http URL without the plain-http allowance | A clear, actionable refusal naming the missing allowance |
+
+## TC-03 — exposure check
+
+| Action | Expected Result |
+|---|---|
+| From any machine that can reach the host's served ports, connect and call a device tool | It succeeds — documenting that reachability alone grants full control of the phone (WiFi, OTPs, screenshots). Records whether an auth boundary is required (open question). |

--- a/docs/tests/TS-07-concurrency-shared-device.md
+++ b/docs/tests/TS-07-concurrency-shared-device.md
@@ -1,0 +1,28 @@
+---
+id: TS-07
+title: Two clients, one phone (shared-device behaviour)
+namespace: remote-stack
+story: STORY-001
+story_hash: 2937da1a558ea87ccb89179849dc3cf225de98f93ebf192f4819db0a3ee1a5a8
+plan: 95
+issue: 94
+status: green
+---
+
+# TS-07: Two clients, one phone (shared-device behaviour)
+
+**Objective:** When two clients target the same phone at once, behaviour is
+**defined** — not silent corruption. Covers the story's concurrency open
+question (relates to #62); can be deferred if scope stays single-user.
+
+## TC-01 — two clients connect at once
+
+| Action | Expected Result |
+|---|---|
+| Two remote clients connect to the stack simultaneously and each lists tools | Both connect and list tools; neither evicts the other unexpectedly |
+
+## TC-02 — concurrent device-affecting calls
+
+| Action | Expected Result |
+|---|---|
+| The two clients issue device-affecting calls at the same time (e.g. both select/drive the device) | The outcome is **defined** — serialized, last-wins, or a clear error — and the device state is never left corrupt or ambiguous |


### PR DESCRIPTION
## Summary
The story + test-docs bundle for **STORY-001 — drive the phone remotely through the whole MCP stack** (stdio local + http remote), authored via the dev/qa-workflow.

- `docs/stories/STORY-001.md` (the need) + `docs/stories/README.md` (format contract)
- `docs/tests/TS-01..07-*.md` — the 7 scenarios from the **[STORY-001] Test Plan (#95)** as Action/Expected case docs + `docs/tests/README.md` (format contract)

Cases are **to-be** (the http-serving of `android-playwright`/`mobile-next` is the #94 build) and kept outcome-shaped, not pinned to exact commands/ports.

Gated by `dw-review-story` / `qw-review-plan` / `qw-review-cases` — all PASS.

Relates to **#94** (dev plan), **#95** (test plan). No `Fixes` — these are the artifacts, not an implementation.

## Test plan
- [x] story_hash in each TS doc matches `docs/stories/STORY-001.md`
- [x] front-matter consistent (id, story, plan=95, status=green) across all 7
- [x] each doc = one scenario with Action/Expected Steps tables
- [ ] later: bind TS-01..07 → `cicd/tests` YAML (`TC-RMT-*`) once #94 is built

Generated with [Claude Code](https://claude.com/claude-code)