### PR TITLE
fix(bridge): fail fast on command-file write failure instead of a silent 30s timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ cicd/tests/dist/
 
 # @playwright/mcp scratch (when used as an upstream)
 .playwright-mcp/
+
+# Enterprise-WiFi test material — holds a private key, never commit
+lab-certs/

--- a/src/adb/companion-bridge.ts
+++ b/src/adb/companion-bridge.ts
@@ -63,7 +63,14 @@ export class CompanionAppBridge {
    */
   async sendBroadcastAndWait(action: string, payload?: object): Promise<BridgeResponse> {
     if (payload !== undefined) {
-      await this.writeCommandFile(payload);
+      const writeError = await this.writeCommandFile(payload);
+      if (writeError) {
+        // A silently-ignored write failure here is exactly what turned a bad
+        // command file into a 30 s result-poll timeout (#115). Fail fast with
+        // the real reason instead — the companion would otherwise read a stale
+        // or missing file and never write a result.
+        return { raw: null, broadcastError: `Failed to write command file: ${writeError}` };
+      }
     }
     await this.clearResultFile();
 
@@ -82,13 +89,21 @@ export class CompanionAppBridge {
    * Write `payload` as JSON into the companion app's filesDir.
    * Payload is base64-encoded so embedded JSON quotes / cert hyphens cannot
    * break shell escaping.
+   *
+   * Returns an error string when the write fails (`run-as` denied, redirect
+   * failed, oversized payload), or `undefined` on success. The caller must not
+   * broadcast on failure — see {@link sendBroadcastAndWait}.
    */
-  private async writeCommandFile(payload: object): Promise<void> {
+  private async writeCommandFile(payload: object): Promise<string | undefined> {
     const json = JSON.stringify(payload);
     const b64 = Buffer.from(json, 'utf-8').toString('base64');
-    await this.adb.shell(
+    const result = await this.adb.shell(
       `run-as ${COMPANION_PACKAGE} sh -c 'echo ${b64} | base64 -d > ${COMMAND_FILE_REL}'`
     );
+    if (!result.success) {
+      return result.stderr || result.stdout || 'Unknown error';
+    }
+    return undefined;
   }
 
   private async clearResultFile(): Promise<void> {

--- a/tests/unit/companion-bridge.test.mjs
+++ b/tests/unit/companion-bridge.test.mjs
@@ -28,12 +28,17 @@ class FakeAdbClient {
     this.calls = [];
     this.resultFileContent = opts.resultFileContent ?? null;
     this.companionAppInstalled = opts.companionAppInstalled ?? true;
+    this.commandWriteError = opts.commandWriteError ?? null;
   }
 
   async shell(command, _timeout) {
     this.calls.push(command);
     if (command.includes('pm list packages')) {
       return ok(this.companionAppInstalled ? `package:${COMPANION_PACKAGE}` : '');
+    }
+    // Simulate a failed command-file write (run-as denied, oversized payload, …).
+    if (this.commandWriteError && command.includes('base64 -d > files/wifi_mcp_command.json')) {
+      return fail(this.commandWriteError);
     }
     if (command.includes('cat files/wifi_mcp_result.json')) {
       return ok(this.resultFileContent ?? '');
@@ -48,6 +53,10 @@ class FakeAdbClient {
 
 function ok(stdout) {
   return { success: true, stdout, stderr: '', exitCode: 0 };
+}
+
+function fail(stderr) {
+  return { success: false, stdout: '', stderr, exitCode: 1 };
 }
 
 function validPeapConfig() {
@@ -236,4 +245,31 @@ test('run-as: writeCommandFile produces b64-pipe-decode command with correct pay
   assert.equal(decoded.domainSuffixMatch, 'corp.example.com');
   assert.equal(decoded.password, 'pw');
   assert.ok(typeof decoded.timestamp === 'number');
+});
+
+// ============ Command-file write failure (#115) ============
+//
+// A failed command-file write used to be ignored: the bridge broadcast anyway,
+// the companion read a stale/missing file, and the host burned the full 30 s
+// result-poll before reporting a bare timeout. The write must now fail fast
+// with the underlying reason, and must NOT broadcast or poll.
+
+test('write-failure: connectEnterprise fails fast with the write error, no broadcast', async () => {
+  const fake = new FakeAdbClient({
+    commandWriteError: 'run-as: Package is not debuggable',
+  });
+  const ent = new EnterpriseWifiCommands(fake);
+  const result = await ent.connectEnterprise(validPeapConfig());
+
+  assert.equal(result.success, false);
+  assert.match(result.error, /run-as: Package is not debuggable/);
+  // Must abort before broadcasting / polling — that was the 30 s hang.
+  assert.ok(
+    !fake.calls.some((c) => c.includes('am broadcast')),
+    'must not broadcast after a failed command-file write'
+  );
+  assert.ok(
+    !fake.calls.some((c) => c.includes('cat files/wifi_mcp_result.json')),
+    'must not poll for a result after a failed command-file write'
+  );
 });


### PR DESCRIPTION
## What

`CompanionAppBridge.writeCommandFile` sent the `run-as … > wifi_mcp_command.json` write and **ignored its result**. Any genuine write failure (`run-as` denied, redirect failed, etc.) left the companion reading a stale/missing command file, which surfaced only as a 30 s result-poll timeout with no reason.

Now the write result is checked. On failure, `sendBroadcastAndWait` returns immediately via `broadcastError` with the underlying stderr — **no broadcast, no 30 s poll**. Adds a unit test covering the fast-fail path.

## Why this scope (not the adb-push rewrite)

Filed as #115 on the theory that a large EAP-TLS cert payload overflowed the inlined-base64 command line. **Disproven on-device:** a real EAP-TLS connect against the lab RADIUS showed the ~4 KB bundle (well under execFile's 128 KB arg limit) written and read fine — `Network suggestion added successfully`, result file written, supplicant associated, `CTRL-EVENT-EAP-STARTED`. The actual TLS failure was an 802.1X **auth rejection** (`Authentication failure reason=3`), a cert/RADIUS matter, not the bridge. See the issue thread for the full logcat.

So this PR keeps only the real, independent hardening: a silent write failure is now loud. The adb-push rewrite (original Task 3) is dropped as unwarranted.

## Test

- `npm run test:unit` — 192/192 pass, incl. new `write-failure: connectEnterprise fails fast with the write error, no broadcast`.
- On-device: rebuilt + restarted server, EAP-TLS connect exercised via the MCP tool; bridge path confirmed working in logcat.

Rescopes #115.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
