### PR TITLE
docs(doc-workflow): require one SVG→PNG diagram per key idea

### DIFF
--- a/.claude/commands/doc-workflow/doc-gen-readme.md
+++ b/.claude/commands/doc-workflow/doc-gen-readme.md
@@ -9,7 +9,7 @@ Target: {{input}}  (a repo path, or empty for the current repo)
 
 Turns a codebase into a README a newcomer gets in a minute. It grounds the structure in
 a fresh web search (so it tracks current convention, not a frozen template), studies the
-project for the few ideas worth leading with, optionally draws a diagram per idea, and
+project for the few ideas worth leading with, draws one SVG→PNG diagram per key idea, and
 writes the file. The producer half of the doc-workflow; its output is gated by
 `/doc-review-readme`. See `.claude/rules/doc-workflow.md`.
 
@@ -58,11 +58,15 @@ This writes the README only. It does NOT open a PR.
         │       features → quickstart → usage/config → reference → docs index → license.
         │   - Lead with the point; keep it scannable; link out rather than inline.
         │
-        ├─► Step 4: Diagrams (optional — one per key idea)
-        │   - If diagrams help, author one SVG per key idea (the editable source) and
-        │     render each to PNG for reliable rendering; embed the PNG.
+        ├─► Step 4: Diagrams — one SVG → PNG per key idea (required for the lead set)
+        │   - For EACH key idea named in Step 2 (the focused ≈3), author its OWN SVG file
+        │     in the images dir (the editable source) and render each to its OWN PNG;
+        │     embed each PNG beside the idea it explains. One idea → one .svg → one .png.
         │   - Make the render reproducible (a script / make target), not hand-exported.
         │   - Mirror any existing ASCII diagrams in docs/ so the picture matches reality.
+        │   - Right-size at Step 2 (how MANY key ideas), not here: a small project leads
+        │     with fewer ideas — but every key idea it does lead with gets its own diagram.
+        │     A truly diagram-less project names zero key ideas, never one with no picture.
         │
         ├─► Step 5: Write the README
         │   - If asked to rewrite, delete the old file and write fresh (don't patch prose).
@@ -82,8 +86,8 @@ This writes the README only. It does NOT open a PR.
 
     1. WebSearch "README best practices <year> structure badges diagrams"
     2. Study repo → key ideas: <A>, <B>, <C>
-    3. Draft structure; recommend 3 diagrams
-    4. Author docs/images/<idea>.svg → render PNG (a reproducible render step)
+    3. Draft structure; one diagram per key idea (A, B, C)
+    4. Author docs/images/{A,B,C}.svg → render each to PNG (one per key idea, reproducible)
     5. Write README.md; verify tool names / env vars / links against the code
     6. Hand off → /doc-review-readme
 
@@ -93,7 +97,9 @@ This writes the README only. It does NOT open a PR.
 
 - Reads the repo + the web; writes README.md (+ docs/images/* if diagrams). No PR.
 - The WebSearch step is mandatory — it is what keeps this command from going stale.
-- Diagrams are optional; when used, SVG is the source of truth and the PNG is rendered.
+- One SVG → PNG diagram per key idea; the SVG is the source of truth and the PNG is
+  rendered (diagram policy resolves from project-profile → Docs & diagrams).
 - Producer paired with the review `/doc-review-readme` (see .claude/rules/doc-workflow.md).
-- Right-size: a tiny project may need no diagrams; don't manufacture them.
+- Right-size at Step 2 (how many key ideas), not Step 4: every key idea you lead with
+  gets its own SVG → PNG; don't lead with ideas that don't warrant a picture.
 ```

--- a/.claude/commands/doc-workflow/doc-review-readme.md
+++ b/.claude/commands/doc-workflow/doc-review-readme.md
@@ -37,6 +37,9 @@ Fits in the doc-workflow:
         │         reproducible render step (script / make target) beside them — NOT
         │         Mermaid or any inline/fenced diagram block, so they render on GitHub
         │         with no build step. Each diagram exists, renders, and matches the code.
+        │   - [ ] One SVG → PNG per key idea: every idea the README leads with has its
+        │         OWN committed .svg + rendered .png. Flag any lead idea with no diagram
+        │         (and any diagram with no .svg source) as a REVISE finding.
         │
         ├─► Step 3: Delivers for the reader
         │   - [ ] A newcomer gets what it is, why it's distinctive, and how to run it
@@ -57,8 +60,8 @@ Fits in the doc-workflow:
 
 - Reuses `reviewing-phrasing` + `reviewing-typography` (the human-read doc review) and
   adds the accuracy pass a README needs — it does not duplicate those skills.
-- Enforces what the producer promises: SVG→PNG diagrams (no Mermaid) and a README that
-  leads with the key point. If the producer's rules change, update this pass to match.
+- Enforces what the producer promises: one SVG→PNG diagram per key idea (no Mermaid) and
+  a README that leads with the key point. If the producer's rules change, update this pass.
 - Read-mostly: reads the README + the code; on REVISE, edits the README in place.
 - Review paired with the producer `/doc-gen-readme` (see .claude/rules/doc-workflow.md).
 ```

--- a/.claude/rules/doc-workflow.md
+++ b/.claude/rules/doc-workflow.md
@@ -20,12 +20,12 @@ in current best practice, leading with the few ideas worth a diagram, and true t
         │                    └─ reuses reviewing-phrasing + reviewing-typography,
         │                       then verifies every claim against the code
         ▼
-   README.md (+ docs/images/* when diagrams help)
+   README.md (+ docs/images/* — one SVG→PNG per key idea)
 ```
 
 `doc-gen-readme` opens with a mandatory **WebSearch** step so the structure tracks current
-convention rather than a frozen template. Diagrams are optional: when used, the SVG is the
-source of truth and the embedded PNG is rendered reproducibly.
+convention rather than a frozen template. It draws **one SVG→PNG diagram per key idea** it
+leads with: the SVG is the source of truth and the embedded PNG is rendered reproducibly.
 
 ## Producer → review pairing
 

--- a/.claude/rules/project-profile.md
+++ b/.claude/rules/project-profile.md
@@ -73,7 +73,7 @@ project's choice.
 ## Docs & diagrams
 
 - README output: `README.md`
-- diagram policy: SVG source committed + rendered to PNG (no Mermaid / inline diagram blocks)
+- diagram policy: one diagram per key idea — each its own SVG source committed + rendered to PNG (no Mermaid / inline diagram blocks)
 - images dir: `docs/images/` (also under Paths)
 
 ## Review semantics


### PR DESCRIPTION
## Summary
The diagram contract was "optional — one per key idea", and the review only checked diagram **format** (PNG + SVG + render step), not per-idea **coverage** — so a README could lead with several ideas, ship a single diagram, and still pass.

Make it firm across the contract:
- **`doc-gen-readme`** Step 4 — author one `.svg` per key idea (the focused ~3 from Step 2) and render each to its own `.png`; right-size by choosing fewer key ideas, never by dropping a chosen idea's diagram.
- **`doc-review-readme`** — adds a per-key-idea coverage check (flag any lead idea with no diagram, or any diagram with no SVG source).
- **rule + project-profile** diagram policy updated to match.

Reviewed with `reviewing-artifacts` (the project's review for agent-read commands): PASS after fixing one stale flow caption.

Pairs with the README regen in the sibling PR, which this contract enables.