### PR TITLE
fix(serve-all): proxy mobile-next through android-wifi for remote reach (#102)

### DIFF
--- a/.mcp.example
+++ b/.mcp.example
@@ -1,23 +1,23 @@
 {
   "_README": [
-    "Connect a REMOTE client to the full QA stack served on the USB host via",
-    "`make serve-all` (android-wifi :3000, android-playwright :8931, mobile-next :8932).",
-    "Copy this to the client's .mcp.json and replace <SERVER_LAN_IP> with the host's",
-    "reachable IP (e.g. 192.168.6.147), or 'localhost' if the client runs on the host.",
+    "Connect a REMOTE client to the QA stack served on the USB host via",
+    "`make serve-all`. Copy this to the client's .mcp.json and replace",
+    "<SERVER_LAN_IP> with the host's reachable IP (e.g. 192.168.6.147), or",
+    "'localhost' if the client runs on the host.",
     "",
-    "The remote must share a subnet / route to the host, with those ports open in the",
-    "host firewall. All three bind 0.0.0.0 with NO auth — reachability alone grants full",
-    "phone control. Keep it on a trusted network (exposure stance: #100).",
+    "Two HTTP endpoints, both Streamable HTTP -> bridge with 'mcp-remote' (codeless",
+    "via npx; --allow-http is REQUIRED for a plain-HTTP non-localhost URL):",
+    "- android-wifi :3000  — WiFi/device tools, AND mobile-next's mobile_* UI tools,",
+    "  which are proxied in as a stdio upstream (#102) so they ride android-wifi's",
+    "  multi-session HTTP instead of mobile-next's single-session SSE.",
+    "- android-playwright :8931 — device-browser tools.",
     "",
-    "Transports differ per server:",
-    "- android-wifi + android-playwright speak Streamable HTTP -> bridge with 'mcp-remote'",
-    "  (codeless via npx; --allow-http is REQUIRED for a plain-HTTP non-localhost URL).",
-    "- mobile-next speaks SSE and is SINGLE-SESSION: mcp-remote opens two connections and",
-    "  gets a 409 (#102). Use a NATIVE SSE-capable client pointed at the URL (one",
-    "  connection), as below — Claude Code can't bridge it today.",
+    "So a remote client registers just these two and gets all three servers' tools.",
+    "Native-HTTP clients (Zed, Cursor, ...) can skip mcp-remote and use the bare URL:",
+    "{ \"<name>\": { \"url\": \"http://<SERVER_LAN_IP>:<port>/mcp\" } }.",
     "",
-    "Native-HTTP clients (Zed, Cursor, ...) can skip mcp-remote and use the bare URL for",
-    "all three: { \"<name>\": { \"url\": \"http://<SERVER_LAN_IP>:<port>/mcp\" } }."
+    "Both bind 0.0.0.0 with NO auth — reachability alone grants full phone control.",
+    "Keep it on a trusted network (exposure stance: #100)."
   ],
   "mcpServers": {
     "android-wifi": {
@@ -37,9 +37,6 @@
         "http://<SERVER_LAN_IP>:8931/mcp",
         "--allow-http"
       ]
-    },
-    "mobile-next": {
-      "url": "http://<SERVER_LAN_IP>:8932/mcp"
     }
   }
 }

--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,15 @@ PSQL_DB ?= android_wifi_mcp
 PORT ?= 3000
 UDEV_RULE ?= /etc/udev/rules.d/51-android-wifi-mcp.rules
 
-# Ports for the full remote stack (make serve-all). All bind 0.0.0.0.
+# Ports for the remote stack (make serve-all). Both bind 0.0.0.0.
 PW_PORT ?= 8931
-MOBILE_PORT ?= 8932
 CDP_PORT ?= 9222
 SERVE_ALL_LOG ?= /tmp/android-wifi-mcp
