### PR TITLE
test(notifications): close STORY-004 coverage gap

### DIFF
--- a/cicd/tests/testcases/notifications/TC-NOTIF-004.yml
+++ b/cicd/tests/testcases/notifications/TC-NOTIF-004.yml
@@ -1,0 +1,21 @@
+id: TC-NOTIF-004
+name: notifications_list_recent is reachable and well-shaped
+suite: notifications
+tags: [notifications]
+priority: 4
+timeout: 30000
+dependencies: []
+
+steps:
+  - name: List recent notifications
+    command: npx tsx cicd/tests/src/mcp-client.ts notifications_list_recent '{"limit":5}'
+    expectPatterns:
+      - "notifications"
+      - "count"
+    rejectPatterns:
+      - "isError"
+
+criteria: |
+  notifications_list_recent responds cleanly with the {notifications, count} shape
+  (the array may be empty, and a warning is returned when notification access is not
+  granted — neither is an error). Reachability + shape coverage for the tool.

--- a/cicd/tests/testcases/notifications/TC-NOTIF-005.yml
+++ b/cicd/tests/testcases/notifications/TC-NOTIF-005.yml
@@ -1,0 +1,23 @@
+id: TC-NOTIF-005
+name: wifi_check_companion_app detects the installed companion app
+suite: notifications
+tags: [notifications, companion]
+priority: 5
+timeout: 30000
+dependencies: []
+
+steps:
+  - name: Check companion-app state
+    command: npx tsx cicd/tests/src/mcp-client.ts wifi_check_companion_app '{}'
+    expectPatterns:
+      - "companionAppInstalled.*true"
+      - "notificationAccessGranted"
+      - "capturedNotifications"
+    rejectPatterns:
+      - "isError"
+
+criteria: |
+  wifi_check_companion_app reports the companion-app state and actually detects the
+  installed app (companionAppInstalled true), not merely that the field exists — plus
+  the notificationAccessGranted and capturedNotifications fields. Assumes the companion
+  app is installed on the test device (part of the lab setup).


### PR DESCRIPTION
## Summary
Closes the STORY-004 coverage gap from the trim (#129): the two tools left untested are re-covered.
- **TC-NOTIF-004** `notifications_list_recent` — reachability + {notifications, count} shape.
- **TC-NOTIF-005** `wifi_check_companion_app` — asserts the companion app is **actually detected** (companionAppInstalled true), not just field presence — more meaningful than the shape-only case that was trimmed.

Both **pass live** on the Pixel 8 (local device reads — no internet needed).

Closes #139
Part of STORY-004 · plan #120

Generated with [Claude Code](https://claude.com/claude-code)