### PR TITLE
docs(stories): add STORY-003 and STORY-004 for the CI-coverage gap

### DIFF
--- a/docs/stories/STORY-003.md
+++ b/docs/stories/STORY-003.md
@@ -1,0 +1,54 @@
+# STORY-003: Judge WiFi tool tests by intent, with an AI agent
+
+## User Story
+
+As a test author for this WiFi MCP server,
+I want the CI runner to decide whether a tool worked by judging its intent — using an
+AI agent where the outcome isn't deterministic,
+So that live, varying WiFi responses are verified for real instead of matched against
+brittle fixed patterns.
+
+## The Need
+
+The whole point of the suite is to prove our MCP tools actually work. But we are a WiFi
+server, and WiFi is not static: which access points are in range, whether a connect
+succeeds, the signal, the exact SSID and status text all change from run to run. Today
+the runner can only pattern-match — does the response contain these keys, these
+regexes. That forces every test into a rigid shape and can't tell a genuine success
+from a string that happened to appear.
+
+The tools are not uniform either. Some are deterministic — device info, a settings
+round-trip — where pattern-matching is exactly right and cheap. Others are stateful and
+non-deterministic — connect, scan, status — where "did it work" is a judgment call
+against the real device.
+
+So for those, the tester itself may need to be an AI agent: one that reads the tool's
+output and the test's stated intent, and where needed actively checks the live device,
+rather than us hand-writing expected strings that break on the next run.
+
+## Success Looks Like
+
+- A test can state its intent ("the device is now associated to the target network")
+  and the runner reaches a correct pass/fail even when the exact response text differs
+  between runs.
+- Deterministic tools keep their fast, cheap checks; only the non-deterministic ones
+  need agent judgment — no one is forced to use one style for everything.
+- When the agent tester can't run in an environment (no credentials, no device), the
+  run degrades safely to the deterministic check instead of failing every test.
+- A WiFi connect regression that today slips past pattern-matching is caught.
+
+## Open Questions
+
+- Which judgment tiers to adopt from the upstream `agent-workflows-runner` fork we
+  already carry — the semantic agent-judge, the live-tool verifier (agent calls our
+  read-only tools to confirm ground truth), or both — and how they compose with the
+  existing deterministic judge.
+- How the agent tester authenticates locally vs. in GitHub Actions, and the behavior on
+  a hosted runner with no attached device.
+- How each tool is categorized (deterministic vs. needs-agent) and where that lives.
+- Relationship to STORY-004, whose test corpus runs under this runner.
+
+## Status
+
+- Created: 2026-07-01
+- Plan: #119

--- a/docs/stories/STORY-004.md
+++ b/docs/stories/STORY-004.md
@@ -1,0 +1,54 @@
+# STORY-004: A test for every WiFi MCP tool, driven by real config
+
+## User Story
+
+As a maintainer of this WiFi MCP server,
+I want a meaningful test for every tool we expose, with the SSIDs and credentials the
+WiFi tools need supplied from config and runnable both locally and in CI,
+So that we know our whole tool surface works before shipping, instead of testing only
+the read-only corners.
+
+## The Need
+
+We are a WiFi MCP tool, yet our tests cover only a read-only slice — and several of
+those only assert that a response has certain keys, which proves almost nothing. The
+tools that matter most — connect, enterprise connect, forget, install certificate —
+have no test at all, which is exactly why connect regressions reach users.
+
+Real WiFi tests need real inputs: a target network, a password, enterprise
+credentials. Those are environment-specific and secret, so they belong in a config
+source, not hard-coded — and the same tests should then run locally first and, wired
+with secrets, in GitHub Actions.
+
+The existing test scripts are not sacred. Dead-weight can be trimmed or deleted, and
+because the runner itself is changing (STORY-003) we don't need to migrate the old
+cases — we can build the corpus fresh, working outward from the actual tool list.
+
+## Success Looks Like
+
+- Every MCP tool we expose has at least one test that exercises it for real, not just
+  its response shape.
+- WiFi tools that need a network or credential draw them from a single config source;
+  nothing secret is hard-coded; running locally is the first-class path and CI reuses
+  the same tests through secrets.
+- The low-value shape-only tests are gone and the corpus is lean — every case earns its
+  place.
+- Coverage is traceable back to the tool surface — anyone can see which tool each test
+  covers and confirm no tool is left untested.
+
+## Open Questions
+
+- The intended build order is tools → test docs under `docs/tests/` → runnable scripts;
+  confirm that sequence and what each layer owns.
+- Which existing cases to delete vs. keep — the pure key-existence smoke/sms/
+  notifications tests are the first trim candidates.
+- Where enterprise (802.1X) end-to-end lives: STORY-002 already sketches it as
+  `(to-be)` test docs, so the two stories must be reconciled to avoid duplication.
+- What keys the config/`.env` needs and how they map to GitHub Actions secrets.
+- What "meaningful" coverage means for tools needing physical conditions CI can't
+  reliably create (a captive portal, an inbound OTP SMS).
+
+## Status
+
+- Created: 2026-07-01
+- Plan: #120


### PR DESCRIPTION
## Summary
- Adds **STORY-003** — judge WiFi tool tests by intent with an AI agent (WiFi responses are non-deterministic, so fixed patterns are brittle).
- Adds **STORY-004** — a meaningful test for every MCP tool, config-driven inputs, local-first then CI.
- Both split the coverage gap raised in #118 into two goals; plans already drafted.

Part of STORY-003 and STORY-004.
Refs #118 · plans #119, #120 (kept open for human review + dw-tasks — intentionally not auto-closed).

## Test plan
- [ ] Both files render with the five required story headings (User Story, The Need, Success Looks Like, Open Questions, Status).
- [ ] No acceptance-criteria checklist / leaked spec in the body (goal-not-spec).
- [ ] Status lines link the correct plan issues (#119, #120).

Generated with [Claude Code](https://claude.com/claude-code)