+# mobile-next is single-session SSE over the network (#102), so instead of a
+# separate port we proxy it as a stdio upstream of android-wifi — its tools
+# surface via android-wifi's :$(PORT) (Streamable HTTP), reachable by mcp-remote
+# with no 409. (Reuses the upstream-proxy, #14.)
+MOBILE_UPSTREAM ?= mobile-next=npx -y @mobilenext/mobile-mcp@latest --stdio
 
 # Bare `make` prints help rather than starting the Postgres stack.
 .DEFAULT_GOAL := help
@@ -26,9 +30,9 @@ help:
 	@echo "  make serve         start the MCP backend (foreground, :$(PORT))"
 	@echo "  make serve-stop    stop the running backend"
 	@echo "  make serve-restart restart the backend"
-	@echo "  make serve-all     serve the full 3-MCP stack over HTTP (android-wifi :$(PORT),"
-	@echo "                     android-playwright :$(PW_PORT), mobile-next :$(MOBILE_PORT)) + CDP bridge"
-	@echo "  make serve-all-stop  stop the 3-MCP stack"
+	@echo "  make serve-all     serve the stack over HTTP for remote QA: android-wifi :$(PORT)"
+	@echo "                     (+ mobile-next proxied in), android-playwright :$(PW_PORT), + CDP bridge"
+	@echo "  make serve-all-stop  stop the remote stack"
 	@echo "  make setup         ensure adb + build, then run doctor"
 	@echo ""
 	@echo "Logging stack (Postgres):"
@@ -86,39 +90,39 @@ serve-stop:
 serve-restart:
 	PORT=$(PORT) npm run restart
 
-# Serve the full QA stack over HTTP from this (USB-connected) host, so a remote
-# client can reach all three servers — they all run next to the phone (#98).
-# Backends are detached (setsid) and logged under $(SERVE_ALL_LOG); stop with
-# serve-all-stop. android-playwright/mobile-next are fetched via npx.
-# All three bind 0.0.0.0 with NO auth, and playwright's DNS-rebinding host-check
-# is disabled (--allowed-hosts "*") so it answers a remote IP — i.e. reachability
-# alone grants full phone control. The exposure/auth stance is tracked in #100.
+# Serve the QA stack over HTTP from this (USB-connected) host so a remote client
+# can reach it — everything runs next to the phone (#98). android-wifi serves on
+# :$(PORT) with mobile-next proxied in as a stdio upstream (#102, reuses #14), and
+# android-playwright on :$(PW_PORT). Backends are detached (setsid) + logged under
+# $(SERVE_ALL_LOG); stop with serve-all-stop.
+# Both bind 0.0.0.0 with NO auth, and playwright's host-check is disabled
+# (--allowed-hosts "*") so it answers a remote IP — reachability grants full phone
+# control. Exposure/auth stance: #100.
 serve-all: build
 	@command -v adb >/dev/null 2>&1 || { echo "adb not found -> make adb"; exit 1; }
 	@mkdir -p $(SERVE_ALL_LOG)
-	@for p in $(PORT) $(PW_PORT) $(MOBILE_PORT); do command -v lsof >/dev/null 2>&1 && lsof -ti:$$p >/dev/null 2>&1 && echo "  warning: :$$p already in use — run 'make serve-all-stop' first if this is a stale bundle" || true; done
+	@for p in $(PORT) $(PW_PORT); do command -v lsof >/dev/null 2>&1 && lsof -ti:$$p >/dev/null 2>&1 && echo "  warning: :$$p already in use — run 'make serve-all-stop' first if this is a stale bundle" || true; done
 	@echo "CDP bridge : adb forward tcp:$(CDP_PORT) -> chrome_devtools_remote"
 	@adb forward tcp:$(CDP_PORT) localabstract:chrome_devtools_remote >/dev/null 2>&1 \
 	  || echo "  warning: CDP forward failed (no device?) — android-playwright can't reach the browser; the others still start"
