### PR TITLE
docs(story): mark STORY-001 done — remote MCP stack acceptance green

### DIFF
--- a/docs/stories/STORY-001.md
+++ b/docs/stories/STORY-001.md
@@ -28,5 +28,7 @@ The team wants one phone, wired to a shared host, drivable by whoever needs it, 
 
 ## Status
 
+- **Done: 2026-06-26** — acceptance run green (see #95); all of "Success Looks Like" met: local stdio drives all three, a remote machine drives all three + an end-to-end flow on the one phone, from documented repeatable setup.
 - Created: 2026-06-25
-- Issues: #94 (plan), #95 (test plan), #98 · #99 · #100 (tasks)
+- Issues: #94 (plan), #95 (test plan), #98 · #99 · #100 (tasks), #102 (mobile-next remote fix — proxied through android-wifi)
+- Notes: the device-browser legs require Chrome Canary foregrounded (precondition, see `docs/integrations/canary-cdp.md`); shared-device concurrent-writes (TS-07 TC-02) left defined-by-serialization, not stress-tested (relates to #62).


### PR DESCRIPTION
Marks STORY-001 **done**: the full acceptance run (#95) is green and all of "Success Looks Like" is met — local stdio drives all three servers, a remote machine drives all three over HTTP plus an end-to-end flow on the one USB phone, from a documented repeatable setup.

Tasks #98/#99/#100 shipped the build; #102 unblocked mobile-next over the network (proxied through android-wifi). Closes out the story.