### PR TITLE
docs(stories): record task issue numbers for STORY-003/004

### DIFF
--- a/docs/stories/STORY-003.md
+++ b/docs/stories/STORY-003.md
@@ -52,3 +52,4 @@ rather than us hand-writing expected strings that break on the next run.
 
 - Created: 2026-07-01
 - Plan: #119
+- Issues: #122, #123, #124, #125, #126

--- a/docs/stories/STORY-004.md
+++ b/docs/stories/STORY-004.md
@@ -52,3 +52,4 @@ cases — we can build the corpus fresh, working outward from the actual tool li
 
 - Created: 2026-07-01
 - Plan: #120
+- Issues: #127, #128, #129, #130, #131, #132, #133


### PR DESCRIPTION
## Summary
- Records the `dw-tasks` breakdown on each story's Status.
- STORY-003 → #122–#126 · STORY-004 → #127–#133.

Refs #119, #120 (plans). Doc bookkeeping only.

Generated with [Claude Code](https://claude.com/claude-code)