-	@echo "android-wifi        :$(PORT)   (log: $(SERVE_ALL_LOG)/android-wifi.log)"
-	@PORT=$(PORT) setsid sh -c 'exec npm start' >$(SERVE_ALL_LOG)/android-wifi.log 2>&1 &
+	@echo "android-wifi        :$(PORT)   (+ mobile-next proxied as a stdio upstream)"
+	@PORT=$(PORT) UPSTREAM_MCP='$(MOBILE_UPSTREAM)' setsid sh -c 'exec npm start' >$(SERVE_ALL_LOG)/android-wifi.log 2>&1 &
 	@echo "android-playwright  :$(PW_PORT)   (log: $(SERVE_ALL_LOG)/android-playwright.log)"
 	@setsid sh -c 'exec npx -y @playwright/mcp@latest --host 0.0.0.0 --port $(PW_PORT) --allowed-hosts "*" --cdp-endpoint http://localhost:$(CDP_PORT)' >$(SERVE_ALL_LOG)/android-playwright.log 2>&1 &
-	@echo "mobile-next         :$(MOBILE_PORT)   (log: $(SERVE_ALL_LOG)/mobile-next.log)"
-	@setsid sh -c 'exec npx -y @mobilenext/mobile-mcp@latest --listen 0.0.0.0:$(MOBILE_PORT)' >$(SERVE_ALL_LOG)/mobile-next.log 2>&1 &
 	@sleep 2
 	@echo ""
-	@echo "Bundle starting. Reachable at http://<this-host>:{$(PORT),$(PW_PORT),$(MOBILE_PORT)}"
+	@echo "Bundle starting. android-wifi(+mobile-next) :$(PORT)  ·  android-playwright :$(PW_PORT)"
 	@echo "Stop with: make serve-all-stop"
 
 serve-all-stop:
 	-@PORT=$(PORT) npm run stop >/dev/null 2>&1 || true
-	@for p in $(PW_PORT) $(MOBILE_PORT); do \
+	@for p in $(PW_PORT); do \
 	  pids=$$(lsof -ti:$$p 2>/dev/null); \
 	  if [ -n "$$pids" ]; then echo "$$pids" | xargs -r kill -TERM 2>/dev/null; echo "stopped :$$p"; else echo "nothing on :$$p"; fi; \
 	done
 	-@adb forward --remove tcp:$(CDP_PORT) >/dev/null 2>&1 || true
 	@echo "removed CDP forward (tcp:$(CDP_PORT))"
+	@echo "(mobile-next runs as an android-wifi child — it stops with the :$(PORT) server)"
 
 setup:
 	@command -v adb >/dev/null 2>&1 || $(MAKE) adb

--- a/README.md
+++ b/README.md
@@ -174,25 +174,22 @@ The remote and the server must share a subnet (or have a route to each other). S
 
 #### Serving the whole stack for remote QA — `make serve-all`
 
-`android-wifi` is an HTTP service, but `android-playwright` and `mobile-next` are normally launched *by the client*, so a remote client can't reach the phone through them. To drive the **full** QA stack from another machine, serve all three over HTTP **on the USB host** (where the phone is):
+`android-wifi` is an HTTP service, but `android-playwright` and `mobile-next` are normally launched *by the client*, so a remote client can't reach the phone through them. To drive the **full** QA stack from another machine, serve it over HTTP **on the USB host** (where the phone is):
 
 ```bash
-make serve-all        # android-wifi :3000, android-playwright :8931, mobile-next :8932, + CDP bridge
+make serve-all        # android-wifi :3000 (+ mobile-next proxied in), android-playwright :8931, + CDP bridge
 make serve-all-stop   # tear it all down
 ```
 
