### PR TITLE
fix(enterprise): verify actual association, not just suggestion-accepted (#70)

### DIFF
--- a/src/adb/enterprise-wifi.ts
+++ b/src/adb/enterprise-wifi.ts
@@ -1,5 +1,6 @@
 import { AdbClient } from './adb-client.js';
 import { CompanionAppBridge, COMPANION_PACKAGE } from './companion-bridge.js';
+import { WifiCommands } from './wifi-commands.js';
 import {
   EapConfig,
   EapMethod,
@@ -79,7 +80,34 @@ export class EnterpriseWifiCommands {
       };
     }
 
-    return normalizeEnterpriseResult(raw, config.ssid, config.eapMethod);
+    const result = normalizeEnterpriseResult(raw, config.ssid, config.eapMethod);
+
+    // The suggestion API is fire-and-forget: a success above means the OS
+    // ACCEPTED the config, not that the device associated (#70). Unless the
+    // caller opts out (verify: false), poll for real L2 association — the same
+    // host-side approach proven for PSK wifi_connect (#65), so no companion change.
+    if (!result.success || config.verify === false) return result;
+    const timeoutMs = config.verifyTimeoutMs ?? 30_000;
+    const associated = await this.pollAssociation(result.ssid, timeoutMs);
+    return applyVerification(result, associated, timeoutMs);
+  }
+
+  /**
+   * Poll for real L2 association to `ssid` after a suggestion is accepted.
+   * Time-based, with no terminal early-bail: the OS schedules suggestion
+   * materialization asynchronously, so an early DISCONNECTED is normal rather
+   * than a failure (avoids #91's class of premature bail).
+   */
+  private async pollAssociation(ssid: string, timeoutMs: number): Promise<boolean> {
+    const wifi = new WifiCommands(this.adb);
+    const POLL_INTERVAL_MS = 500;
+    const deadline = Date.now() + timeoutMs;
+    while (true) {
+      const status = await wifi.getStatus();
+      if (status.connected && status.ssid === ssid) return true;
+      if (Date.now() >= deadline) return false;
+      await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL_MS));
+    }
   }
 
   /**
@@ -166,6 +194,27 @@ function normalizeEnterpriseResult(
         ? raw.eapMethod
         : fallbackEapMethod,
     error: success ? undefined : pickErrorMessage(raw),
+  };
+}
+
+/**
+ * Shape the result after an association poll. With verify on, `success` reflects
+ * whether the device actually associated — not merely that the OS accepted the
+ * suggestion — so a reported success is never a false positive (#70).
+ */
+export function applyVerification(
+  base: EnterpriseConnectionResult,
+  associated: boolean,
+  timeoutMs: number
+): EnterpriseConnectionResult {
+  if (associated) {
+    return { ...base, associated: true };
+  }
+  return {
+    ...base,
+    success: false,
+    associated: false,
+    error: `Suggestion accepted but the device did not associate to "${base.ssid}" within ${Math.round(timeoutMs / 1000)}s — it may be out of range, awaiting first-run user approval, or rejected during the EAP handshake.`,
   };
 }
 

--- a/src/adb/enterprise-wifi.ts
+++ b/src/adb/enterprise-wifi.ts
@@ -103,8 +103,14 @@ export class EnterpriseWifiCommands {
     const POLL_INTERVAL_MS = 500;
     const deadline = Date.now() + timeoutMs;
     while (true) {
-      const status = await wifi.getStatus();
-      if (status.connected && status.ssid === ssid) return true;
+      try {
+        const status = await wifi.getStatus();
+        if (status.connected && status.ssid === ssid) return true;
+      } catch {
+        // adb hiccup / transient device drop mid-poll — treat as not-yet-
+        // associated and keep polling to the deadline, so connectEnterprise
+        // still returns its structured result rather than throwing.
+      }
       if (Date.now() >= deadline) return false;
       await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL_MS));
     }

