### PR TITLE
docs(tests): re-bless STORY-001 test-doc story_hash

### DIFF
--- a/docs/tests/STORY-001/TS-01-local-stdio-stack.md
+++ b/docs/tests/STORY-001/TS-01-local-stdio-stack.md
@@ -3,7 +3,7 @@ id: TS-01
 title: Local client drives the full stack via stdio
 namespace: remote-stack
 story: STORY-001
-story_hash: 2937da1a558ea87ccb89179849dc3cf225de98f93ebf192f4819db0a3ee1a5a8
+story_hash: 4f42d5b1693d86abbca8a49743d1cd89f479d8db07d8ec0a0d379fc211fa144c
 plan: 95
 issue: 94
 status: green

--- a/docs/tests/STORY-001/TS-02-remote-http-android-wifi.md
+++ b/docs/tests/STORY-001/TS-02-remote-http-android-wifi.md
@@ -3,7 +3,7 @@ id: TS-02
 title: Remote client reaches android-wifi over http
 namespace: remote-stack
 story: STORY-001
-story_hash: 2937da1a558ea87ccb89179849dc3cf225de98f93ebf192f4819db0a3ee1a5a8
+story_hash: 4f42d5b1693d86abbca8a49743d1cd89f479d8db07d8ec0a0d379fc211fa144c
 plan: 95
 issue: 94
 status: green

--- a/docs/tests/STORY-001/TS-03-remote-http-browser-ui.md
+++ b/docs/tests/STORY-001/TS-03-remote-http-browser-ui.md
@@ -3,7 +3,7 @@ id: TS-03
 title: Remote client reaches the browser + UI servers over http
 namespace: remote-stack
 story: STORY-001
-story_hash: 2937da1a558ea87ccb89179849dc3cf225de98f93ebf192f4819db0a3ee1a5a8
+story_hash: 4f42d5b1693d86abbca8a49743d1cd89f479d8db07d8ec0a0d379fc211fa144c
 plan: 95
 issue: 94
 status: green

--- a/docs/tests/STORY-001/TS-04-e2e-remote-flow.md
+++ b/docs/tests/STORY-001/TS-04-e2e-remote-flow.md
@@ -3,7 +3,7 @@ id: TS-04
 title: End-to-end remote QA flow on one phone
 namespace: remote-stack
 story: STORY-001
-story_hash: 2937da1a558ea87ccb89179849dc3cf225de98f93ebf192f4819db0a3ee1a5a8
+story_hash: 4f42d5b1693d86abbca8a49743d1cd89f479d8db07d8ec0a0d379fc211fa144c
 plan: 95
 issue: 94
 status: green

--- a/docs/tests/STORY-001/TS-05-setup-documented.md
+++ b/docs/tests/STORY-001/TS-05-setup-documented.md
@@ -3,7 +3,7 @@ id: TS-05
 title: Setup is documented and repeatable
 namespace: remote-stack
 story: STORY-001
-story_hash: 2937da1a558ea87ccb89179849dc3cf225de98f93ebf192f4819db0a3ee1a5a8
+story_hash: 4f42d5b1693d86abbca8a49743d1cd89f479d8db07d8ec0a0d379fc211fa144c
 plan: 95
 issue: 94
 status: green

--- a/docs/tests/STORY-001/TS-06-failure-exposure.md
+++ b/docs/tests/STORY-001/TS-06-failure-exposure.md
@@ -3,7 +3,7 @@ id: TS-06
 title: Failure modes and exposure are clear
 namespace: remote-stack
 story: STORY-001
-story_hash: 2937da1a558ea87ccb89179849dc3cf225de98f93ebf192f4819db0a3ee1a5a8
+story_hash: 4f42d5b1693d86abbca8a49743d1cd89f479d8db07d8ec0a0d379fc211fa144c
 plan: 95
 issue: 94
 status: green

--- a/docs/tests/STORY-001/TS-07-concurrency-shared-device.md
+++ b/docs/tests/STORY-001/TS-07-concurrency-shared-device.md
@@ -3,7 +3,7 @@ id: TS-07
 title: Two clients, one phone (shared-device behaviour)
 namespace: remote-stack
 story: STORY-001
-story_hash: 2937da1a558ea87ccb89179849dc3cf225de98f93ebf192f4819db0a3ee1a5a8
+story_hash: 4f42d5b1693d86abbca8a49743d1cd89f479d8db07d8ec0a0d379fc211fa144c
 plan: 95
 issue: 94
 status: green


### PR DESCRIPTION
## Summary
`qw-review-cases` on STORY-001 found all 7 TS docs had `story_hash` drift — `STORY-001.md`'s Status was updated (Done/Issues/Notes) after the docs were written. The semantic sections are unchanged and the scenarios still map to "Success Looks Like", so the hashes are re-blessed against the current story file. Doc-only.

Part of STORY-001.

Generated with [Claude Code](https://claude.com/claude-code)