-Each binds `0.0.0.0` (ports configurable: `PORT`, `PW_PORT`, `MOBILE_PORT`); logs land in `/tmp/android-wifi-mcp/`.
+Two HTTP endpoints bind `0.0.0.0` (ports configurable: `PORT`, `PW_PORT`); logs land in `/tmp/android-wifi-mcp/`. **mobile-next** isn't a third port: it's single-session SSE over the network ([#102]), so `serve-all` runs it as a **stdio upstream of android-wifi** — its `mobile_*` UI tools surface through android-wifi's `:3000`, riding that server's multi-session Streamable HTTP.
 
-A remote client then registers **all three** — copy [`.mcp.example`](.mcp.example) and substitute the host IP. The transports differ:
+A remote client then registers just the **two** endpoints — copy [`.mcp.example`](.mcp.example) and substitute the host IP. Both speak Streamable HTTP → bridge with `mcp-remote … --allow-http` (or point a native-HTTP client straight at the URL). Registering `android-wifi` gets you its WiFi/device tools **and** mobile-next's UI tools.
 
-- **android-wifi** + **android-playwright** speak Streamable HTTP → bridge with `mcp-remote … --allow-http` (or point a native-HTTP client straight at the URL).
-- **mobile-next** speaks **SSE** and is **single-session**, so the `mcp-remote` bridge opens two connections and gets a `409` ([#102]). Use a **native SSE-capable client** pointed at `http://<SERVER_LAN_IP>:8932/mcp` (one connection); Claude Code can't bridge it today.
+**Security & exposure (decision).** The bundle is **unauthenticated by design** — both endpoints bind `0.0.0.0` with no token, and playwright's host-check is disabled for remote access, so **anyone who can reach the ports can fully drive the phone** (WiFi, OTPs, screenshots, browser, UI). This is acceptable for a **lab QA tool on a trusted network**; we deliberately don't bolt bespoke auth onto these servers. Use it safely by controlling the **network boundary**, not per-request auth:
 
-**Security & exposure (decision).** The bundle is **unauthenticated by design** — all three servers bind `0.0.0.0` with no token, and playwright's host-check is disabled for remote access, so **anyone who can reach the ports can fully drive the phone** (WiFi, OTPs, screenshots, browser, UI). This is acceptable for a **lab QA tool on a trusted network**; we deliberately don't bolt bespoke auth onto three heterogeneous servers. Use it safely by controlling the **network boundary**, not per-request auth:
-
-- Keep the host on a **trusted LAN** and open `:3000` / `:8931` / `:8932` in the firewall only to known source IPs (or not beyond the LAN at all).
+- Keep the host on a **trusted LAN** and open `:3000` / `:8931` in the firewall only to known source IPs (or not beyond the LAN at all).
 - For access across an untrusted network, put it behind a **VPN / Tailscale** and bind to that interface — never expose the ports to the public internet.
-- Only `mobile-next` supports a bearer token (`MOBILEMCP_AUTH`); `android-wifi` and `android-playwright` have none, so a token isn't a uniform control here.
+- Neither HTTP endpoint has built-in auth, so a token isn't a uniform control here — the boundary is the control.
 
 This exposure is exercised by [`TS-06`](docs/tests/TS-06-failure-exposure.md).
 


### PR DESCRIPTION
## Summary
`mobile-next` over the network is single-session SSE, so the `mcp-remote` bridge opened two connections → `409`; a remote Claude Code client couldn't reach it. Fix: run it as a **stdio upstream of android-wifi** (`UPSTREAM_MCP`, reusing the #14 upstream-proxy) instead of a separate SSE port — its `mobile_*` tools surface through android-wifi's `:3000`, riding that server's **multi-session** Streamable HTTP. Drops the `:8932` server.

Remote clients now register **two** HTTP endpoints (android-wifi `:3000` — now carrying the `mobile_*` tools — and android-playwright `:8931`); `.mcp.example` + README updated.

## Trace
Confirmed via codebase-memory that `initUpstreamProxy()` reads `UPSTREAM_MCP` and `parseUpstreamConfig` accepts the `name=command args` shorthand → no code change needed, only wiring.

## Test plan
- [x] Live (Pixel 8 host, via LAN IP): android-wifi exposes **55 tools (32 native + 23 `mobile_*`)**; remote client drove `mobile_list_available_devices` → real device
- [x] **Two simultaneous clients** both connected (no `409`) → unblocks TS-07 concurrency for the mobile path
- [x] `serve-all-stop` reaps the stdio child (no orphan); build + 187 unit tests pass

Closes #102 · Part of #94