### PR TITLE
docs(tests): refresh STORY-004 test docs (story_hash + to-be)

### DIFF
--- a/docs/tests/STORY-004/TS-01-connect-verify-cleanup.md
+++ b/docs/tests/STORY-004/TS-01-connect-verify-cleanup.md
@@ -3,7 +3,7 @@ id: TS-01
 title: Connect means associated, and the device is left as found
 namespace: wifi
 story: STORY-004
-story_hash: 272e833442d0605dbbeca4a67c22e58be0f08f499e49da8edfc31e6b1620fb64
+story_hash: ecc52dc3d9f6ce59597ff8fd9e041a04bd35c5ad3423062c086b064a6f521fa0
 plan: 120
 issue: 128
 status: green
@@ -15,8 +15,8 @@ status: green
 associated** to the target SSID — confirmed independently, not assumed from "config
 accepted" — and the test leaves the device in its original state.
 
-Cases are **(to-be)** until the runnable binding ships (#130) and a target network is
-configured (`TEST_SSID_*`).
+Cases are **(to-be)** — the runnable binding shipped in #130 (`cicd/tests/testcases/wifi/`);
+they go green once run against a lab access point with `TEST_SSID_*` configured.
 
 ## TC-01 — success means associated (to-be)
 

--- a/docs/tests/STORY-004/TS-02-radio-and-forget.md
+++ b/docs/tests/STORY-004/TS-02-radio-and-forget.md
@@ -3,7 +3,7 @@ id: TS-02
 title: Radio controls and forget do what they say
 namespace: wifi
 story: STORY-004
-story_hash: 272e833442d0605dbbeca4a67c22e58be0f08f499e49da8edfc31e6b1620fb64
+story_hash: ecc52dc3d9f6ce59597ff8fd9e041a04bd35c5ad3423062c086b064a6f521fa0
 plan: 120
 issue: 128
 status: green
@@ -15,7 +15,8 @@ status: green
 `wifi_disconnect`, `wifi_forget`) change device state as claimed, confirmed by reading
 status out of band, and each test restores what it changed.
 
-Cases are **(to-be)** until the runnable binding ships (#130).
+Cases are **(to-be)** — the runnable binding shipped in #130 (`cicd/tests/testcases/wifi/`);
+they go green once run against a lab access point with `TEST_SSID_*` configured.
 
 ## TC-01 — enable turns the radio on (to-be)
 

--- a/docs/tests/STORY-004/TS-03-network-diagnostics.md
+++ b/docs/tests/STORY-004/TS-03-network-diagnostics.md
@@ -3,7 +3,7 @@ id: TS-03
 title: Network diagnostics reach a real host
 namespace: network
 story: STORY-004
-story_hash: 272e833442d0605dbbeca4a67c22e58be0f08f499e49da8edfc31e6b1620fb64
+story_hash: ecc52dc3d9f6ce59597ff8fd9e041a04bd35c5ad3423062c086b064a6f521fa0
 plan: 120
 issue: 128
 status: green


### PR DESCRIPTION
## Summary
`qw-review-cases` on `docs/tests/STORY-004/` found two REVISE items, fixed here:
- **story_hash drift** — the hub edit (#136) changed `STORY-004.md`; the three TS docs still recorded the old hash. The story's *need* is unchanged, so the scenarios are re-blessed against the new hash.
- **stale `(to-be)` marker** — TS-01/TS-02 said "until the binding ships (#130)"; #130 shipped, so the real gate is a lab AP (now matches TS-03).

Doc-only. Part of STORY-004.

Generated with [Claude Code](https://claude.com/claude-code)