### PR TITLE
docs(STORY-002): trustworthy, lab-usable enterprise (802.1X) WiFi — story + test docs

### DIFF
--- a/docs/stories/STORY-002.md
+++ b/docs/stories/STORY-002.md
@@ -35,3 +35,4 @@ The result is a feature that looks like it works but can't be relied on for the 
 
 - Created: 2026-06-30
 - Issues: #69, #70, #71, #72 (technical breakdown; #73 closed — folded into #69)
+- Test plan: #109 → test docs in `docs/tests/STORY-002/` (TS-01..05)

--- a/docs/stories/STORY-002.md
+++ b/docs/stories/STORY-002.md
@@ -1,0 +1,37 @@
+# STORY-002: Trustworthy, lab-usable enterprise (802.1X) WiFi
+
+## User Story
+
+As a QA engineer testing devices against **enterprise / 802.1X** WiFi,
+I want to put the phone onto an enterprise network and **know it actually connected** — including the lab and test APs we use day to day,
+So that I can run enterprise WiFi QA flows whose results I can trust, without hand-checking the phone.
+
+## The Need
+
+Enterprise 802.1X is a primary QA target — corporate networks, RADIUS-backed lab SSIDs, compliance deployments. Today the tool can *build and submit* an enterprise config, but it's only half-usable:
+
+- **It can't be trusted.** `wifi_connect_enterprise` reports success the moment Android *accepts* the configuration — not when the device has actually associated. A "success" can mean the phone never joined the network, so every enterprise result is a half-truth a tester has to verify by hand.
+- **It can't reach the networks we actually test on.** It only handles strict WPA2-Enterprise with full server-certificate validation (a pinned CA *and* a known RADIUS domain). The everyday lab case — a test AP with no CA on hand, a RADIUS hostname that rotates, or a WPA3-Enterprise-only SSID — simply fails, often with a cryptic Android error instead of an actionable one.
+
+The result is a feature that looks like it works but can't be relied on for the enterprise scenarios that matter most.
+
+## Success Looks Like
+
+- When `wifi_connect_enterprise` reports **success, the device is genuinely associated** to the SSID — and when it isn't, the result says so plainly, rather than a false success.
+- A tester can connect to a **lab / test 802.1X AP** that has no pinned CA or an unknown RADIUS domain — via a documented, deliberate trust-on-first-use choice — and gets a **clear, actionable error** when a config genuinely can't be validated.
+- A **pinned-CA-without-a-known-domain** config connects.
+- **WPA3-Enterprise** SSIDs connect where the AP supports them.
+- The existing local (stdio + companion-app) path keeps working — no regression to today's WPA2-Enterprise flows.
+
+## Open Questions
+
+- Where the association check lives — the trace suggests reusing the host-side poll already proven for PSK `wifi_connect` (#65) rather than blocking inside the companion. To confirm during planning.
+- Trust-on-first-use correctness on Android 13+ (the corrected `enableTrustOnFirstUse` approach from #69/#73) and the behaviour/error below API 33.
+- How the association verify interacts with the still-open `ASSOCIATING`-past-deadline gap (#91).
+- WPA3-Enterprise verification needs a WPA3-Enterprise lab AP; if one isn't available, that slice may ship as code with a deferred/pending acceptance test (#72).
+- Companion-app version bump + rebuild/reinstall cadence, and which slices need a new APK vs. host-only changes.
+
+## Status
+
+- Created: 2026-06-30
+- Issues: #69, #70, #71, #72 (technical breakdown; #73 closed — folded into #69)

--- a/docs/tests/STORY-002/TS-01-association-verified.md
+++ b/docs/tests/STORY-002/TS-01-association-verified.md
@@ -1,0 +1,34 @@
+---
+id: TS-01
+title: Association is verified, not assumed
+namespace: enterprise-wifi
+story: STORY-002
+story_hash: 13aa58ae0565169296cd69e377528f698171f4bce41adc938ab5edb6dda5fe32
+plan: 109
+issue: 70
+status: green
+---
+
+# TS-01: Association is verified, not assumed
+
+**Objective:** A reported success from an enterprise connect means the device is
+**actually associated** to the SSID; a non-association is reported plainly, never
+as a false success.
+
+## TC-01 — success means associated (to-be)
+
+| Action | Expected Result |
+|---|---|
+| Connect to a known-good enterprise SSID with valid credentials | The result reports the device **associated** to the SSID — not merely "configuration accepted" |
+
+## TC-02 — a failed association is not a false success (to-be)
+
+| Action | Expected Result |
+|---|---|
+| Connect with credentials/conditions that won't associate (wrong password, or the SSID out of range) | Within a bounded verify window the result is **not** a success — it reports not-associated with a clear reason, rather than claiming success |
+
+## TC-03 — independent confirmation (to-be)
+
+| Action | Expected Result |
+|---|---|
+| After a reported success, read the device's current WiFi status out of band | The current SSID matches the network just connected — confirming the result reflected reality |

--- a/docs/tests/STORY-002/TS-01-association-verified.md
+++ b/docs/tests/STORY-002/TS-01-association-verified.md
@@ -3,7 +3,7 @@ id: TS-01
 title: Association is verified, not assumed
 namespace: enterprise-wifi
 story: STORY-002
-story_hash: 13aa58ae0565169296cd69e377528f698171f4bce41adc938ab5edb6dda5fe32
+story_hash: 875f03224823a642778e30a216471799c99e90c36a6ee7e8d231c0808d6e18b7
 plan: 109
 issue: 70
 status: green

--- a/docs/tests/STORY-002/TS-02-trust-on-first-use.md
+++ b/docs/tests/STORY-002/TS-02-trust-on-first-use.md
@@ -1,0 +1,34 @@
+---
+id: TS-02
+title: Lab-usable via trust-on-first-use
+namespace: enterprise-wifi
+story: STORY-002
+story_hash: 13aa58ae0565169296cd69e377528f698171f4bce41adc938ab5edb6dda5fe32
+plan: 109
+issue: 69
+status: green
+---
+
+# TS-02: Lab-usable via trust-on-first-use
+
+**Objective:** A tester can connect to a lab/test 802.1X AP that has no pinned CA
+and no/unknown RADIUS domain, via an explicit trust-on-first-use choice, with clear
+guard rails when a config can't be validated.
+
+## TC-01 — TOFU connect on a supported device (to-be)
+
+| Action | Expected Result |
+|---|---|
+| On a current Android device, connect to a lab enterprise SSID with trust-on-first-use chosen, no CA, and no domain | The device associates to the SSID |
+
+## TC-02 — an unvalidatable config gives an actionable error (to-be)
+
+| Action | Expected Result |
+|---|---|
+| Connect with no CA, no domain, and trust-on-first-use **not** chosen | A clear, actionable error naming the choices (enable trust-on-first-use, or provide a CA / domain) — not a raw framework error and not a false success |
+
+## TC-03 — trust-on-first-use on an unsupported OS (to-be)
+
+| Action | Expected Result |
+|---|---|
+| Request trust-on-first-use on a device too old to support it | A clear "requires a newer Android" message — not a silent failure or a misleading success |

--- a/docs/tests/STORY-002/TS-02-trust-on-first-use.md
+++ b/docs/tests/STORY-002/TS-02-trust-on-first-use.md
@@ -3,7 +3,7 @@ id: TS-02
 title: Lab-usable via trust-on-first-use
 namespace: enterprise-wifi
 story: STORY-002
-story_hash: 13aa58ae0565169296cd69e377528f698171f4bce41adc938ab5edb6dda5fe32
+story_hash: 875f03224823a642778e30a216471799c99e90c36a6ee7e8d231c0808d6e18b7
 plan: 109
 issue: 69
 status: green

--- a/docs/tests/STORY-002/TS-03-validation-modes.md
+++ b/docs/tests/STORY-002/TS-03-validation-modes.md
@@ -3,7 +3,7 @@ id: TS-03
 title: Server-validation modes behave correctly
 namespace: enterprise-wifi
 story: STORY-002
-story_hash: 13aa58ae0565169296cd69e377528f698171f4bce41adc938ab5edb6dda5fe32
+story_hash: 875f03224823a642778e30a216471799c99e90c36a6ee7e8d231c0808d6e18b7
 plan: 109
 issue: 71
 status: green

--- a/docs/tests/STORY-002/TS-03-validation-modes.md
+++ b/docs/tests/STORY-002/TS-03-validation-modes.md
@@ -1,0 +1,33 @@
+---
+id: TS-03
+title: Server-validation modes behave correctly
+namespace: enterprise-wifi
+story: STORY-002
+story_hash: 13aa58ae0565169296cd69e377528f698171f4bce41adc938ab5edb6dda5fe32
+plan: 109
+issue: 71
+status: green
+---
+
+# TS-03: Server-validation modes behave correctly
+
+**Objective:** Each documented server-validation mode connects — including the lab
+combinations — while the existing strict mode is preserved.
+
+## TC-01 — strict validation (CA + domain)
+
+| Action | Expected Result |
+|---|---|
+| Connect with both a pinned CA and a known RADIUS domain | The device associates — today's strict happy path, unchanged |
+
+## TC-02 — pinned CA, no domain (to-be)
+
+| Action | Expected Result |
+|---|---|
+| Connect with a pinned CA but no domain suffix | The device associates — the certificate chain is trusted without a domain check |
+
+## TC-03 — domain only, public CA (to-be)
+
+| Action | Expected Result |
+|---|---|
+| Connect with a domain suffix and no pinned CA, against a RADIUS server using a publicly-trusted CA | The device associates using the system trust store |

--- a/docs/tests/STORY-002/TS-04-wpa3-enterprise.md
+++ b/docs/tests/STORY-002/TS-04-wpa3-enterprise.md
@@ -1,0 +1,29 @@
+---
+id: TS-04
+title: WPA3-Enterprise
+namespace: enterprise-wifi
+story: STORY-002
+story_hash: 13aa58ae0565169296cd69e377528f698171f4bce41adc938ab5edb6dda5fe32
+plan: 109
+issue: 72
+status: green
+---
+
+# TS-04: WPA3-Enterprise
+
+**Objective:** Connect to a WPA3-Enterprise SSID where the access point supports it.
+
+> **Pending a WPA3-Enterprise lab AP** — these cases run once such an AP is available;
+> until then they stay (to-be) rather than being asserted on WPA2 hardware.
+
+## TC-01 — WPA3-Enterprise connect (to-be)
+
+| Action | Expected Result |
+|---|---|
+| Connect to a WPA3-Enterprise SSID | The device associates using WPA3-Enterprise |
+
+## TC-02 — WPA3-Enterprise 192-bit / suite-B (to-be)
+
+| Action | Expected Result |
+|---|---|
+| Connect to a WPA3-Enterprise 192-bit (suite-B) SSID on a supporting AP | The device associates in 192-bit mode |

--- a/docs/tests/STORY-002/TS-04-wpa3-enterprise.md
+++ b/docs/tests/STORY-002/TS-04-wpa3-enterprise.md
@@ -3,7 +3,7 @@ id: TS-04
 title: WPA3-Enterprise
 namespace: enterprise-wifi
 story: STORY-002
-story_hash: 13aa58ae0565169296cd69e377528f698171f4bce41adc938ab5edb6dda5fe32
+story_hash: 875f03224823a642778e30a216471799c99e90c36a6ee7e8d231c0808d6e18b7
 plan: 109
 issue: 72
 status: green

--- a/docs/tests/STORY-002/TS-05-no-regression.md
+++ b/docs/tests/STORY-002/TS-05-no-regression.md
@@ -3,7 +3,7 @@ id: TS-05
 title: No regression to existing enterprise flows
 namespace: enterprise-wifi
 story: STORY-002
-story_hash: 13aa58ae0565169296cd69e377528f698171f4bce41adc938ab5edb6dda5fe32
+story_hash: 875f03224823a642778e30a216471799c99e90c36a6ee7e8d231c0808d6e18b7
 plan: 109
 status: green
 ---

--- a/docs/tests/STORY-002/TS-05-no-regression.md
+++ b/docs/tests/STORY-002/TS-05-no-regression.md
@@ -1,0 +1,26 @@
+---
+id: TS-05
+title: No regression to existing enterprise flows
+namespace: enterprise-wifi
+story: STORY-002
+story_hash: 13aa58ae0565169296cd69e377528f698171f4bce41adc938ab5edb6dda5fe32
+plan: 109
+status: green
+---
+
+# TS-05: No regression to existing enterprise flows
+
+**Objective:** Today's WPA2-Enterprise path keeps working unchanged — the new
+verification and validation options don't break the flows that already work.
+
+## TC-01 — existing WPA2-Enterprise connect
+
+| Action | Expected Result |
+|---|---|
+| Connect to a WPA2-Enterprise SSID via PEAP/TTLS/TLS with a CA and a domain (the current flow) | The device associates as it does today — no new requirement or failure introduced |
+
+## TC-02 — companion-app status check
+
+| Action | Expected Result |
+|---|---|
+| Query the companion-app presence and notification-access status | It reports install + grant state correctly, as before |


### PR DESCRIPTION
## Summary
The QA + dev paperwork for the enterprise-802.1X cluster (#69/#70/#71/#72), all gated green.

- **STORY-002** (`docs/stories/STORY-002.md`) — need, not spec; passed `dw-review-story`.
- **Test docs** (`docs/tests/STORY-002/TS-01..05`) — association-verified (#70), trust-on-first-use (#69), validation-modes (#71), WPA3-Enterprise (#72, pending an AP), no-regression. Passed `qw-review-cases` (front-matter resolves, story_hash matches).
- Test plan persisted as issue #109 (passed `qw-review-plan`); breakdown #69–#72 passed `dw-review-tasks`.

No code yet — `dw-implement` starts after this lands. Depends on #110 (per-story folders), already merged.