### PR TITLE
feat(make): serve-all — host the 3-MCP stack over HTTP (#98)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,18 @@
 .PHONY: up down restart logs psql migrate migrate-down test test-unit build clean \
-        doctor adb devices udev serve serve-stop serve-restart setup help
+        doctor adb devices udev serve serve-stop serve-restart serve-all serve-all-stop \
+        setup help
 
 COMPOSE ?= docker compose
 PSQL_USER ?= mcp
 PSQL_DB ?= android_wifi_mcp
 PORT ?= 3000
 UDEV_RULE ?= /etc/udev/rules.d/51-android-wifi-mcp.rules
+
+# Ports for the full remote stack (make serve-all). All bind 0.0.0.0.
+PW_PORT ?= 8931
+MOBILE_PORT ?= 8932
+CDP_PORT ?= 9222
+SERVE_ALL_LOG ?= /tmp/android-wifi-mcp
 
 # Bare `make` prints help rather than starting the Postgres stack.
 .DEFAULT_GOAL := help
@@ -19,6 +26,9 @@ help:
 	@echo "  make serve         start the MCP backend (foreground, :$(PORT))"
 	@echo "  make serve-stop    stop the running backend"
 	@echo "  make serve-restart restart the backend"
+	@echo "  make serve-all     serve the full 3-MCP stack over HTTP (android-wifi :$(PORT),"
+	@echo "                     android-playwright :$(PW_PORT), mobile-next :$(MOBILE_PORT)) + CDP bridge"
+	@echo "  make serve-all-stop  stop the 3-MCP stack"
 	@echo "  make setup         ensure adb + build, then run doctor"
 	@echo ""
 	@echo "Logging stack (Postgres):"
@@ -75,6 +85,40 @@ serve-stop:
 
 serve-restart:
 	PORT=$(PORT) npm run restart
+
+# Serve the full QA stack over HTTP from this (USB-connected) host, so a remote
+# client can reach all three servers — they all run next to the phone (#98).
+# Backends are detached (setsid) and logged under $(SERVE_ALL_LOG); stop with
+# serve-all-stop. android-playwright/mobile-next are fetched via npx.
+# All three bind 0.0.0.0 with NO auth, and playwright's DNS-rebinding host-check
+# is disabled (--allowed-hosts "*") so it answers a remote IP — i.e. reachability
+# alone grants full phone control. The exposure/auth stance is tracked in #100.
+serve-all: build
+	@command -v adb >/dev/null 2>&1 || { echo "adb not found -> make adb"; exit 1; }
+	@mkdir -p $(SERVE_ALL_LOG)
+	@for p in $(PORT) $(PW_PORT) $(MOBILE_PORT); do command -v lsof >/dev/null 2>&1 && lsof -ti:$$p >/dev/null 2>&1 && echo "  warning: :$$p already in use — run 'make serve-all-stop' first if this is a stale bundle" || true; done
+	@echo "CDP bridge : adb forward tcp:$(CDP_PORT) -> chrome_devtools_remote"
+	@adb forward tcp:$(CDP_PORT) localabstract:chrome_devtools_remote >/dev/null 2>&1 \
+	  || echo "  warning: CDP forward failed (no device?) — android-playwright can't reach the browser; the others still start"
+	@echo "android-wifi        :$(PORT)   (log: $(SERVE_ALL_LOG)/android-wifi.log)"
+	@PORT=$(PORT) setsid sh -c 'exec npm start' >$(SERVE_ALL_LOG)/android-wifi.log 2>&1 &
+	@echo "android-playwright  :$(PW_PORT)   (log: $(SERVE_ALL_LOG)/android-playwright.log)"
+	@setsid sh -c 'exec npx -y @playwright/mcp@latest --host 0.0.0.0 --port $(PW_PORT) --allowed-hosts "*" --cdp-endpoint http://localhost:$(CDP_PORT)' >$(SERVE_ALL_LOG)/android-playwright.log 2>&1 &
+	@echo "mobile-next         :$(MOBILE_PORT)   (log: $(SERVE_ALL_LOG)/mobile-next.log)"
+	@setsid sh -c 'exec npx -y @mobilenext/mobile-mcp@latest --listen 0.0.0.0:$(MOBILE_PORT)' >$(SERVE_ALL_LOG)/mobile-next.log 2>&1 &
+	@sleep 2
+	@echo ""
+	@echo "Bundle starting. Reachable at http://<this-host>:{$(PORT),$(PW_PORT),$(MOBILE_PORT)}"
+	@echo "Stop with: make serve-all-stop"
+
+serve-all-stop:
+	-@PORT=$(PORT) npm run stop >/dev/null 2>&1 || true
+	@for p in $(PW_PORT) $(MOBILE_PORT); do \
+	  pids=$$(lsof -ti:$$p 2>/dev/null); \
+	  if [ -n "$$pids" ]; then echo "$$pids" | xargs -r kill -TERM 2>/dev/null; echo "stopped :$$p"; else echo "nothing on :$$p"; fi; \
+	done
+	-@adb forward --remove tcp:$(CDP_PORT) >/dev/null 2>&1 || true
+	@echo "removed CDP forward (tcp:$(CDP_PORT))"
 
 setup:
 	@command -v adb >/dev/null 2>&1 || $(MAKE) adb

--- a/README.md
+++ b/README.md
@@ -172,6 +172,19 @@ The bundled shim above needs this repo present, and `localhost` only works when 
 
 The remote and the server must share a subnet (or have a route to each other). See [`.mcp.example`](.mcp.example) for the copy-and-edit JSON config.
 
+#### Serving the whole stack for remote QA — `make serve-all`
+
+`android-wifi` is an HTTP service, but `android-playwright` and `mobile-next` are normally launched *by the client*, so a remote client can't reach the phone through them. To drive the **full** QA stack from another machine, serve all three over HTTP **on the USB host** (where the phone is):
+
+```bash
+make serve-all        # android-wifi :3000, android-playwright :8931, mobile-next :8932, + CDP bridge
+make serve-all-stop   # tear it all down
+```
+
+Each binds `0.0.0.0` (ports configurable: `PORT`, `PW_PORT`, `MOBILE_PORT`); a remote client then registers all three URLs (one `mcp-remote` entry per server). Logs land in `/tmp/android-wifi-mcp/`.
+
+> **Exposure:** all three run with **no auth** and playwright's host-check is disabled for remote access — anyone who can reach the ports can drive the phone. Keep it on a trusted network / behind a firewall. (Auth stance: [#100].)
+
 ### 5. Setup Enterprise WiFi (Optional)
 
 Skip this section if you only need WPA2/WPA3 personal networks.

--- a/docs/stories/STORY-001.md
+++ b/docs/stories/STORY-001.md
@@ -29,4 +29,4 @@ The team wants one phone, wired to a shared host, drivable by whoever needs it, 
 ## Status
 
 - Created: 2026-06-25
-- Issues: #94 (technical plan)
+- Issues: #94 (plan), #95 (test plan), #98 · #99 · #100 (tasks)


### PR DESCRIPTION
## Summary
`make serve-all` brings up the full QA stack as HTTP services on the USB host so a remote client can reach all three (they run next to the phone): android-wifi `:3000`, android-playwright `:8931` (`@playwright/mcp --allowed-hosts "*"`), mobile-next `:8932` (`@mobilenext/mobile-mcp`, SSE), plus the CDP `adb forward`. `make serve-all-stop` tears it down via `lsof` (same as `npm run stop`). Ports configurable; `make help` + README document it.

All three bind `0.0.0.0` with **no auth** — exposure stance is #100.

## Review hardening (this branch)
- CDP forward is best-effort (a no-device run still starts android-wifi/mobile-next)
- pre-flight warns on an already-bound port
- `serve-all-stop` reuses `lsof` instead of a bespoke `ss | grep`

## Test plan
- [x] `make -n serve-all` / `serve-all-stop` parse
- [x] Live (Pixel 8 host): all three listen on `0.0.0.0`; `mcp-remote` connects to android-wifi + android-playwright over the LAN IP; mobile-next serves SSE at `/mcp`; `serve-all-stop` frees all three ports
- [ ] Reviewer: confirm on a second machine (true remote)

Closes #98 · Part of #94