--- a/src/server.ts
+++ b/src/server.ts
@@ -556,6 +556,8 @@ export function createMcpServer(
       clientCertificate: z.string().optional().describe('Client certificate for EAP-TLS (base64-encoded PEM)'),
       privateKey: z.string().optional().describe('Private key for EAP-TLS (base64-encoded PEM)'),
       privateKeyPassword: z.string().optional().describe('Private key password (if encrypted)'),
+      verify: z.boolean().optional().default(true).describe('Poll for actual association after the suggestion is accepted; a success then means the device is on the SSID, not just that the config was accepted. Set false for the old fire-and-forget behaviour.'),
+      verifyTimeoutMs: z.number().int().optional().default(30000).describe('How long to wait for association when verify is true (ms, default 30000)'),
     },
     async (params) => {
       await ensureDevice();
@@ -573,6 +575,8 @@ export function createMcpServer(
         clientCertificate: params.clientCertificate,
         privateKey: params.privateKey,
         privateKeyPassword: params.privateKeyPassword,
+        verify: params.verify,
+        verifyTimeoutMs: params.verifyTimeoutMs,
       });
 
       if (result.success) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,12 +71,15 @@ export interface EapConfig {
   clientCertificate?: string;        // Base64-encoded PEM (for EAP-TLS)
   privateKey?: string;               // Base64-encoded PEM (for EAP-TLS)
   privateKeyPassword?: string;       // If private key is encrypted
+  verify?: boolean;                  // Poll for actual association after the suggestion is accepted (default true)
+  verifyTimeoutMs?: number;          // How long to wait for association (default 30000)
 }
 
 export interface EnterpriseConnectionResult {
   success: boolean;
   ssid: string;
   eapMethod: EapMethod;
+  associated?: boolean;              // Set when verify ran: true = on the SSID, false = accepted but did not associate
   error?: string;
 }
 

--- a/tests/unit/companion-bridge.test.mjs
+++ b/tests/unit/companion-bridge.test.mjs
@@ -142,7 +142,9 @@ test('normalize: success=true returns success with no error', async () => {
     resultFileContent: JSON.stringify({ success: true, ssid: 'TestSSID', eapMethod: 'peap' }),
   });
   const ent = new EnterpriseWifiCommands(fake);
-  const result = await ent.connectEnterprise(validPeapConfig());
+  // verify:false isolates normalization (the suggestion-accepted path) from the
+  // #70 association poll, which is covered by enterprise-verify.test.mjs.
+  const result = await ent.connectEnterprise({ ...validPeapConfig(), verify: false });
 
   assert.equal(result.success, true);
   assert.equal(result.error, undefined);

--- a/tests/unit/enterprise-verify.test.mjs
+++ b/tests/unit/enterprise-verify.test.mjs
@@ -1,0 +1,43 @@
+/**
+ * Unit tests for wifi_connect_enterprise association verification (#70).
+ *
+ * connectEnterprise() returned success as soon as the OS ACCEPTED the
+ * suggestion — not when the device associated. It now polls getStatus and
+ * shapes the result via applyVerification, so `success` reflects real
+ * association rather than "config accepted". This covers that shaping (the
+ * pure decision); the poll loop mirrors the proven wifi_connect verify (#65).
+ *
+ * Run with: npm run test:unit  (after npm run build)
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { applyVerification } from '../../dist/adb/enterprise-wifi.js';
+
+const base = { success: true, ssid: 'CorpNet', eapMethod: 'peap' };
+
+test('associated → success stays true, associated:true, no error', () => {
+  const r = applyVerification(base, true, 30000);
+  assert.equal(r.success, true);
+  assert.equal(r.associated, true);
+  assert.equal(r.error, undefined);
+  assert.equal(r.ssid, 'CorpNet');
+});
+
+test('not associated → not a false success: success:false, associated:false, clear error', () => {
+  const r = applyVerification(base, false, 30000);
+  assert.equal(r.success, false);
+  assert.equal(r.associated, false);
+  assert.match(r.error, /CorpNet/);
+  assert.match(r.error, /30s/);
+});
+
+test('error reports the timeout in seconds (rounded)', () => {
+  assert.match(applyVerification(base, false, 12000).error, /12s/);
+});
+
+test('does not mutate the base result', () => {
+  const original = { success: true, ssid: 'CorpNet', eapMethod: 'peap' };
+  applyVerification(original, false, 30000);
+  assert.equal(original.success, true);
+  assert.equal(original.associated, undefined);
+});


### PR DESCRIPTION
## Summary
`wifi_connect_enterprise` returned success the moment the OS *accepted* the `WifiNetworkSuggestion` — before the device associated. Now, unless `verify:false`, `connectEnterprise` polls `getStatus` for real L2 association (host-side, reusing the proven PSK `wifi_connect` poll #65 — **no companion change**), and `success` reflects association.

- `EapConfig` += `verify?` (default true) + `verifyTimeoutMs?` (default 30000)
- `EnterpriseConnectionResult` += `associated?` — false + `success:false` + clear error when accepted-but-not-associated
- Time-based poll, no terminal early-bail (OS schedules suggestion materialization async; early DISCONNECTED isn't failure — avoids #91)
- Review fix: poll tolerates adb errors mid-window (keeps the structured result)

## Test plan
- [x] Build + 191 unit tests pass (new `applyVerification` test; normalize test opts out with `verify:false`)
- [x] `/code-review medium` — one fix applied; by-design items noted; pre-existing comma-SSID parse → follow-up #112
- [ ] **Live association (TS-01)** is blocked until TOFU (#69) lets us reach the no-CA lab AP

Part of STORY-002 · Closes #70