### PR TITLE
docs(stories): make STORY-004 a findable hub

### DIFF
--- a/docs/stories/STORY-004.md
+++ b/docs/stories/STORY-004.md
@@ -52,3 +52,8 @@ cases — we can build the corpus fresh, working outward from the actual tool li
 
 - Created: 2026-07-01
 - Plan: #120
+- Issues: #127 (coverage matrix — recorded as a comment on the issue), #128, #129, #130, #131, #132, #133
+- Shipped (PR #135): scenario docs #128, wifi suite #130, gap tools #131, trim #129
+- Open: #132 (enterprise ownership vs STORY-002), #133 (CI wiring — held for STORY-003)
+- Test docs: `docs/tests/STORY-004/` (TS-01 connect e2e, TS-02 radio+forget, TS-03 network diagnostics)
+- Runnable cases: `cicd/tests/testcases/` — `wifi/` (TC-WIFI-001..005), `smoke/` (TC-SMK-015..018), `logging/` (TC-LOG-001)


### PR DESCRIPTION
## Summary
STORY-004's Status now links everything: plan #120, issues #127–#133, the shipped PR #135, the test docs (`docs/tests/STORY-004/`), and the runnable cases (`cicd/tests/testcases/{wifi,smoke,logging}/`). So the story is the single navigable entry point for its work.

Doc bookkeeping only.

Generated with [Claude Code](https://claude.com/claude-code)