### PR TITLE
feat(ci): agent judge + live-MCP verifier (STORY-003)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,15 @@ name: CI
 
 on:
   workflow_dispatch:
+    inputs:
+      judge_mode:
+        description: 'Judge mode for the suites'
+        required: false
+        default: 'simple'
+        type: choice
+        options:
+          - simple
+          - dual
 
 jobs:
   build:
@@ -10,4 +19,6 @@ jobs:
   test-smoke:
     needs: build
     uses: ./.github/workflows/test-smoke.yml
+    with:
+      judge_mode: ${{ inputs.judge_mode }}
     secrets: inherit

--- a/.github/workflows/test-run.yml
+++ b/.github/workflows/test-run.yml
@@ -7,6 +7,11 @@ on:
         description: 'Suite tag to filter tests (e.g. smoke)'
         required: true
         type: string
+      judge_mode:
+        description: "Judge mode: 'simple' (deterministic only) or 'dual' (also run the ACP agent judge on tests that opt in with `judge: agent`)"
+        required: false
+        default: 'simple'
+        type: string
 
 jobs:
   test:
@@ -31,3 +36,8 @@ jobs:
         env:
           TEST_DEVICE_SERIAL: ${{ secrets.TEST_DEVICE_SERIAL }}
           ADB_PATH: ${{ secrets.ADB_PATH }}
+          # Judge mode + agent auth (STORY-003). In 'dual', tests marked `judge: agent`
+          # also run the ACP agent judge; if the token/agent is absent it degrades to
+          # deterministic verdicts (never a mass failure).
+          JUDGE_MODE: ${{ inputs.judge_mode }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/test-smoke.yml
+++ b/.github/workflows/test-smoke.yml
@@ -3,10 +3,17 @@ name: "Test: Smoke"
 on:
   workflow_dispatch:
   workflow_call:
+    inputs:
+      judge_mode:
+        description: "Judge mode: simple or dual"
+        required: false
+        default: 'simple'
+        type: string
 
 jobs:
   test:
     uses: ./.github/workflows/test-run.yml
     with:
       tag: smoke
+      judge_mode: ${{ inputs.judge_mode || 'simple' }}
     secrets: inherit

--- a/cicd/tests/package-lock.json
+++ b/cicd/tests/package-lock.json
@@ -8,9 +8,12 @@
       "name": "android-wifi-mcp-tests",
       "version": "1.0.0",
       "dependencies": {
+        "@agentclientprotocol/claude-agent-acp": "^0.44.0",
+        "@agentclientprotocol/sdk": "^0.25.1",
         "@modelcontextprotocol/sdk": "^1.12.0",
         "chalk": "^5.3.0",
         "commander": "^12.1.0",
+        "dotenv": "^16.6.1",
         "glob": "^10.3.10",
         "js-yaml": "^4.1.0"
       },
@@ -22,6 +25,198 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@agentclientprotocol/claude-agent-acp": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@agentclientprotocol/claude-agent-acp/-/claude-agent-acp-0.44.0.tgz",
+      "integrity": "sha512-FWET6TS3XpVgm4xhPtxzPJACNBK+O1rWnZ+6ZDA1vvtxy9KmAu6yGCDSGSsPeArEcouc8u69iuNW4vLaUELNcw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@agentclientprotocol/sdk": "0.25.0",
+        "@anthropic-ai/claude-agent-sdk": "0.3.170",
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "bin": {
+        "claude-agent-acp": "dist/index.js"
+      }
+    },
+    "node_modules/@agentclientprotocol/claude-agent-acp/node_modules/@agentclientprotocol/sdk": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.25.0.tgz",
+      "integrity": "sha512-wU1VgXNtMvdVotX49txc3WJUDV+/QbLpsgjMvFhlRmp37osdLbI7L7y+iwAlQATwfjLxcv1r1p3ZxZBcXlGhcQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/@agentclientprotocol/sdk": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.25.1.tgz",
+      "integrity": "sha512-jx2rF3bdpGwZ75Q/meyEDLLbYmbtxk82Uh9hDCdxDvcEedBnNSF5hZAnL/kJR5VNz56JqwOmqnAqasC84MwwkQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk": {
+      "version": "0.3.170",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.170.tgz",
+      "integrity": "sha512-pAvhfk+iTodXZ6RF18Kz7BEUWFjL7EcR3tKuhUNdPpE1NAYCR3mSHGbafi72JsrNwKEDIs7FU31z3fqhwy8QzA==",
+      "license": "SEE LICENSE IN README.md",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.170",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.170",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.170",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.170",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.170",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.170",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.170",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.170"
+      },
+      "peerDependencies": {
+        "@anthropic-ai/sdk": ">=0.93.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
+      "version": "0.3.170",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.170.tgz",
+      "integrity": "sha512-rwfgArIa5WI0QPNqFsRBgvtSI0mrtpynUm0oK6+l6/KX4hcgnYGEzciZR1bOeD9/7sSZlTdIgt+T9alKeZmXcg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
+      "version": "0.3.170",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.170.tgz",
+      "integrity": "sha512-0e58h8UQMtsQxLGIv9r4foxfBFWKZ7NeDtoplLhuD7EwQonehomw1sBXCch77t/IfUS+q5vQ5zv+fOGmap5nLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
+      "version": "0.3.170",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.170.tgz",
+      "integrity": "sha512-gLbaFqcGppFJQd4DLNV4IXoeahejT/p2/M8bSSvRDbla9GOsBr1AxV5XLRyBn1e7xFGozZIAIQr3+1chp7NJgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
+      "version": "0.3.170",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.170.tgz",
+      "integrity": "sha512-SRYfQcsXlOq+CD/FqkQBTSHbaD++w73GnnO+NUV9adLYrca3kfetRwWT1iguY1cNS0l34dCR3rlzCPq78vg1Jg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
+      "version": "0.3.170",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.170.tgz",
+      "integrity": "sha512-Xl/m7TaSC3T5IDBdHrZQ9fCQYyDmPELN34CL+MoyPIf7uSmuZnjE9fUOqDh2Rv26JxWssi1M6X+BBvVuKd6Cpg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
+      "version": "0.3.170",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.170.tgz",
+      "integrity": "sha512-m4+I0qBEk7cxRKS+pL+eoWXbXTFOAo83fQ0tQvap4z/mDMm06IWJtEPoYTaMBwsp32GJWLkHWKbZSBCHZnp2DQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
+      "version": "0.3.170",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.170.tgz",
+      "integrity": "sha512-IG+8isJNNJKbnnhO7m+PGhfVCg+XoQ/MDxGde5eigFI0WsEfitjuWSWwx82bT9ghxI1aa6qNvI+UPgPcZuo5Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
+      "version": "0.3.170",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.170.tgz",
+      "integrity": "sha512-7cuqSKbHVItPGVwRbd3A0BEJwcNtc7Fhoh6qHN4C6yrmjSrvdYYx3MLvq/VI768/RoG7mAMDxb+j7WfEfoP9BA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.109.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.109.1.tgz",
+      "integrity": "sha512-q9OnEKLr5H9nxSuXdgDgJhxfYMiE+AaUEBze2Gk91UcaaLnsN+Lx5fbCYywiqurU/APLdwv23x03Wm6WN3EBsg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -545,6 +740,13 @@
         "node": ">=14"
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/js-yaml": {
       "version": "4.0.9",
       "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
@@ -851,6 +1053,18 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -1005,7 +1219,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -1067,6 +1280,13 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense",
+      "peer": true
     },
     "node_modules/fast-uri": {
       "version": "3.1.0",
@@ -1275,7 +1495,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
       "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -1395,6 +1614,20 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/json-schema-traverse": {
@@ -1859,6 +2092,17 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -1972,6 +2216,13 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tsx": {
       "version": "4.21.0",
@@ -2163,7 +2414,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/cicd/tests/package.json
+++ b/cicd/tests/package.json
@@ -12,9 +12,12 @@
     "dev": "tsx src/cli.ts"
   },
   "dependencies": {
+    "@agentclientprotocol/claude-agent-acp": "^0.44.0",
+    "@agentclientprotocol/sdk": "^0.25.1",
     "@modelcontextprotocol/sdk": "^1.12.0",
     "chalk": "^5.3.0",
     "commander": "^12.1.0",
+    "dotenv": "^16.6.1",
     "glob": "^10.3.10",
     "js-yaml": "^4.1.0"
   },

--- a/cicd/tests/src/cli.ts
+++ b/cicd/tests/src/cli.ts
@@ -13,7 +13,7 @@ import { mkdirSync, existsSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { TestLoader } from './loader.js';
 import { TestExecutor } from './executor.js';
-import { SimpleJudge, AgentJudge } from './judge/index.js';
+import { SimpleJudge, AgentJudge, redactSecrets } from './judge/index.js';
 import { CONFIG, pickEnv } from './config.js';
 import { JsonReporter, ConsoleReporter } from './reporter/index.js';
 import { runMcpTest } from './mcp/test-mcp.js';
@@ -145,17 +145,22 @@ program
         judgments = judgments.map((sj) => {
           const aj = agentMap.get(sj.testId);
           if (!aj) return sj;
+          // Report reason AND evidence from the SAME judge — the one that failed
+          // (simple first); if both pass, the agent's. Keeps provenance aligned and
+          // preserves any extended fields the agent set. Redact secrets a test's
+          // stdout may have surfaced into the agent's evidence before it hits the report.
+          const reported = !sj.pass ? sj : aj;
           return {
+            ...aj,
             testId: sj.testId,
             pass: sj.pass && aj.pass,
-            // Surface the reason from whichever judge failed (simple first).
-            reason: !sj.pass ? sj.reason : aj.reason,
-            evidence: aj.evidence,
+            reason: reported.reason,
+            evidence: reported.evidence ? redactSecrets(reported.evidence) : undefined,
           };
         });
       } else {
         process.stderr.write(
-          '[JUDGE] [WARN] Agent judge unavailable — using deterministic verdicts only.\n'
+          `[JUDGE] [WARN] Agent judge unavailable — ${agentTargets.length} test(s) marked \`judge: agent\` fall back to deterministic verdicts only (not agent-verified).\n`
         );
       }
     }

--- a/cicd/tests/src/cli.ts
+++ b/cicd/tests/src/cli.ts
@@ -130,11 +130,17 @@ program
     // Dual mode (STORY-003): also run the ACP agent judge; a test passes only if
     // BOTH the deterministic and agent judges pass. Fail-safe: if the agent can't
     // run (no auth/agent), keep the simple verdicts rather than failing everything.
-    if (CONFIG.judge.mode === 'dual') {
-      process.stderr.write('[JUDGE] Running agent judge (dual mode)...\n');
+    // Per-test judge style (#125): only tests that opt in with `judge: agent` pay for
+    // the agent judge; deterministic tests keep the fast SimpleJudge verdict.
+    const agentTargets = results.filter((r) => r.testCase.judge === 'agent');
+    if (CONFIG.judge.mode === 'dual' && agentTargets.length === 0) {
+      process.stderr.write('[JUDGE] Dual mode: no tests declare `judge: agent` — deterministic only.\n');
+    }
+    if (CONFIG.judge.mode === 'dual' && agentTargets.length > 0) {
+      process.stderr.write(`[JUDGE] Running agent judge (dual mode) on ${agentTargets.length} test(s)...\n`);
       const agentJudge = new AgentJudge();
       if (await agentJudge.isAvailable()) {
-        const agentJudgments = await agentJudge.judgeResults(results);
+        const agentJudgments = await agentJudge.judgeResults(agentTargets);
         const agentMap = new Map(agentJudgments.map((j) => [j.testId, j]));
         judgments = judgments.map((sj) => {
           const aj = agentMap.get(sj.testId);

--- a/cicd/tests/src/cli.ts
+++ b/cicd/tests/src/cli.ts
@@ -13,7 +13,8 @@ import { mkdirSync, existsSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { TestLoader } from './loader.js';
 import { TestExecutor } from './executor.js';
-import { SimpleJudge } from './judge/index.js';
+import { SimpleJudge, AgentJudge } from './judge/index.js';
+import { CONFIG } from './config.js';
 import { JsonReporter, ConsoleReporter } from './reporter/index.js';
 import { RunConfig } from './types.js';
 
@@ -122,7 +123,34 @@ program
 
     process.stderr.write('\n[JUDGE] Running simple judge...\n');
     const simpleJudge = new SimpleJudge();
-    const judgments = simpleJudge.judgeAll(results);
+    let judgments = simpleJudge.judgeAll(results);
+
+    // Dual mode (STORY-003): also run the ACP agent judge; a test passes only if
+    // BOTH the deterministic and agent judges pass. Fail-safe: if the agent can't
+    // run (no auth/agent), keep the simple verdicts rather than failing everything.
+    if (CONFIG.judge.mode === 'dual') {
+      process.stderr.write('[JUDGE] Running agent judge (dual mode)...\n');
+      const agentJudge = new AgentJudge();
+      if (await agentJudge.isAvailable()) {
+        const agentJudgments = await agentJudge.judgeResults(results);
+        const agentMap = new Map(agentJudgments.map((j) => [j.testId, j]));
+        judgments = judgments.map((sj) => {
+          const aj = agentMap.get(sj.testId);
+          if (!aj) return sj;
+          return {
+            testId: sj.testId,
+            pass: sj.pass && aj.pass,
+            // Surface the reason from whichever judge failed (simple first).
+            reason: !sj.pass ? sj.reason : aj.reason,
+            evidence: aj.evidence,
+          };
+        });
+      } else {
+        process.stderr.write(
+          '[JUDGE] [WARN] Agent judge unavailable — using deterministic verdicts only.\n'
+        );
+      }
+    }
 
     const jsonReporter = new JsonReporter(outputDir);
     const { summary, reports } = jsonReporter.generateReports(

--- a/cicd/tests/src/cli.ts
+++ b/cicd/tests/src/cli.ts
@@ -14,8 +14,10 @@ import { fileURLToPath } from 'url';
 import { TestLoader } from './loader.js';
 import { TestExecutor } from './executor.js';
 import { SimpleJudge, AgentJudge } from './judge/index.js';
-import { CONFIG } from './config.js';
+import { CONFIG, pickEnv } from './config.js';
 import { JsonReporter, ConsoleReporter } from './reporter/index.js';
+import { runMcpTest } from './mcp/test-mcp.js';
+import { makeBackend } from './mcp/backends/index.js';
 import { RunConfig } from './types.js';
 
 const program = new Command();
@@ -206,6 +208,63 @@ program
 
     console.log('\n' + '='.repeat(60));
     console.log(`Total: ${testCases.length} test(s)`);
+  });
+
+program
+  .command('test-mcp')
+  .description("Test whether models can drive our MCP server's tools (with --verify-live, the judge calls the read-only tools itself)")
+  .argument('<models...>', 'One or more model names to test')
+  .option('--prompt <text>', 'Prompt that should trigger a tool call', CONFIG.mcp.prompt)
+  .option('-c, --num-ctx <n>', 'Context window size', '8192')
+  .option('--judge', 'Also run the agent judge on the final answer (dual mode)', false)
+  .option('-H, --host <url>', 'Backend host (e.g. the Ollama host)', CONFIG.mcp.host)
+  .option('--backend <name>', 'Chat backend (model runtime) — built-in: ollama', CONFIG.mcp.backend)
+  .option('--mcp-command <cmd>', 'Command to launch our MCP server', CONFIG.mcp.command)
+  .option('--mcp-args <args>', 'Args for the MCP server (space-separated; no spaces within a single arg)', CONFIG.mcp.args.join(' '))
+  .option('--mcp-env <names>', 'Comma-separated env var names to forward to the server as creds (overrides MCP_ENV)', '')
+  .option('--distractor-command <cmd>', 'Optional second (menu-only) MCP server — its tools join the menu as distractors the model must NOT pick; the verifier never touches it')
+  .option('--distractor-args <args>', 'Args for the distractor MCP server (space-separated; no spaces within a single arg)', '')
+  .option('--verify-live', "Verify the answer against LIVE truth: the judge calls the server's read-only tools itself (supersedes --judge)", false)
+  .option('--verify-allow <names>', 'Comma-separated exact tool names the verifier may call (fail-closed: empty verifies nothing)', '')
+  .option('--verify-server-name <name>', 'Name of the server the verifier spawns (its tools are mcp__<name>__<tool>)', 'mcp')
+  .option('--timeout <seconds>', 'Per-call response timeout', '1800')
+  .option('-o, --output <file>', 'Write the JSON report to this file')
+  .action(async (models: string[], options) => {
+    const code = await runMcpTest({
+      models,
+      prompt: options.prompt,
+      numCtx: Number(options.numCtx),
+      timeoutMs: Number(options.timeout) * 1000,
+      judge: options.judge,
+      verifyLive: options.verifyLive,
+      verifyAllow: options.verifyAllow
+        ? String(options.verifyAllow).split(',').map((s: string) => s.trim()).filter(Boolean)
+        : undefined,
+      verifyServerName: options.verifyServerName,
+      backend: makeBackend(options.backend, { host: options.host }),
+      // Primary server (the verifier's read-only target) is named after --verify-server-name
+      // so the verifier can find it. An optional distractor server joins the model's menu only.
+      servers: [
+        {
+          name: options.verifyServerName,
+          command: options.mcpCommand,
+          args: String(options.mcpArgs).split(' ').filter(Boolean),
+          cwd: CONFIG.mcp.cwd,
+          env: options.mcpEnv ? pickEnv(options.mcpEnv) : CONFIG.mcp.env,
+        },
+        ...(options.distractorCommand
+          ? [{
+              name: 'distractor',
+              command: options.distractorCommand,
+              args: String(options.distractorArgs).split(' ').filter(Boolean),
+            }]
+          : []),
+      ],
+      output: options.output,
+    });
+    // Flush stdout before forcing exit — the markdown summary is piped to tee in CI.
+    await new Promise<void>((resolve) => process.stdout.write('', () => resolve()));
+    process.exit(code);
   });
 
 program.parse();

--- a/cicd/tests/src/config.ts
+++ b/cicd/tests/src/config.ts
@@ -14,6 +14,22 @@ export const CONFIG = {
     cleanupAge: 24 * 60 * 60 * 1000,
     maxBuffer: 50 * 1024 * 1024,
   },
+
+  // Agent judge (STORY-003). The deterministic SimpleJudge always runs; set
+  // JUDGE_MODE=dual to ALSO run the ACP agent judge (both must pass).
+  judge: {
+    // 'simple' (default) = deterministic checks only. 'dual' = also run the agent judge.
+    mode: process.env.JUDGE_MODE || 'simple',
+    // Command that launches the ACP agent. Empty → the bundled Claude ACP agent
+    // (@agentclientprotocol/claude-agent-acp), keyless via the agent's own auth
+    // (~/.claude / CLAUDE_CODE_OAUTH_TOKEN). Set to another ACP agent's command to
+    // swap models/vendors — config, not code.
+    agent: process.env.JUDGE_AGENT || '',
+    timeout: 300000,
+    stdoutLimit: 1000,
+    stderrLimit: 500,
+    logsLimit: 3000,
+  },
 };
 
 export const ERROR_PATTERNS: RegExp[] = [

--- a/cicd/tests/src/config.ts
+++ b/cicd/tests/src/config.ts
@@ -30,7 +30,8 @@ export const CONFIG = {
   // JUDGE_MODE=dual to ALSO run the ACP agent judge (both must pass).
   judge: {
     // 'simple' (default) = deterministic checks only. 'dual' = also run the agent judge.
-    mode: process.env.JUDGE_MODE || 'simple',
+    // Case-insensitive so JUDGE_MODE=DUAL isn't a silent no-op.
+    mode: (process.env.JUDGE_MODE || 'simple').toLowerCase(),
     // Command that launches the ACP agent. Empty → the bundled Claude ACP agent
     // (@agentclientprotocol/claude-agent-acp), keyless via the agent's own auth
     // (~/.claude / CLAUDE_CODE_OAUTH_TOKEN). Set to another ACP agent's command to

--- a/cicd/tests/src/config.ts
+++ b/cicd/tests/src/config.ts
@@ -5,6 +5,17 @@
 export const SUITES = ['smoke', 'wifi', 'enterprise', 'ui', 'sms', 'notifications', 'portal', 'proxy'] as const;
 export type Suite = typeof SUITES[number];
 
+/** Forward selected env vars by NAME (comma-separated) — used to hand the MCP server
+ *  only the credentials it needs, never the whole environment. */
+export function pickEnv(names: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const n of names.split(',').map((s) => s.trim()).filter(Boolean)) {
+    const v = process.env[n];
+    if (v !== undefined) out[n] = v;
+  }
+  return out;
+}
+
 export const CONFIG = {
   projectName: 'android-wifi-mcp',
   defaultTimeout: 60000,
@@ -29,6 +40,20 @@ export const CONFIG = {
     stdoutLimit: 1000,
     stderrLimit: 500,
     logsLimit: 3000,
+  },
+
+  // Live-MCP paths (STORY-003 #124): the model-under-test host (test-mcp) and the
+  // live verifier. Our server speaks HTTP — the runner spawns it with PORT=0 and
+  // connects to the printed URL (see mcp/http-server.ts), so command/args describe
+  // how to LAUNCH it, not a stdio pipe. Point elsewhere via .env.
+  mcp: {
+    command: process.env.MCP_COMMAND || 'node',
+    args: (process.env.MCP_ARGS || 'dist/index.js').split(' ').filter(Boolean),
+    cwd: process.env.MCP_CWD || undefined,
+    prompt: process.env.MCP_PROMPT || 'List the connected Android devices.',
+    env: pickEnv(process.env.MCP_ENV || ''),
+    backend: process.env.MCP_BACKEND || 'ollama', // selects the ChatBackend (model runtime)
+    host: process.env.OLLAMA_HOST || 'http://localhost:11434',
   },
 };
 

--- a/cicd/tests/src/judge/agent-judge.ts
+++ b/cicd/tests/src/judge/agent-judge.ts
@@ -1,0 +1,386 @@
+/**
+ * Agent Judge - Semantic analysis of test results via an ACP agent.
+ *
+ * Uses a reasoning model to evaluate test execution logs against criteria,
+ * catching silent failures that exit-code checking misses.
+ *
+ * The judge is an Agent Client Protocol (ACP) client: it spawns a configured
+ * agent process (JUDGE_AGENT; default the bundled Claude ACP agent) over stdio
+ * and drives one prompt turn per test through @agentclientprotocol/sdk
+ * (initialize → session/new → session/prompt), then parses a JSON verdict from
+ * the agent's reply. Auth is the agent's concern — the default Claude agent runs
+ * keyless on a subscription (~/.claude locally, CLAUDE_CODE_OAUTH_TOKEN in CI),
+ * no ANTHROPIC_API_KEY required. Swapping models/vendors is a JUDGE_AGENT config
+ * change, not a code change.
+ */
+
+import { spawn, type ChildProcess, type StdioOptions } from 'node:child_process';
+import { Readable, Writable } from 'node:stream';
+import { createRequire } from 'node:module';
+import { dirname, resolve } from 'node:path';
+import {
+  ClientSideConnection,
+  ndJsonStream,
+  PROTOCOL_VERSION,
+  type Client,
+  type SessionNotification,
+  type RequestPermissionRequest,
+  type RequestPermissionResponse,
+} from '@agentclientprotocol/sdk';
+import { TestResult, Judgment } from '../types.js';
+import { CONFIG } from '../config.js';
+
+export class AgentJudge {
+  private agentCmd: string;
+  private cwd: string;
+  private child?: ChildProcess;
+  private conn?: ClientSideConnection;
+  private sessionId?: string;
+  /** Accumulates the current turn's agent text (reset before each prompt). */
+  private turnText = '';
+
+  constructor(agentCmd: string = CONFIG.judge.agent, cwd: string = process.cwd()) {
+    this.agentCmd = agentCmd;
+    this.cwd = cwd;
+    // Register the orphan-guard once per instance (not per spawn) — the session
+    // is re-spawned on timeouts, and re-registering here would leak listeners.
+    process.once('exit', () => this.kill());
+  }
+
+  /**
+   * Await a promise but reject if it outruns CONFIG.judge.timeout — so a hung
+   * handshake or turn fails the judge rather than wedging the whole run.
+   */
+  private async withTimeout<T>(p: Promise<T>, label: string): Promise<T> {
+    let timer: NodeJS.Timeout;
+    const timeout = new Promise<never>((_, rej) => {
+      timer = setTimeout(() => rej(new Error(`${label} exceeded ${CONFIG.judge.timeout}ms`)), CONFIG.judge.timeout);
+    });
+    try {
+      return await Promise.race([p, timeout]);
+    } finally {
+      clearTimeout(timer!);
+    }
+  }
+
+  /**
+   * Spawn the configured ACP agent as a stdio child. Clears the CLAUDECODE
+   * markers so the bundled Claude agent (which wraps the `claude` CLI) runs
+   * standalone rather than refusing to launch nested. Auth flows from the
+   * inherited environment (~/.claude / CLAUDE_CODE_OAUTH_TOKEN / any key the
+   * agent honours) — the judge sets none itself.
+   */
+  private spawnAgent(): ChildProcess {
+    const env = { ...process.env };
+    delete env.CLAUDECODE;
+    delete env.CLAUDE_CODE_ENTRYPOINT;
+    delete env.CLAUDE_CODE_SSE_PORT;
+    const stdio: StdioOptions = ['pipe', 'pipe', 'inherit'];
+
+    if (this.agentCmd) {
+      // Any agent command, via the shell — "add a model = config, not code".
+      return spawn(this.agentCmd, { cwd: this.cwd, stdio, env, shell: true });
+    }
+    // Default: the bundled Claude ACP agent. Resolve its entry from package.json
+    // and run it under the current node — avoids .bin/PATH/shebang quirks.
+    const require = createRequire(import.meta.url);
+    const pkg = require.resolve('@agentclientprotocol/claude-agent-acp/package.json');
+    const entry = resolve(dirname(pkg), 'dist/index.js');
+    return spawn(process.execPath, [entry], { cwd: this.cwd, stdio, env });
+  }
+
+  /**
+   * Spawn + initialize + open a session, once. Idempotent — a second call is a
+   * no-op once a session exists.
+   */
+  private async ensureStarted(): Promise<void> {
+    if (this.sessionId) return;
+
+    const child = this.spawnAgent();
+    this.child = child;
+
+    const stream = ndJsonStream(
+      Writable.toWeb(child.stdin!) as WritableStream<Uint8Array>,
+      Readable.toWeb(child.stdout!) as ReadableStream<Uint8Array>,
+    );
+
+    const client: Client = {
+      sessionUpdate: async (params: SessionNotification): Promise<void> => {
+        const u = params.update;
+        if (u.sessionUpdate === 'agent_message_chunk' && u.content.type === 'text') {
+          this.turnText += u.content.text;
+        }
+      },
+      // A judge must not execute anything — refuse every tool-permission request.
+      requestPermission: async (
+        params: RequestPermissionRequest,
+      ): Promise<RequestPermissionResponse> => {
+        const reject = params.options.find((o) => o.kind?.startsWith('reject'));
+        return reject
+          ? { outcome: { outcome: 'selected', optionId: reject.optionId } }
+          : { outcome: { outcome: 'cancelled' } };
+      },
+      // fs is disabled in clientCapabilities, so these should never be called.
+      readTextFile: async () => { throw new Error('filesystem access disabled for the judge'); },
+      writeTextFile: async () => { throw new Error('filesystem access disabled for the judge'); },
+    };
+
+    this.conn = new ClientSideConnection(() => client, stream);
+    try {
+      await this.withTimeout(this.conn.initialize({
+        protocolVersion: PROTOCOL_VERSION,
+        clientCapabilities: { fs: { readTextFile: false, writeTextFile: false }, terminal: false },
+        clientInfo: { name: `${CONFIG.projectName}-judge`, version: '1.0.0' },
+      }), 'agent initialize');
+      const session = await this.withTimeout(
+        this.conn.newSession({ cwd: this.cwd, mcpServers: [] }),
+        'agent session/new',
+      );
+      this.sessionId = session.sessionId;
+    } catch (e) {
+      // A spawnable-but-silent agent would otherwise leave a live child and a
+      // pending handshake. Tear it down so isAvailable() fails over cleanly.
+      this.kill();
+      throw e;
+    }
+  }
+
+  /** Tear down the agent process. Safe to call more than once. */
+  private kill(): void {
+    try { this.child?.kill('SIGKILL'); } catch { /* already gone */ }
+    this.child = undefined;
+    this.conn = undefined;
+    this.sessionId = undefined;
+  }
+
+  /**
+   * Probe the configured agent: spawn, open a session, and run one bounded
+   * throwaway turn. The warmup turn matters — a successful handshake doesn't
+   * prove the agent can actually answer (e.g. broken/expired auth surfaces only
+   * at prompt time), so without it a misauthed agent would pass the probe and
+   * every test would be marked FAIL instead of falling back to the simple judge.
+   * Returns false on any failure. On success the session is kept open for
+   * judgeResults().
+   */
+  async isAvailable(): Promise<boolean> {
+    try {
+      await this.ensureStarted();
+      const reply = await this.promptAgent('Reply with exactly: ok');
+      if (!reply.trim()) throw new Error('agent produced no output on probe turn');
+      return true;
+    } catch (error) {
+      process.stderr.write(`  [judge] Agent not reachable: ${error}\n`);
+      this.kill();
+      return false;
+    }
+  }
+
+  /**
+   * Truncate a string to a maximum length.
+   */
+  private truncate(text: string, limit: number): string {
+    if (text.length <= limit) return text;
+    return text.substring(0, limit) + '... (truncated)';
+  }
+
+  /**
+   * Build structured JSON prompt for evaluation of a single test.
+   */
+  private buildPrompt(result: TestResult): string {
+    const r = result;
+
+    const steps = r.steps.map((step, j) => {
+      const stepDef = r.testCase.steps[j];
+      return {
+        name: step.name,
+        command: step.command.trim(),
+        exit_code: step.exitCode,
+        duration_ms: step.duration,
+        timeout_ms: stepDef?.timeout || r.testCase.timeout,
+        stdout: this.truncate(step.stdout, CONFIG.judge.stdoutLimit),
+        stderr: this.truncate(step.stderr, CONFIG.judge.stderrLimit),
+      };
+    });
+
+    const promptData = {
+      role: `You are a test result evaluator for ${CONFIG.projectName}. Analyze the test execution data and determine if the test passed or failed.`,
+      rules: [
+        'Check step stdout for error responses (e.g. {"error":"..."} means FAIL)',
+        'Errors with exit code 0 are still FAIL',
+        'For AI-generated text, accept reasonable variations',
+        'Long durations within timeout are acceptable',
+        'Focus on semantic correctness, not formatting differences',
+      ],
+      test: {
+        id: r.testCase.id,
+        name: r.testCase.name,
+        suite: r.testCase.suite,
+        goal: r.testCase.goal || r.testCase.name,
+        criteria: r.testCase.criteria,
+        timeout_ms: r.testCase.timeout,
+        duration_ms: r.totalDuration,
+      },
+      steps,
+      container_logs: this.truncate(r.logs, CONFIG.judge.logsLimit),
+      respond: {
+        format: 'Respond with a single JSON object and nothing else',
+        fields: {
+          testId: r.testCase.id,
+          pass: 'true if test meets all criteria, false otherwise',
+          reason: 'Brief explanation of your verdict',
+          evidence: 'Required if pass is false — the exact stdout content or log line that caused failure',
+        },
+      },
+    };
+
+    const prompt = JSON.stringify(promptData, null, 2);
+
+    // Log prompt stats
+    const totalStdout = r.steps.reduce((sum, s) => sum + s.stdout.length, 0);
+    const totalStderr = r.steps.reduce((sum, s) => sum + s.stderr.length, 0);
+    process.stderr.write(`  [judge] Prompt for ${r.testCase.id}: logs ${r.logs.length} chars, stdout ${totalStdout} chars, stderr ${totalStderr} chars\n`);
+    process.stderr.write(`  [judge] Prompt size: ${prompt.length} chars\n`);
+
+    return prompt;
+  }
+
+  /**
+   * Extract the first JSON object from a model response, tolerating prose or
+   * markdown fences around it.
+   */
+  private extractJson(text: string): string | null {
+    const start = text.indexOf('{');
+    const end = text.lastIndexOf('}');
+    if (start === -1 || end === -1 || end < start) return null;
+    return text.substring(start, end + 1);
+  }
+
+  /**
+   * Run one prompt turn through the agent and return its raw reply text.
+   * Bounded by CONFIG.judge.timeout. On timeout/failure the turn isn't actually
+   * cancelled — it keeps running on the session and its late chunks would bleed
+   * into the next test's reply (which shares this.turnText). So we tear the
+   * agent down here; the next test re-spawns a clean session via ensureStarted.
+   */
+  private async promptAgent(prompt: string): Promise<string> {
+    this.turnText = '';
+    try {
+      await this.withTimeout(
+        this.conn!.prompt({ sessionId: this.sessionId!, prompt: [{ type: 'text', text: prompt }] }),
+        'agent turn',
+      );
+    } catch (e) {
+      this.kill();
+      throw e;
+    }
+    return this.turnText;
+  }
+
+  /**
+   * Judge a single test result.
+   */
+  private async judgeOne(result: TestResult): Promise<Judgment> {
+    const prompt = this.buildPrompt(result);
+    const testId = result.testCase.id;
+
+    const responseText = await this.promptAgent(prompt);
+
+    // Handle empty response
+    if (!responseText) {
+      process.stderr.write(`  [judge] WARNING: Empty response for ${testId}\n`);
+      return {
+        testId,
+        pass: false,
+        reason: 'Agent returned empty response',
+      };
+    }
+
+    process.stderr.write(`  [judge] Raw response for ${testId} (${responseText.length} chars): ${responseText.substring(0, 500)}\n`);
+
+    const json = this.extractJson(responseText);
+    if (!json) {
+      process.stderr.write(`  [judge] WARNING: No JSON object in response for ${testId}\n`);
+      return {
+        testId,
+        pass: false,
+        reason: `No JSON object in agent response: ${responseText.substring(0, 200)}`,
+      };
+    }
+
+    try {
+      const judgment = JSON.parse(json) as Judgment;
+
+      // Validate testId matches
+      if (judgment.testId !== testId) {
+        process.stderr.write(`  [judge] WARNING: Response testId "${judgment.testId}" doesn't match expected "${testId}"\n`);
+        judgment.testId = testId;
+      }
+
+      // Coerce string "true"/"false" to boolean (models often return strings)
+      if (typeof judgment.pass === 'string') {
+        judgment.pass = (judgment.pass as unknown as string).toLowerCase() === 'true';
+      }
+
+      // Validate required fields
+      if (typeof judgment.pass !== 'boolean') {
+        process.stderr.write(`  [judge] WARNING: Response missing "pass" field for ${testId}\n`);
+        return {
+          testId,
+          pass: false,
+          reason: `Agent response missing "pass" field: ${responseText.substring(0, 200)}`,
+        };
+      }
+
+      if (!judgment.reason) {
+        judgment.reason = judgment.pass ? 'Passed (no reason provided)' : 'Failed (no reason provided)';
+      }
+
+      return judgment;
+    } catch {
+      process.stderr.write(`  [judge] WARNING: Failed to parse JSON for ${testId}\n`);
+      process.stderr.write(`  [judge] Full response: ${responseText}\n`);
+      return {
+        testId,
+        pass: false,
+        reason: `Failed to parse agent response: ${responseText.substring(0, 200)}`,
+      };
+    }
+  }
+
+  /**
+   * Judge all test results, one at a time, over a single reused agent session.
+   * Tears the agent down when done.
+   */
+  async judgeResults(results: TestResult[]): Promise<Judgment[]> {
+    const allJudgments: Judgment[] = [];
+
+    try {
+      for (let i = 0; i < results.length; i++) {
+        const result = results[i];
+        process.stderr.write(
+          `  [judge] Judging ${i + 1}/${results.length}: ${result.testCase.id}...\n`
+        );
+
+        try {
+          // Idempotent when the session is alive; re-spawns a clean one if a
+          // prior test's timeout tore the agent down.
+          await this.ensureStarted();
+          const judgment = await this.judgeOne(result);
+          allJudgments.push(judgment);
+          process.stderr.write(`  [judge] ${result.testCase.id}: ${judgment.pass ? 'PASS' : 'FAIL'} — ${judgment.reason}\n`);
+        } catch (error) {
+          process.stderr.write(`  [judge] Failed to judge ${result.testCase.id}: ${error}\n`);
+          allJudgments.push({
+            testId: result.testCase.id,
+            pass: false,
+            reason: 'Agent judgment failed: ' + String(error),
+          });
+        }
+      }
+    } finally {
+      this.kill();
+    }
+
+    return allJudgments;
+  }
+}

--- a/cicd/tests/src/judge/index.ts
+++ b/cicd/tests/src/judge/index.ts
@@ -1,1 +1,2 @@
 export { SimpleJudge } from './simple-judge.js';
+export { AgentJudge } from './agent-judge.js';

--- a/cicd/tests/src/judge/index.ts
+++ b/cicd/tests/src/judge/index.ts
@@ -1,2 +1,3 @@
 export { SimpleJudge } from './simple-judge.js';
 export { AgentJudge } from './agent-judge.js';
+export { VerifierJudge } from './verifier-judge.js';

--- a/cicd/tests/src/judge/index.ts
+++ b/cicd/tests/src/judge/index.ts
@@ -1,3 +1,3 @@
 export { SimpleJudge } from './simple-judge.js';
 export { AgentJudge } from './agent-judge.js';
-export { VerifierJudge } from './verifier-judge.js';
+export { VerifierJudge, redactSecrets } from './verifier-judge.js';

--- a/cicd/tests/src/judge/verifier-judge.ts
+++ b/cicd/tests/src/judge/verifier-judge.ts
@@ -1,0 +1,560 @@
+/**
+ * Verifier Judge — independently verifies a model's MCP answer against LIVE ground truth.
+ *
+ * Unlike the sandboxed AgentJudge (which opens its session with `mcpServers: []` and
+ * rejects every tool call), the verifier spawns the same ACP agent WITH the test's MCP
+ * server attached and lets it call the tools itself to check the answer. Tool access is
+ * restricted to a per-case **exact allow-list** of tool names (read-only by intent),
+ * enforced two ways:
+ *
+ *   1. `requestPermission` backstop — the gate. For an MCP tool the permission request's
+ *      `toolCall.title` IS the `mcp__<server>__<tool>` id (the bundled claude-agent-acp
+ *      sets it there; `_meta.claudeCode.toolName` is NOT populated on permission requests).
+ *      We strip it to the bare name and ALLOW only if it's in the exact allow-list, else
+ *      REJECT. Built-in tools (Bash/Edit/Write/…) carry a prose title that is never in the
+ *      allow-list, so they are rejected too; an empty/unknown name also rejects (fail-closed).
+ *   2. Claude SDK `disallowedTools` (via newSession `_meta.claudeCode.options`) — defence in
+ *      depth: every server tool NOT in the allow-list is also denied by the agent's own SDK
+ *      before it reaches permission.
+ *
+ * Read-only is therefore by *exact allow-list*, never a name prefix (a prefix would let a
+ * `get_and_purge` through). This file does NOT touch `agent-judge.ts` — the generic judge
+ * stays sandboxed.
+ *
+ * NOTE: that the SDK actually hard-denies, and that the agent does call the tools, is proven
+ * live by the forced-write-refusal test in the validation task before this is trusted
+ * against a real backend.
+ */
+
+import { spawn, type ChildProcess, type StdioOptions } from 'node:child_process';
+import { Readable, Writable } from 'node:stream';
+import { createRequire } from 'node:module';
+import { dirname, resolve, join } from 'node:path';
+import { mkdirSync, writeFileSync, existsSync, symlinkSync, rmSync } from 'node:fs';
+import { homedir } from 'node:os';
+import {
+  ClientSideConnection,
+  ndJsonStream,
+  PROTOCOL_VERSION,
+  type Client,
+  type SessionNotification,
+  type RequestPermissionRequest,
+  type RequestPermissionResponse,
+} from '@agentclientprotocol/sdk';
+import type { McpServerConfig } from '../mcp/server-config.js';
+import { spawnHttpMcpServer } from '../mcp/http-server.js';
+import type { Judgment } from '../types.js';
+import { CONFIG } from '../config.js';
+
+/** VERIFY_DEBUG=1 → reveal every ACP event (sessionUpdate kinds, tool calls, permission/trust
+ *  requests) so nothing the adapter emits is swallowed silently. */
+const DEBUG = !!process.env.VERIFY_DEBUG;
+/** VERIFY_VERBOSE=1 → a middle level between the terse default and the DEBUG firehose: the
+ *  decisive per-step trace (config isolation, tool calls/results) without every event or the
+ *  warm-up turn. DEBUG implies VERBOSE. */
+const VERBOSE = DEBUG || !!process.env.VERIFY_VERBOSE;
+
+/** How much captured tool result to keep — large enough for the deterministic cross-check to see
+ *  every record (the report still shows only the first ~200 chars). */
+const EVIDENCE_CAP = 20000;
+
+/** Redact secret-like JSON field values (api_key, token, password, …) from a captured tool result
+ *  before it becomes evidence — so credentials a server returns never reach the report, the JSON
+ *  artifact, or the CI log. Matches the field NAME; leaves everything else intact. */
+export function redactSecrets(s: string): string {
+  // Field name contains a secret-ish word → replace its value (string-with-escapes, array, object,
+  // or bare number/bool/null) with [redacted]. Over-redacts (safe direction) rather than miss one.
+  return s.replace(
+    /("(?:[\w-]*(?:api[_-]?key|key|token|secret|password|passwd|credential|authorization|auth|bearer|session|cookie|signature|access|private)[\w-]*)"\s*:\s*)(?:"(?:\\.|[^"\\])*"|\[[^\]]*\]|\{[^}]*\}|[^,}\]\s][^,}\]]*)/gi,
+    '$1"[redacted]"',
+  );
+}
+
+/** Deterministic cross-check (STORY-011): the distinctive identifiers a model's answer claims —
+ *  multi-digit ids and identifier-like names (those containing a digit or hyphen) — must appear in
+ *  the captured live result. Returns the claims that DON'T, i.e. the likely inventions. Conservative
+ *  by design: it ignores plain prose words so it never fails a truthful answer over wording, which
+ *  means it catches invented/contradicted facts — not incompleteness (that stays the model's job). */
+export function unsupportedClaims(answer: string, evidence: string): string[] {
+  if (!evidence) return [];
+  const ev = evidence.toLowerCase();
+  const claims = new Set<string>();
+  for (const m of answer.matchAll(/\b\d{3,}\b/g)) claims.add(m[0]);          // numeric ids (3+ digits)
+  for (const m of answer.matchAll(/\b[a-zA-Z][\w.-]{3,}\b/g)) {              // identifier-like names
+    if (/[0-9-]/.test(m[0])) claims.add(m[0]);                              // …but only the distinctive ones
+  }
+  return [...claims].filter((c) => !ev.includes(c.toLowerCase()));
+}
+
+/** One model's answer to verify against the live server. */
+export interface VerifyTarget {
+  testId: string;
+  prompt: string;
+  answer: string;
+  /** The model-under-test's actual tool calls — so the verifier can grade tool selection and
+   *  query, not just the final answer. */
+  toolCalls: { name: string; arguments: Record<string, unknown> }[];
+}
+
+export interface VerifierConfig {
+  /** The stdio MCP server the host used (same command/args/env). */
+  server: McpServerConfig;
+  /** Rule prefix: the server's tools are `mcp__<serverName>__<tool>`. */
+  serverName: string;
+  /** Every tool the server exposes — used to derive the SDK deny-list (deny-by-default). */
+  toolNames: string[];
+  /** EXACT bare tool names the verifier may call (read-only by intent). Anything not here is
+   *  rejected. Empty ⇒ the verifier can call nothing (fail-closed). */
+  allowTools: string[];
+}
+
+export class VerifierJudge {
+  private agentCmd: string;
+  private isolatedCfgDir?: string;
+  private isolatedCwd?: string;
+  private child?: ChildProcess;
+  /** Tears down our spawned HTTP MCP server (fork-local: upstream's agent spawns a
+   *  stdio server itself, ours is HTTP so the verifier runs it and hands over the URL). */
+  private serverCleanup?: () => void;
+  private conn?: ClientSideConnection;
+  private sessionId?: string;
+  private turnText = '';
+  /** Raw live tool result(s) the agent received this turn — captured from `tool_call_update`
+   *  events, independent of what the agent says it saw. Surfaced as Judgment.evidence. */
+  private toolEvidence = '';
+  /** `toolCallId`s of allow-listed tool calls seen this turn — gates evidence capture so the report
+   *  only ever shows ground truth from a tool we permit (not a denied/built-in call). Correlated by
+   *  id because a `tool_call_update` carries the id but not the tool title. */
+  private allowedCallIds = new Set<string>();
+  /** Whether the gate denied any tool this turn — lets an empty evidence cell explain itself. */
+  private sawDeniedCall = false;
+
+  private readonly cfg: VerifierConfig;
+  private readonly allow: Set<string>;
+  /** `mcp__<server>__<tool>` rules for every tool NOT in the allow-list (SDK hard-deny). */
+  private readonly disallowedTools: string[];
+
+  constructor(cfg: VerifierConfig, agentCmd: string = CONFIG.judge.agent) {
+    this.cfg = cfg;
+    this.agentCmd = agentCmd;
+    this.allow = new Set(cfg.allowTools);
+    this.disallowedTools = cfg.toolNames
+      .filter((t) => !this.allow.has(t))
+      .map((t) => `mcp__${cfg.serverName}__${t}`);
+    process.once('exit', () => this.kill());
+  }
+
+  /** `mcp__server__tool` (or a bare name) → the bare tool name. */
+  private bareName(name: string): string {
+    const parts = name.split('__');
+    return parts.length >= 3 ? parts.slice(2).join('__') : name;
+  }
+
+  /** Why this turn's evidence is what it is — so an empty cell explains itself (STORY-010). */
+  private currentEvidenceStatus(): NonNullable<Judgment['evidenceStatus']> {
+    if (this.toolEvidence) return 'captured';
+    if (this.sawDeniedCall) return 'denied';
+    if (this.allowedCallIds.size === 0) return 'not-called';
+    return 'no-data';
+  }
+
+  /** Pull the actual result text out of a `tool_call_update.content` envelope
+   *  (`[{ type:'content', content:{ type:'text', text } }]`) — not the wrapper JSON. */
+  private toolResultText(content: unknown): string {
+    if (!Array.isArray(content)) return '';
+    const parts: string[] = [];
+    for (const block of content) {
+      const b = block as { content?: { type?: string; text?: string }; text?: string };
+      if (b?.content?.type === 'text' && typeof b.content.text === 'string') parts.push(b.content.text);
+      else if (typeof b?.text === 'string') parts.push(b.text);
+    }
+    return parts.join('\n');
+  }
+
+  private async withTimeout<T>(p: Promise<T>, label: string): Promise<T> {
+    let timer: NodeJS.Timeout;
+    const timeout = new Promise<never>((_, rej) => {
+      timer = setTimeout(() => rej(new Error(`${label} exceeded ${CONFIG.judge.timeout}ms`)), CONFIG.judge.timeout);
+    });
+    try {
+      return await Promise.race([p, timeout]);
+    } finally {
+      clearTimeout(timer!);
+    }
+  }
+
+  /** A PERMANENT CLAUDE_CONFIG_DIR holding only keyless creds + a pre-trusted, connector-free
+   *  `.claude.json`, plus a clean cwd with no project `.claude/`. This isolates the spawned client
+   *  from the operator's account connectors AND this repo's project config — the two confirmed
+   *  sources that flood the agent's toolset and bury the injected MCP server.
+   *
+   *  Built ONCE and then left completely alone (build-once-if-absent — every file is only written
+   *  when missing). The connectors-off guarantee lives in the per-spawn `ENABLE_CLAUDEAI_MCP_SERVERS=0`
+   *  env (see spawnAgent), NOT in this file staying pristine — the agent writes its own state back
+   *  here over time and that is fine. Fixed path keeps it outside the git tree. Credentials are a
+   *  symlink to the live `~/.claude/.credentials.json` (never an API key), so the token stays fresh
+   *  and is never duplicated on disk. Override the path with VERIFY_CONFIG_DIR. In CI no
+   *  `~/.claude/.credentials.json` exists, so the SDK reads the CLAUDE_CODE_OAUTH_TOKEN secret. */
+  private prepareIsolation(): { cfgDir: string; cwd: string } {
+    if (this.isolatedCfgDir && this.isolatedCwd) return { cfgDir: this.isolatedCfgDir, cwd: this.isolatedCwd };
+    const base = process.env.VERIFY_CONFIG_DIR || join(homedir(), '.cache', `${CONFIG.projectName}-verify`);
+    const cfgDir = join(base, 'config');
+    const work = join(base, 'work');
+    mkdirSync(cfgDir, { recursive: true });
+    mkdirSync(work, { recursive: true });
+    const cred = join(homedir(), '.claude', '.credentials.json');
+    const credDest = join(cfgDir, '.credentials.json');
+    // SYMLINK (not copy) to the live credentials, so the verifier always uses the current,
+    // auto-refreshing OAuth token and we never duplicate the secret on disk. A frozen copy
+    // expires within ~1h and 401s. Self-heal a prior run's stale copy/link. In CI the source is
+    // absent, so we skip it and the SDK reads CLAUDE_CODE_OAUTH_TOKEN from the environment.
+    if (existsSync(cred)) {
+      rmSync(credDest, { force: true });
+      symlinkSync(cred, credDest);
+    }
+    // Pre-trust the clean cwd so no trust-folder prompt blocks; zero connectors, zero project servers.
+    const cfgJson = join(cfgDir, '.claude.json');
+    if (!existsSync(cfgJson)) writeFileSync(cfgJson, JSON.stringify({
+      hasCompletedOnboarding: true,
+      mcpServers: {},
+      projects: { [work]: { hasTrustDialogAccepted: true, mcpServers: {}, enabledMcpjsonServers: [], allowedTools: [] } },
+    }));
+    const settings = join(cfgDir, 'settings.json');
+    if (!existsSync(settings)) writeFileSync(settings, '{}');
+    if (VERBOSE) process.stderr.write(`  [verify:isolate] CLAUDE_CONFIG_DIR=${cfgDir} cwd=${work}\n`);
+    this.isolatedCfgDir = cfgDir;
+    this.isolatedCwd = work;
+    return { cfgDir, cwd: work };
+  }
+
+  /** Spawn the configured ACP agent as a stdio child (same logic as AgentJudge), in an isolated
+   *  config dir + clean cwd, with claude.ai connectors and tool-search disabled. */
+  private spawnAgent(): ChildProcess {
+    const { cfgDir, cwd } = this.prepareIsolation();
+    const env = { ...process.env };
+    delete env.CLAUDECODE;
+    delete env.CLAUDE_CODE_ENTRYPOINT;
+    delete env.CLAUDE_CODE_SSE_PORT;
+    env.CLAUDE_CONFIG_DIR = cfgDir;
+    env.ENABLE_CLAUDEAI_MCP_SERVERS = '0';
+    env.ENABLE_TOOL_SEARCH = '0';
+    const stdio: StdioOptions = ['pipe', 'pipe', 'inherit'];
+
+    if (this.agentCmd) {
+      return spawn(this.agentCmd, { cwd, stdio, env, shell: true });
+    }
+    const require = createRequire(import.meta.url);
+    const pkg = require.resolve('@agentclientprotocol/claude-agent-acp/package.json');
+    const entry = resolve(dirname(pkg), 'dist/index.js');
+    return spawn(process.execPath, [entry], { cwd, stdio, env });
+  }
+
+  /** The read-only gate: allow only exact-allow-listed tools, else reject (fail-closed). */
+  private decide(params: RequestPermissionRequest): RequestPermissionResponse {
+    const tc = params.toolCall as { _meta?: { claudeCode?: { toolName?: string } }; title?: string };
+    // For MCP tools `title` is the `mcp__server__tool` id; `_meta.claudeCode.toolName` is not
+    // set on permission requests, so prefer title and treat both as best-effort.
+    const raw = tc?.title ?? tc?._meta?.claudeCode?.toolName ?? '';
+    const allowed = this.allow.has(this.bareName(String(raw)));
+    const want = allowed ? 'allow' : 'reject';
+    const opt =
+      params.options.find((o) => o.kind?.startsWith(want)) ??
+      params.options.find((o) => o.kind?.startsWith('reject'));
+    // The security boundary — always log every decision (allow and reject), not just DEBUG.
+    process.stderr.write(`  [verify] ${allowed ? 'ALLOWED' : 'DENIED'} tool permission: "${String(raw).slice(0, 80)}"\n`);
+    if (!allowed) this.sawDeniedCall = true;
+    return opt
+      ? { outcome: { outcome: 'selected', optionId: opt.optionId } }
+      : { outcome: { outcome: 'cancelled' } };
+  }
+
+  private async ensureStarted(): Promise<void> {
+    if (this.sessionId) return;
+
+    const child = this.spawnAgent();
+    this.child = child;
+
+    const stream = ndJsonStream(
+      Writable.toWeb(child.stdin!) as WritableStream<Uint8Array>,
+      Readable.toWeb(child.stdout!) as ReadableStream<Uint8Array>,
+    );
+
+    const client: Client = {
+      sessionUpdate: async (params: SessionNotification): Promise<void> => {
+        const u = params.update;
+        const x = u as Record<string, unknown>;
+        // VERBOSE shows the decisive tool-call steps; DEBUG adds every other event (the firehose).
+        const isToolEvent = u.sessionUpdate === 'tool_call' || u.sessionUpdate === 'tool_call_update';
+        if (DEBUG || (VERBOSE && isToolEvent)) {
+          const extra = isToolEvent
+            ? ` id=${JSON.stringify(x.toolCallId)} title=${JSON.stringify(x.title)} status=${String(x.status)}`
+            : '';
+          process.stderr.write(`  [verify:event] ${u.sessionUpdate}${extra}\n`);
+        }
+        if (u.sessionUpdate === 'agent_message_chunk' && u.content.type === 'text') {
+          this.turnText += u.content.text;
+        }
+        // Remember which calls are allow-listed (the `tool_call` carries the title); a later
+        // `tool_call_update` for the same id is then known to be ground truth we permit.
+        if (u.sessionUpdate === 'tool_call' && typeof x.toolCallId === 'string' &&
+            this.allow.has(this.bareName(String(x.title ?? '')))) {
+          this.allowedCallIds.add(x.toolCallId);
+        }
+        // Bucket #3: capture the live tool result the agent received, independent of its prose —
+        // hard ground-truth evidence for the report. Only a COMPLETED call we allow-listed counts
+        // (a denied/built-in call is not ground truth); extract the inner text from the
+        // ToolCallContent envelope; total-cap so a chatty server can't blow the field.
+        if (u.sessionUpdate === 'tool_call_update' && typeof x.toolCallId === 'string' &&
+            this.allowedCallIds.has(x.toolCallId) && String(x.status) === 'completed') {
+          const text = this.toolResultText(x.content);
+          if (text) this.toolEvidence = (this.toolEvidence + redactSecrets(text)).slice(0, EVIDENCE_CAP);
+        }
+      },
+      requestPermission: async (params: RequestPermissionRequest): Promise<RequestPermissionResponse> => {
+        if (DEBUG) process.stderr.write(`  [verify:event] requestPermission ${JSON.stringify(params).slice(0, 500)}\n`);
+        return this.decide(params);
+      },
+      readTextFile: async () => { throw new Error('filesystem access disabled for the verifier'); },
+      writeTextFile: async () => { throw new Error('filesystem access disabled for the verifier'); },
+    };
+
+    this.conn = new ClientSideConnection(() => client, stream);
+    try {
+      await this.withTimeout(this.conn.initialize({
+        protocolVersion: PROTOCOL_VERSION,
+        clientCapabilities: { fs: { readTextFile: false, writeTextFile: false }, terminal: false },
+        clientInfo: { name: `${CONFIG.projectName}-verifier`, version: '1.0.0' },
+      }), 'verifier initialize');
+
+      // Fork-local: our server speaks HTTP, so the verifier spawns it (PORT=0) and
+      // attaches it to the agent as an { type:'http' } MCP server pointing at the
+      // printed URL — upstream attaches a stdio server the agent spawns itself. The
+      // verifier owns this server's lifecycle (torn down in kill()).
+      const running = await spawnHttpMcpServer(this.cfg.server);
+      this.serverCleanup = running.cleanup;
+      const session = await this.withTimeout(
+        this.conn.newSession({
+          cwd: this.prepareIsolation().cwd,
+          // Populate the server (the generic judge keeps this empty); hard-deny every
+          // non-allow-listed server tool via the agent's own SDK config (defence in depth).
+          mcpServers: [{ type: 'http', name: this.cfg.serverName, url: `${running.baseUrl}/mcp`, headers: [] }],
+          // settingSources:[] loads NO filesystem settings (no project/local `.claude/`); the
+          // injected mcpServers above survive regardless.
+          _meta: { claudeCode: { options: { settingSources: [], disallowedTools: this.disallowedTools } } },
+        }),
+        'verifier session/new',
+      );
+      this.sessionId = session.sessionId;
+      if (DEBUG) {
+        // Diagnostic warm-up: ask the agent to list its actual toolset, so we can see whether the
+        // injected mcp__<server>__* tools surfaced and whether the flood is gone.
+        this.turnText = '';
+        await this.withTimeout(
+          this.conn.prompt({ sessionId: this.sessionId, prompt: [{ type: 'text', text: 'List the exact names of every tool you can call right now, one per line. Nothing else.' }] }),
+          'verifier warm-up',
+        ).catch((e) => process.stderr.write(`  [verify:warmup] error: ${e}\n`));
+        process.stderr.write(`  [verify:warmup] tools:\n${this.turnText}\n`);
+      }
+    } catch (e) {
+      this.kill();
+      throw e;
+    }
+  }
+
+  private kill(): void {
+    try { this.child?.kill('SIGKILL'); } catch { /* already gone */ }
+    try { this.serverCleanup?.(); } catch { /* already gone */ }
+    this.serverCleanup = undefined;
+    this.child = undefined;
+    this.conn = undefined;
+    this.sessionId = undefined;
+  }
+
+  /** Probe agent reachability — without the MCP server, so it tests the agent, not the backend. */
+  async isAvailable(): Promise<boolean> {
+    let child: ChildProcess | undefined;
+    try {
+      child = this.spawnAgent();
+      const stream = ndJsonStream(
+        Writable.toWeb(child.stdin!) as WritableStream<Uint8Array>,
+        Readable.toWeb(child.stdout!) as ReadableStream<Uint8Array>,
+      );
+      let text = '';
+      const client: Client = {
+        sessionUpdate: async (p: SessionNotification) => {
+          const u = p.update;
+          if (u.sessionUpdate === 'agent_message_chunk' && u.content.type === 'text') text += u.content.text;
+        },
+        requestPermission: async () => ({ outcome: { outcome: 'cancelled' } } as RequestPermissionResponse),
+        readTextFile: async () => { throw new Error('disabled'); },
+        writeTextFile: async () => { throw new Error('disabled'); },
+      };
+      const conn = new ClientSideConnection(() => client, stream);
+      await this.withTimeout(conn.initialize({
+        protocolVersion: PROTOCOL_VERSION,
+        clientCapabilities: { fs: { readTextFile: false, writeTextFile: false }, terminal: false },
+        clientInfo: { name: `${CONFIG.projectName}-verifier`, version: '1.0.0' },
+      }), 'verifier probe initialize');
+      const s = await this.withTimeout(conn.newSession({ cwd: this.prepareIsolation().cwd, mcpServers: [] }), 'verifier probe session');
+      await this.withTimeout(conn.prompt({ sessionId: s.sessionId, prompt: [{ type: 'text', text: 'Reply with exactly: ok' }] }), 'verifier probe turn');
+      if (!text.trim()) throw new Error('verifier agent produced no output on probe turn');
+      return true;
+    } catch (error) {
+      process.stderr.write(`  [verify] Agent not reachable: ${error}\n`);
+      return false;
+    } finally {
+      try { child?.kill('SIGKILL'); } catch { /* gone */ }
+    }
+  }
+
+  private buildPrompt(t: VerifyTarget): string {
+    return JSON.stringify({
+      role: `You independently verify another model's tool-use attempt for ${CONFIG.projectName}, by calling the ${this.cfg.serverName} MCP tools yourself.`,
+      task: 'Retrieve the ground truth by calling the allowed tools yourself, then grade the model\'s ATTEMPT against the three-stage rubric below. Do NOT trust the model — check it. If you cannot call any tool, set pass=false and say so.',
+      allowed_tools: [...this.allow],
+      // The question the model was asked.
+      question_asked_to_model: t.prompt,
+      // The model's attempt — what it DID and what it CLAIMED. This is the thing under test; the
+      // ground truth is what YOU retrieve yourself, kept separate so you judge against fact, not the claim.
+      model_attempt: {
+        tool_calls: t.toolCalls,
+        answer: t.answer,
+      },
+      grade_each_stage: {
+        tool_selection: 'Did the model call the right tool(s) for the question — the necessary ones, no wrong or wasteful extras?',
+        query: 'Did it call them with correct arguments (right values/filters, no invented parameters)?',
+        interpretation: 'Is the final answer both correct/complete AND grounded — every fact it states is actually present in the data you retrieved, nothing invented?',
+      },
+      rules: [
+        'Call the allowed tools to retrieve the ground truth BEFORE deciding.',
+        'pass=true only if all three stages hold against the real data.',
+        'If the answer states facts the tools contradict or do not contain, pass=false.',
+      ],
+      respond: {
+        format: 'Respond with a single JSON object and nothing else',
+        fields: {
+          testId: t.testId,
+          tool_selection_ok: 'true/false — right tool(s) for the question',
+          query_ok: 'true/false — correct arguments',
+          interpretation_ok: 'true/false — answer correct and grounded in the retrieved data',
+          pass: 'true only if all three stages are true',
+          reason: 'Brief explanation: name the tool(s) you called and, if pass=false, which stage failed',
+        },
+      },
+    }, null, 2);
+  }
+
+  private extractJson(text: string): string | null {
+    const start = text.indexOf('{');
+    if (start === -1) return null;
+    // Scan from the first '{' tracking string state to find the matching close. The
+    // ACP agent sometimes ends a turn one token short of its trailing '}' (or the final
+    // streamed chunk isn't captured), so a complete-but-unclosed object would otherwise
+    // be discarded — flipping a genuine verdict to a "No JSON" FAIL. Tolerate that by
+    // appending the missing closers, but only when the truncation is OUTSIDE a string
+    // (a value cut mid-string is genuinely unrecoverable → null).
+    let depth = 0;
+    let inStr = false;
+    let esc = false;
+    for (let i = start; i < text.length; i++) {
+      const c = text[i];
+      if (inStr) {
+        if (esc) esc = false;
+        else if (c === '\\') esc = true;
+        else if (c === '"') inStr = false;
+      } else if (c === '"') inStr = true;
+      else if (c === '{') depth++;
+      else if (c === '}' && --depth === 0) return text.substring(start, i + 1);
+    }
+    return depth > 0 && !inStr ? text.substring(start) + '}'.repeat(depth) : null;
+  }
+
+  private async promptAgent(prompt: string): Promise<string> {
+    this.turnText = '';
+    this.toolEvidence = '';
+    this.allowedCallIds.clear();
+    this.sawDeniedCall = false;
+    try {
+      await this.withTimeout(
+        this.conn!.prompt({ sessionId: this.sessionId!, prompt: [{ type: 'text', text: prompt }] }),
+        'verifier turn',
+      );
+    } catch (e) {
+      this.kill();
+      throw e;
+    }
+    return this.turnText;
+  }
+
+  private async verifyOne(t: VerifyTarget): Promise<Judgment> {
+    const responseText = await this.promptAgent(this.buildPrompt(t));
+    // Parity with AgentJudge — log the raw response at the normal level so a surprising verdict
+    // (or a parse failure) is diagnosable without VERIFY_DEBUG.
+    process.stderr.write(`  [verify] Raw response for ${t.testId} (${responseText.length} chars): ${responseText.substring(0, 500)}\n`);
+    const evidenceStatus = this.currentEvidenceStatus();
+    if (!responseText) {
+      return { testId: t.testId, pass: false, reason: 'Verifier returned empty response', evidenceStatus };
+    }
+    const json = this.extractJson(responseText);
+    if (!json) {
+      return { testId: t.testId, pass: false, reason: `No JSON in verifier response: ${responseText.substring(0, 200)}`, evidenceStatus };
+    }
+    try {
+      const judgment = JSON.parse(json) as Judgment;
+      judgment.testId = t.testId;
+      // Capture the verifier's per-stage rubric flags (it grades these; surface them as judge info).
+      const raw = judgment as unknown as Record<string, unknown>;
+      const toBool = (v: unknown) => v === true || String(v).toLowerCase() === 'true';
+      if ('tool_selection_ok' in raw || 'query_ok' in raw || 'interpretation_ok' in raw) {
+        judgment.stages = { tool: toBool(raw.tool_selection_ok), query: toBool(raw.query_ok), content: toBool(raw.interpretation_ok) };
+      }
+      if (typeof judgment.pass === 'string') {
+        judgment.pass = (judgment.pass as unknown as string).toLowerCase() === 'true';
+      }
+      if (typeof judgment.pass !== 'boolean') {
+        return { testId: t.testId, pass: false, reason: `Verifier response missing "pass": ${responseText.substring(0, 200)}`, evidenceStatus };
+      }
+      if (!judgment.reason) judgment.reason = judgment.pass ? 'Verified (no reason provided)' : 'Failed (no reason provided)';
+      // Deterministic cross-check: the verifying model's PASS only stands if the answer's claimed
+      // facts actually appear in the live result we captured. The LLM is a second opinion, never the
+      // sole judge — it cannot wave through an answer the ground truth doesn't support.
+      if (this.toolEvidence) {
+        const unsupported = unsupportedClaims(t.answer, this.toolEvidence);
+        judgment.crossCheckUnsupported = unsupported;        // record the result for the report (judge info)
+        if (judgment.pass && unsupported.length) {
+          judgment.pass = false;
+          judgment.reason = `Deterministic cross-check FAILED: answer claims not present in live data: ${unsupported.join(', ')}. (verifier had said: ${judgment.reason})`;
+          process.stderr.write(`  [verify] cross-check overrode PASS→FAIL — unsupported: ${unsupported.join(', ')}\n`);
+        }
+      }
+      // Prefer the raw tool result we captured ourselves over the agent's self-reported evidence.
+      if (this.toolEvidence) judgment.evidence = this.toolEvidence;
+      judgment.evidenceStatus = evidenceStatus;
+      return judgment;
+    } catch {
+      return { testId: t.testId, pass: false, reason: `Failed to parse verifier response: ${responseText.substring(0, 200)}`, evidenceStatus };
+    }
+  }
+
+  /** Verify each target in its OWN fresh session (no cross-target context bleed). */
+  async verify(targets: VerifyTarget[]): Promise<Judgment[]> {
+    const out: Judgment[] = [];
+    for (let i = 0; i < targets.length; i++) {
+      const t = targets[i];
+      process.stderr.write(`  [verify] Verifying ${i + 1}/${targets.length}: ${t.testId} (allow ${this.allow.size} tools, deny ${this.disallowedTools.length})...\n`);
+      try {
+        await this.ensureStarted();
+        const judgment = await this.verifyOne(t);
+        out.push(judgment);
+        process.stderr.write(`  [verify] ${t.testId}: ${judgment.pass ? 'PASS' : 'FAIL'} — ${judgment.reason}\n`);
+      } catch (error) {
+        process.stderr.write(`  [verify] Failed to verify ${t.testId}: ${error}\n`);
+        out.push({ testId: t.testId, pass: false, reason: 'Verifier failed: ' + String(error), evidenceStatus: 'verifier-unavailable' });
+      } finally {
+        // Fresh session per target — tear down so the next target re-spawns clean.
+        this.kill();
+      }
+    }
+    return out;
+  }
+}

--- a/cicd/tests/src/loader.ts
+++ b/cicd/tests/src/loader.ts
@@ -186,6 +186,7 @@ export class TestLoader {
       dependencies: Array.isArray(raw.dependencies) ? raw.dependencies : [],
       steps,
       criteria: typeof raw.criteria === 'string' ? raw.criteria : '',
+      judge: raw.judge === 'agent' ? 'agent' : undefined,
     };
   }
 }

--- a/cicd/tests/src/loader.ts
+++ b/cicd/tests/src/loader.ts
@@ -10,6 +10,16 @@ import path from 'path';
 import { TestCase, TestStep } from './types.js';
 import { SUITES, CONFIG } from './config.js';
 
+/** Normalize a testcase's `judge` field. 'agent' opts into the agent judge; 'simple'
+ *  or absent means deterministic-only. An unrecognized value is a likely typo that
+ *  would silently downgrade verification — warn rather than swallow it. */
+function normalizeJudge(raw: unknown): 'agent' | undefined {
+  if (raw === undefined || raw === 'simple') return undefined;
+  if (raw === 'agent') return 'agent';
+  console.error(`[loader] Ignoring unrecognized judge value ${JSON.stringify(raw)} — expected 'simple' or 'agent'; running deterministic-only`);
+  return undefined;
+}
+
 export class TestLoader {
   private testcasesDir: string;
 
@@ -186,7 +196,7 @@ export class TestLoader {
       dependencies: Array.isArray(raw.dependencies) ? raw.dependencies : [],
       steps,
       criteria: typeof raw.criteria === 'string' ? raw.criteria : '',
-      judge: raw.judge === 'agent' ? 'agent' : undefined,
+      judge: normalizeJudge(raw.judge),
     };
   }
 }

--- a/cicd/tests/src/mcp/backends/index.ts
+++ b/cicd/tests/src/mcp/backends/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Backend factory — resolves a ChatBackend by name (config-selected).
+ * Adding a runtime = a new backends/<vendor>.ts + one case here. host.ts never changes.
+ */
+import type { ChatBackend } from '../chat-backend.js';
+import { OllamaBackend } from './ollama.js';
+
+export function makeBackend(name: string, opts: { host: string }): ChatBackend {
+  switch (name) {
+    case 'ollama':
+      return new OllamaBackend(opts.host);
+    default:
+      throw new Error(`unknown chat backend "${name}" (built-in: ollama)`);
+  }
+}

--- a/cicd/tests/src/mcp/backends/ollama.ts
+++ b/cicd/tests/src/mcp/backends/ollama.ts
@@ -1,0 +1,134 @@
+/**
+ * Ollama reference backend — the ONLY vendor-coupled module in the MCP path.
+ *
+ * Implements ChatBackend over Ollama's /api/chat. Everything Ollama-specific lives
+ * here: the HTTP endpoint, the response shape (message.tool_calls, prompt_eval_count,
+ * eval_duration, …), the "does not support tools" signal, the JSON-string arg quirk,
+ * and keep_alive:0 eviction. host.ts imports none of this — only the ChatBackend type.
+ */
+import http from 'node:http';
+import https from 'node:https';
+import type {
+  ChatBackend,
+  ChatRequest,
+  ChatResponse,
+  ChatToolCall,
+} from '../chat-backend.js';
+
+/** POST /api/chat over node:http so the per-call timeout is honored end-to-end.
+ *  fetch() (undici) imposes its own ~300s headers/body timeout that AbortSignal
+ *  can't lift — it silently kills slow generations at 5 min. node:http has no
+ *  such cap, so timeoutMs (via AbortSignal) is the only deadline. */
+function post(host: string, path: string, body: string, timeoutMs: number): Promise<any> {
+  const url = new URL(`${host}${path}`);
+  const transport = url.protocol === 'https:' ? https : http;
+  return new Promise((resolve, reject) => {
+    const req = transport.request(
+      url,
+      { method: 'POST', headers: { 'content-type': 'application/json', 'content-length': Buffer.byteLength(body) } },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (c: Buffer) => chunks.push(c));
+        // The response is a separate emitter from req — a reset mid-body (a real risk on a
+        // slow/OOMing backend) errors here, not on req. Without this it's an uncaught throw.
+        res.on('error', reject);
+        res.on('end', () => {
+          try {
+            resolve(JSON.parse(Buffer.concat(chunks).toString('utf8')));
+          } catch {
+            reject(new Error('ollama: invalid JSON response'));
+          }
+        });
+      },
+    );
+    const signal = AbortSignal.timeout(timeoutMs);
+    const onAbort = () => req.destroy(new Error(`ollama request timed out after ${timeoutMs}ms`));
+    signal.addEventListener('abort', onAbort, { once: true });
+    req.on('close', () => signal.removeEventListener('abort', onAbort));
+    req.on('error', reject);
+    req.end(body);
+  });
+}
+
+/** Ollama is documented to return tool-call arguments as an object, but some
+ *  model templates emit a JSON string — normalize both to an object. */
+function asArgs(raw: unknown): Record<string, unknown> {
+  if (typeof raw === 'string') {
+    try {
+      return JSON.parse(raw);
+    } catch {
+      return {};
+    }
+  }
+  return (raw ?? {}) as Record<string, unknown>;
+}
+
+const ZERO_METRICS = { inTokens: 0, outTokens: 0, totalDurationNs: 0, evalDurationNs: 0 };
+
+export class OllamaBackend implements ChatBackend {
+  readonly name = 'ollama';
+  constructor(private host: string) {}
+
+  async chat(req: ChatRequest): Promise<ChatResponse> {
+    const body = JSON.stringify({
+      model: req.model,
+      messages: req.messages,
+      tools: req.tools,
+      stream: false,
+      options: { temperature: 0, seed: 42, num_ctx: req.numCtx },
+    });
+
+    let raw: any;
+    try {
+      raw = await post(this.host, '/api/chat', body, req.timeoutMs);
+    } catch (e) {
+      return { content: '', toolCalls: [], error: e instanceof Error ? e.message : String(e), metrics: { ...ZERO_METRICS } };
+    }
+
+    if (!raw || typeof raw !== 'object') {
+      return { content: '', toolCalls: [], error: 'ollama /api/chat: no/invalid response', metrics: { ...ZERO_METRICS } };
+    }
+    // Ollama returns {error: "...does not support tools"} when the model's template
+    // can't do tool calling — a clean capability verdict, not a crash.
+    if (raw.error) {
+      const toolsUnsupported = /does not support tools/i.test(String(raw.error));
+      return { content: '', toolCalls: [], toolsUnsupported, error: String(raw.error), metrics: { ...ZERO_METRICS } };
+    }
+
+    const msg = raw.message ?? {};
+    const wireCalls = Array.isArray(msg.tool_calls) ? msg.tool_calls : [];
+    const toolCalls: ChatToolCall[] = wireCalls.map((tc: any) => ({
+      name: tc.function?.name ?? '',
+      arguments: asArgs(tc.function?.arguments),
+    }));
+
+    return {
+      content: msg.content ?? '',
+      toolCalls,
+      assistantMessage: { role: 'assistant', content: msg.content ?? '', tool_calls: wireCalls },
+      metrics: {
+        inTokens: raw.prompt_eval_count ?? 0,
+        outTokens: raw.eval_count ?? 0,
+        totalDurationNs: raw.total_duration ?? 0,
+        evalDurationNs: raw.eval_duration ?? 0,
+      },
+    };
+  }
+
+  /** Evict a model (keep_alive: 0). Best-effort: a benchmark loops over models
+   *  sequentially, so each must be released before the next loads — otherwise the
+   *  previous one stays resident and two models contend for the GPU. A failed
+   *  unload must never fail the test. */
+  async unload(model: string): Promise<void> {
+    try {
+      await fetch(`${this.host}/api/generate`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ model, keep_alive: 0 }),
+        signal: AbortSignal.timeout(30000),
+      });
+    } catch {
+      /* best-effort */
+    }
+  }
+}

--- a/cicd/tests/src/mcp/chat-backend.ts
+++ b/cicd/tests/src/mcp/chat-backend.ts
@@ -1,0 +1,84 @@
+/**
+ * ChatBackend — the vendor-neutral seam for the model-under-test.
+ *
+ * The MCP host loop (host.ts) drives a model through a real tool server but knows
+ * NOTHING about which model runtime it's talking to: it only calls `ChatBackend.chat()`.
+ * Every runtime-specific detail (HTTP endpoint, wire shapes, the "can't do tools"
+ * signal, arg coercion, token-eviction) lives in a backend under `backends/`.
+ *
+ * To target another runtime: implement `ChatBackend` in `backends/<vendor>.ts` and
+ * add one `case` to `backends/index.ts`. Do NOT edit host.ts. The reference backend
+ * is `backends/ollama.ts`.
+ *
+ * Message shape note: messages use the OpenAI/Ollama-style convention (a `tool_calls`
+ * array of `{ function: { name, arguments } }` on an assistant turn; a tool result as
+ * `{ role:'tool', content, tool_name }`). The host echoes these verbatim; a backend
+ * whose runtime differs translates them internally inside `chat()`.
+ */
+
+/** A tool offered to the model, in the OpenAI/Ollama "function" shape. */
+export interface ChatTool {
+  type: 'function';
+  function: { name: string; description: string; parameters: unknown };
+}
+
+/** A tool call as it appears on an assistant message (wire shape, echoed verbatim). */
+export interface ChatToolCallWire {
+  function: { name: string; arguments: unknown };
+}
+
+/** One conversation turn. `tool_calls` rides an assistant turn; `tool_name` a tool result. */
+export interface ChatMessage {
+  role: 'user' | 'assistant' | 'tool';
+  content: string;
+  tool_calls?: ChatToolCallWire[];
+  tool_name?: string;
+}
+
+/** One round's request: the conversation so far + the tool menu + decode options. */
+export interface ChatRequest {
+  model: string;
+  messages: ChatMessage[];
+  tools: ChatTool[];
+  numCtx: number;
+  timeoutMs: number;
+}
+
+/** A tool call normalized for the host: bare name + an args object (never a JSON string). */
+export interface ChatToolCall {
+  name: string;
+  arguments: Record<string, unknown>;
+}
+
+/** Per-round generation perf, named neutrally. Durations stay in nanoseconds so the
+ *  host's existing rounding/throughput math is unchanged. */
+export interface ChatMetrics {
+  inTokens: number;
+  outTokens: number;
+  totalDurationNs: number;
+  evalDurationNs: number;
+}
+
+/** One round's reply, normalized away from any vendor's wire shape. */
+export interface ChatResponse {
+  content: string;
+  /** Normalized tool calls for the host to execute + record. Empty ⇒ final answer. */
+  toolCalls: ChatToolCall[];
+  /** The assistant turn to echo back into the history before tool results (when toolCalls
+   *  is non-empty). The host pushes it verbatim; backends shape it for their runtime. */
+  assistantMessage?: ChatMessage;
+  /** The runtime signalled the model/template cannot do tools → a clean capability verdict. */
+  toolsUnsupported?: boolean;
+  /** A backend-level error string. The host returns a trajectory carrying it, never throws. */
+  error?: string;
+  metrics: ChatMetrics;
+}
+
+/** THE SEAM. The host loop calls only this; nothing else knows the runtime. */
+export interface ChatBackend {
+  /** Human label for reports (e.g. 'ollama'). */
+  readonly name: string;
+  chat(req: ChatRequest): Promise<ChatResponse>;
+  /** Optional: release model resources between models (e.g. Ollama keep_alive:0). */
+  unload?(model: string): Promise<void>;
+}

--- a/cicd/tests/src/mcp/host.ts
+++ b/cicd/tests/src/mcp/host.ts
@@ -139,9 +139,11 @@ export async function runMcpHost(opts: McpHostOptions): Promise<McpTrajectory> {
       const serverName = s.name ?? 'mcp';
       const running = await spawnHttpMcpServer(s);
       const client = new Client({ name: 'mcp-host', version: '1.0.0' });
+      // Register for teardown BEFORE connect: if the handshake throws (server printed
+      // its URL then died, or a bad URL), the `finally` still stops the spawned process.
+      conns.push({ name: serverName, client, cleanup: running.cleanup });
       const transport = new StreamableHTTPClientTransport(new URL(`${running.baseUrl}/mcp`));
       await client.connect(transport);
-      conns.push({ name: serverName, client, cleanup: running.cleanup });
 
       const listed = await client.listTools();
       for (const t of listed.tools) {

--- a/cicd/tests/src/mcp/host.ts
+++ b/cicd/tests/src/mcp/host.ts
@@ -1,0 +1,230 @@
+/**
+ * Vendor-neutral MCP host: let a model-under-test drive a real MCP server's tools
+ * end-to-end (no mock).
+ *
+ * Fork note: upstream connects to *stdio* MCP servers. Our server speaks HTTP, so we
+ * spawn each server on an OS-assigned port (mcp/http-server.ts) and connect over
+ * StreamableHTTP. The rest — merge every server's tools into one menu, run the tool
+ * loop (chat → callTool against the real server → feed results back → chat) — is
+ * transport-agnostic and unchanged.
+ *
+ * What's tested is the MODEL: given a real menu, does it pick the right tool with
+ * valid args and use the result? The model runtime is reached ONLY through the
+ * injected `ChatBackend` (chat-backend.ts) — this file knows nothing vendor-specific.
+ * A model whose template lacks tool support is reported `supported:false` (a clean
+ * verdict, not a crash). The server choice + credentials are config, not code.
+ */
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import type { ChatBackend, ChatTool, ChatMessage } from './chat-backend.js';
+import type { McpServerConfig } from './server-config.js';
+import { spawnHttpMcpServer } from './http-server.js';
+
+export interface McpHostOptions {
+  /** The model runtime under test (the only thing that knows a vendor). */
+  backend: ChatBackend;
+  model: string;
+  prompt: string;
+  /** One or more MCP servers whose tools are merged into a single menu the model
+   *  picks from. Two+ servers make "tool selection" a real choice; a tool call
+   *  routes back to its owning server. */
+  servers: McpServerConfig[];
+  numCtx?: number;
+  /** Max chat↔tool rounds before giving up (guards against a tool loop). */
+  maxIters?: number;
+  /** Per-call response timeout (ms). Default 600000 (10 min) — heavy models on slow
+   *  hardware need more than fetch's implicit ~5-min default. */
+  timeoutMs?: number;
+}
+
+export interface ToolCallRecord {
+  name: string;
+  arguments: Record<string, unknown>;
+}
+
+export interface ToolResultRecord {
+  name: string;
+  content: string;
+  isError: boolean;
+}
+
+export interface McpTrajectory {
+  model: string;
+  /** false ⇢ the model's template can't do tools (the backend signalled it). */
+  supported: boolean;
+  /** Tool names the MCP server(s) exposed (merged across servers). */
+  toolNames: string[];
+  /** Required arg names per tool, from each tool's inputSchema.required. */
+  toolRequired: Record<string, string[]>;
+  /** Which server each tool came from (toolName → server name) — lets a caller
+   *  pick out one server's tools (e.g. the verifier's read-only server). */
+  toolServer: Record<string, string>;
+  toolCalls: ToolCallRecord[];
+  toolResults: ToolResultRecord[];
+  finalAnswer: string;
+  /** Generation perf, summed across the chat↔tool rounds. */
+  inTokens: number;
+  /** Largest single round's prompt tokens — the value to compare against num_ctx
+   *  (summed inTokens spans rounds and can't be compared to the window). */
+  maxPromptTokens: number;
+  outTokens: number;
+  totalDurationS: number;
+  evalTps: number;
+  error?: string;
+}
+
+/** MCP tool {name, description?, inputSchema} → ChatTool entry (OpenAI "function" shape). */
+export function toChatTools(tools: Array<{ name: string; description?: string; inputSchema?: unknown }>): ChatTool[] {
+  return tools.map((t) => ({
+    type: 'function',
+    function: {
+      name: t.name,
+      description: t.description ?? '',
+      parameters: t.inputSchema ?? { type: 'object', properties: {} },
+    },
+  }));
+}
+
+const round2 = (n: number): number => Math.round(n * 100) / 100;
+const tps = (tokens: number, durNs: number): number => (durNs > 0 ? round2(tokens / (durNs / 1e9)) : 0);
+
+/** Join an MCP CallToolResult's content blocks into a single text payload. */
+function resultText(content: unknown): string {
+  if (!Array.isArray(content)) return '';
+  return content
+    .map((c: any) => (c?.type === 'text' && typeof c.text === 'string' ? c.text : JSON.stringify(c)))
+    .join('\n');
+}
+
+export async function runMcpHost(opts: McpHostOptions): Promise<McpTrajectory> {
+  const numCtx = opts.numCtx ?? 4096;
+  const maxIters = opts.maxIters ?? 5;
+  // Clamp to a sane (1s … 1h) window: rejects NaN/0/negative (→ default) and caps huge values that
+  // would overflow the 32-bit timer and abort instantly. Bad --timeout can't silently fail every model.
+  const reqMs = Number(opts.timeoutMs);
+  const timeoutMs = Number.isFinite(reqMs) && reqMs > 0 ? Math.min(reqMs, 3_600_000) : 600000;
+  let totalDurNs = 0;
+  let evalDurNs = 0;
+
+  // One connection per server; each is spawned over HTTP (PORT=0) and its tools are
+  // merged into a single menu. A tool call routes back to the server that owns the
+  // name (toolToClient); each server's process is torn down in `finally`.
+  const conns: Array<{ name: string; client: Client; cleanup: () => void }> = [];
+  const toolToClient = new Map<string, Client>();
+
+  const traj: McpTrajectory = {
+    model: opts.model,
+    supported: true,
+    toolNames: [],
+    toolRequired: {},
+    toolServer: {},
+    toolCalls: [],
+    toolResults: [],
+    finalAnswer: '',
+    inTokens: 0,
+    maxPromptTokens: 0,
+    outTokens: 0,
+    totalDurationS: 0,
+    evalTps: 0,
+  };
+
+  const messages: ChatMessage[] = [{ role: 'user', content: opts.prompt }];
+
+  try {
+    // Spawn every server, connect over HTTP, list its tools, and merge into one menu.
+    // A tool name exposed by two servers can't be routed unambiguously — fail fast
+    // rather than silently send the call to the wrong one.
+    const merged: Array<{ name: string; description?: string; inputSchema?: unknown }> = [];
+    for (const s of opts.servers) {
+      const serverName = s.name ?? 'mcp';
+      const running = await spawnHttpMcpServer(s);
+      const client = new Client({ name: 'mcp-host', version: '1.0.0' });
+      const transport = new StreamableHTTPClientTransport(new URL(`${running.baseUrl}/mcp`));
+      await client.connect(transport);
+      conns.push({ name: serverName, client, cleanup: running.cleanup });
+
+      const listed = await client.listTools();
+      for (const t of listed.tools) {
+        if (toolToClient.has(t.name)) {
+          throw new Error(`tool name collision: "${t.name}" exposed by "${traj.toolServer[t.name]}" and "${serverName}"`);
+        }
+        toolToClient.set(t.name, client);
+        traj.toolServer[t.name] = serverName;
+        traj.toolRequired[t.name] = Array.isArray((t.inputSchema as any)?.required) ? (t.inputSchema as any).required : [];
+        merged.push(t);
+      }
+    }
+    traj.toolNames = merged.map((t) => t.name);
+    const tools = toChatTools(merged);
+
+    for (let i = 0; i < maxIters; i++) {
+      const res = await opts.backend.chat({ model: opts.model, messages, tools, numCtx, timeoutMs });
+
+      // Backend signalled the model's template can't do tools — a clean capability verdict.
+      if (res.toolsUnsupported) {
+        traj.supported = false;
+        traj.error = res.error;
+        return traj;
+      }
+      if (res.error) {
+        traj.error = res.error;
+        return traj;
+      }
+
+      // Accumulate generation perf across the rounds (durations are ns).
+      traj.inTokens += res.metrics.inTokens;
+      traj.maxPromptTokens = Math.max(traj.maxPromptTokens, res.metrics.inTokens);
+      traj.outTokens += res.metrics.outTokens;
+      totalDurNs += res.metrics.totalDurationNs;
+      evalDurNs += res.metrics.evalDurationNs;
+      traj.totalDurationS = round2(totalDurNs / 1e9);
+      traj.evalTps = tps(traj.outTokens, evalDurNs);
+
+      if (res.toolCalls.length === 0) {
+        traj.finalAnswer = res.content;
+        return traj;
+      }
+
+      // Echo the assistant's tool-call turn, then run each call.
+      messages.push(res.assistantMessage ?? { role: 'assistant', content: res.content, tool_calls: [] });
+      for (const call of res.toolCalls) {
+        traj.toolCalls.push({ name: call.name, arguments: call.arguments });
+
+        // A bad tool name / args throws — but "the model picked wrong" is exactly
+        // the verdict under test, so capture it and feed it back, don't crash.
+        let content: string;
+        let isError: boolean;
+        const owner = toolToClient.get(call.name);
+        if (!owner) {
+          content = `tool call failed: unknown tool "${call.name}"`;
+          isError = true;
+        } else {
+          try {
+            const result: any = await owner.callTool({ name: call.name, arguments: call.arguments });
+            content = resultText(result?.content);
+            isError = Boolean(result?.isError);
+          } catch (e) {
+            content = `tool call failed: ${e instanceof Error ? e.message : String(e)}`;
+            isError = true;
+          }
+        }
+        traj.toolResults.push({ name: call.name, content, isError });
+        messages.push({ role: 'tool', content, tool_name: call.name });
+      }
+    }
+
+    // Ran out of iterations still calling tools — report what we have.
+    traj.error = `no final answer within ${maxIters} tool rounds`;
+    return traj;
+  } catch (e) {
+    // Connect/list/transport failure or a backend failure: return a trajectory
+    // carrying the error rather than throwing.
+    traj.error = e instanceof Error ? e.message : String(e);
+    return traj;
+  } finally {
+    for (const { client, cleanup } of conns) {
+      await client.close().catch(() => {});
+      cleanup();
+    }
+  }
+}

--- a/cicd/tests/src/mcp/http-server.ts
+++ b/cicd/tests/src/mcp/http-server.ts
@@ -1,0 +1,86 @@
+/**
+ * Spawn our HTTP MCP server and wait until it is listening — the fork-local
+ * adaptation the stdio-based upstream lacks.
+ *
+ * Upstream's host/verifier drive a *stdio* MCP server (the agent/host spawns it and
+ * pipes JSON-RPC over stdin/stdout). Our server speaks HTTP (StreamableHTTP,
+ * `src/index.ts`), so instead we launch it on an OS-assigned port (PORT=0), read the
+ * `listening on http://…` line it prints, and hand callers the base URL. Callers then
+ * connect an MCP Client over StreamableHTTP (the host) or point the ACP agent at the
+ * URL as an `{ type: 'http' }` MCP server (the verifier). Mirrors `mcp-client.ts`.
+ */
+import { spawn, type ChildProcess } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { McpServerConfig } from './server-config.js';
+
+/** Repo root, resolved from this file (…/cicd/tests/src/mcp → repo root). */
+export function repoRoot(): string {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  return path.resolve(here, '..', '..', '..', '..');
+}
+
+export interface RunningServer {
+  /** Base URL, e.g. http://127.0.0.1:54321 — append '/mcp' for the MCP endpoint. */
+  baseUrl: string;
+  /** Terminate the spawned server. Idempotent. */
+  cleanup: () => void;
+}
+
+const READY = /listening on (http:\/\/[\d.]+:\d+)/;
+
+/**
+ * Spawn `cfg.command cfg.args` with PORT=0 and wait (up to startTimeoutMs) for the
+ * server to announce its URL on stdout/stderr. Rejects on early exit or timeout.
+ */
+export async function spawnHttpMcpServer(
+  cfg: McpServerConfig,
+  startTimeoutMs = 15000
+): Promise<RunningServer> {
+  const proc: ChildProcess = spawn(cfg.command, cfg.args, {
+    cwd: cfg.cwd || repoRoot(),
+    env: { ...process.env, ...(cfg.env ?? {}), PORT: '0' },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  let done = false;
+  const cleanup = () => {
+    if (!proc.killed) proc.kill('SIGTERM');
+  };
+
+  const baseUrl = await new Promise<string>((resolve, reject) => {
+    const deadline = setTimeout(() => {
+      if (done) return;
+      done = true;
+      proc.kill('SIGKILL');
+      reject(new Error(`MCP server did not start within ${startTimeoutMs}ms`));
+    }, startTimeoutMs);
+
+    const onLine = (chunk: Buffer) => {
+      const text = chunk.toString();
+      process.stderr.write(text); // surface server logs like mcp-client does
+      const m = text.match(READY);
+      if (m && !done) {
+        done = true;
+        clearTimeout(deadline);
+        resolve(m[1]);
+      }
+    };
+    proc.stdout?.on('data', onLine);
+    proc.stderr?.on('data', onLine);
+    proc.on('error', (err) => {
+      if (done) return;
+      done = true;
+      clearTimeout(deadline);
+      reject(err);
+    });
+    proc.on('exit', (code) => {
+      if (done) return;
+      done = true;
+      clearTimeout(deadline);
+      reject(new Error(`MCP server exited with code ${code} before listening`));
+    });
+  });
+
+  return { baseUrl, cleanup };
+}

--- a/cicd/tests/src/mcp/http-server.ts
+++ b/cicd/tests/src/mcp/http-server.ts
@@ -44,8 +44,15 @@ export async function spawnHttpMcpServer(
   });
 
   let done = false;
+  let killing = false;
   const cleanup = () => {
-    if (!proc.killed) proc.kill('SIGTERM');
+    if (killing) return;
+    killing = true;
+    try { proc.kill('SIGTERM'); } catch { /* already gone */ }
+    // Our server awaits DB/proxy/pool close on SIGTERM; if that wedges, force-kill so a
+    // stuck shutdown can't leak the process. Unref'd so the timer never keeps us alive.
+    const t = setTimeout(() => { try { proc.kill('SIGKILL'); } catch { /* gone */ } }, 3000);
+    t.unref?.();
   };
 
   const baseUrl = await new Promise<string>((resolve, reject) => {
@@ -63,7 +70,8 @@ export async function spawnHttpMcpServer(
       if (m && !done) {
         done = true;
         clearTimeout(deadline);
-        resolve(m[1]);
+        // The server binds/prints 0.0.0.0; connect to loopback (portable across OSes).
+        resolve(m[1].replace('0.0.0.0', '127.0.0.1'));
       }
     };
     proc.stdout?.on('data', onLine);

--- a/cicd/tests/src/mcp/server-config.ts
+++ b/cicd/tests/src/mcp/server-config.ts
@@ -1,0 +1,19 @@
+/**
+ * How to spawn a stdio MCP server — the shared shape used by both MCP paths:
+ * the model-under-test host (host.ts) and the live verifier (verifier-judge.ts).
+ *
+ * Lives in its own module so the verifier can depend on the config shape without
+ * importing the host (which pulls in @modelcontextprotocol/sdk). The server choice
+ * and its credentials are config, never hardcoded here.
+ */
+export interface McpServerConfig {
+  /** Identifies the server when several share one menu — e.g. the verifier picks
+   *  its read-only server by this name. Defaults to 'mcp' when unset. */
+  name?: string;
+  command: string;
+  args: string[];
+  cwd?: string;
+  /** Extra env the server needs (e.g. an API URL / key) — merged over a minimal
+   *  default environment; never hardcoded in this module. */
+  env?: Record<string, string>;
+}

--- a/cicd/tests/src/mcp/test-mcp.ts
+++ b/cicd/tests/src/mcp/test-mcp.ts
@@ -1,0 +1,304 @@
+/**
+ * Per-model MCP tool-call test (the cli.ts test-mcp subcommand).
+ *
+ * For each model: drive a REAL stdio MCP server through the host (host.ts) and
+ * grade the trajectory. The simple check is structural (did the model call a
+ * real tool, did the call succeed, did it produce a final answer?); with
+ * --judge the keyless AgentJudge adds the semantic check (did the final answer
+ * correctly use the tool result?); with --verify-live the VerifierJudge calls
+ * the server's read-only tools itself to check against LIVE truth. A model whose
+ * template can't do tools is reported "no tool support" — a clean verdict, not a
+ * failure of the harness.
+ *
+ * Markdown summary on stdout (CI step summary) and, with --output, a JSON report.
+ * Exit code is non-zero if any supported model fails. The model runtime is reached
+ * only through the injected ChatBackend (host.ts) — this file is vendor-neutral.
+ */
+import { writeFileSync } from 'node:fs';
+import { runMcpHost, type McpTrajectory } from './host.js';
+import type { McpServerConfig } from './server-config.js';
+import type { ChatBackend } from './chat-backend.js';
+import { AgentJudge, VerifierJudge } from '../judge/index.js';
+import { TestResult, Judgment } from '../types.js';
+
+const JUDGE_CRITERIA =
+  'Given the user prompt and the tool result(s) the model received, the final answer must ' +
+  'correctly use the tool result to answer the prompt. Reject empty answers, answers that ' +
+  'ignore or contradict the tool result, or data the tool result does not contain.';
+
+export interface McpTestOptions {
+  models: string[];
+  prompt: string;
+  /** Servers whose tools are merged into one menu for the model. With more than one,
+   *  picking the right tool is a real choice — extra servers act as distractors. */
+  servers: McpServerConfig[];
+  /** The model runtime under test (the only vendor-aware object). */
+  backend: ChatBackend;
+  numCtx: number;
+  judge: boolean;
+  /** Opt in the live verifier: the judge calls the server's read-only tools itself
+   *  to check the answer against live ground truth (supersedes --judge). */
+  verifyLive?: boolean;
+  /** Exact tool names the verifier may call. Fail-closed: if empty/unset, the verifier
+   *  verifies nothing — pass an explicit allow-list (no prefix heuristic across servers). */
+  verifyAllow?: string[];
+  /** Selects WHICH server the verifier spawns (by McpServerConfig.name) and the
+   *  mcp__<name>__<tool> label it registers it under — the verifier only ever sees
+   *  this one server, so distractor servers stay out of its reach. */
+  verifyServerName?: string;
+  /** Per-model response timeout (ms). Default 600000 (10 min). */
+  timeoutMs?: number;
+  output?: string;
+}
+
+interface McpSimpleVerdict {
+  pass: boolean;
+  reason: string;
+}
+
+interface McpModelResult {
+  model: string;
+  supported: boolean;
+  tool_names: string[];
+  tool_calls: { name: string; arguments: Record<string, unknown> }[];
+  tool_results: { name: string; isError: boolean }[];
+  final_answer_preview: string;
+  error?: string;
+  out_tokens: number;
+  max_prompt_tokens: number;
+  total_duration_s: number;
+  eval_tps: number;
+  check: { overall_pass: boolean; simple: McpSimpleVerdict; agent: Judgment | null };
+}
+
+/** Structural check: the model must have called a real tool, the call must have
+ *  succeeded, and it must have produced a non-empty final answer. */
+function simpleMcpCheck(t: McpTrajectory): McpSimpleVerdict {
+  if (!t.supported) return { pass: false, reason: 'model template does not support tools' };
+  if (t.error) return { pass: false, reason: t.error };
+  if (t.toolCalls.length === 0) return { pass: false, reason: 'model produced no tool call' };
+  const unknown = t.toolCalls.find((c) => !t.toolNames.includes(c.name));
+  if (unknown) return { pass: false, reason: `called unknown tool "${unknown.name}"` };
+  // Args vs schema: every required arg of the called tool must be present.
+  for (const c of t.toolCalls) {
+    const missing = (t.toolRequired[c.name] ?? []).filter((k) => !(k in c.arguments));
+    if (missing.length) return { pass: false, reason: `tool "${c.name}" called without required arg(s): ${missing.join(', ')}` };
+  }
+  const errored = t.toolResults.find((r) => r.isError);
+  if (errored) return { pass: false, reason: `tool "${errored.name}" call failed (bad args or server error)` };
+  if (!t.finalAnswer.trim()) return { pass: false, reason: 'empty final answer' };
+  return { pass: true, reason: `called ${t.toolCalls.map((c) => c.name).join(', ')} and produced a final answer` };
+}
+
+/** Build a synthetic TestResult so the AgentJudge can grade groundedness.
+ *  Lead with the prompt + final answer: the judge truncates step stdout, so a
+ *  large tool result must not push the answer out of the judge's window. Each
+ *  tool result is capped to keep enough grounding context within that window. */
+function toTestResult(t: McpTrajectory, prompt: string): TestResult {
+  const toolLog = t.toolCalls
+    .map((c, i) => `- ${c.name}(${JSON.stringify(c.arguments)}) -> ${(t.toolResults[i]?.content ?? '').slice(0, 500)}`)
+    .join('\n');
+  const stdout = `PROMPT: ${prompt}\n\nFINAL ANSWER: ${t.finalAnswer}\n\nTOOL CALLS AND RESULTS:\n${toolLog}`;
+  return {
+    testCase: {
+      id: t.model,
+      name: `mcp:${t.model}`,
+      suite: 'mcp',
+      priority: 1,
+      timeout: 60000,
+      dependencies: [],
+      goal: 'Use the MCP tool result to answer the prompt',
+      steps: [{ name: 'tool-call', command: '(captured MCP trajectory)' }],
+      criteria: JUDGE_CRITERIA,
+    },
+    steps: [{ name: 'tool-call', command: '(captured MCP trajectory)', stdout, stderr: '', exitCode: 0, duration: 0 }],
+    totalDuration: 0,
+    logs: '',
+    logFile: '',
+  };
+}
+
+export async function runMcpTest(opts: McpTestOptions): Promise<number> {
+  const results: McpModelResult[] = [];
+  const trajByModel = new Map<string, McpTrajectory>();
+
+  for (const model of opts.models) {
+    process.stderr.write(`--- ${model} ---\n`);
+    const traj = await runMcpHost({ backend: opts.backend, model, prompt: opts.prompt, servers: opts.servers, numCtx: opts.numCtx, timeoutMs: opts.timeoutMs });
+    trajByModel.set(model, traj);
+    const simple = simpleMcpCheck(traj);
+    results.push({
+      model,
+      supported: traj.supported,
+      tool_names: traj.toolNames,
+      tool_calls: traj.toolCalls,
+      tool_results: traj.toolResults.map((r) => ({ name: r.name, isError: r.isError })),
+      final_answer_preview: traj.finalAnswer.slice(0, 200),
+      error: traj.error,
+      out_tokens: traj.outTokens,
+      max_prompt_tokens: traj.maxPromptTokens,
+      total_duration_s: traj.totalDurationS,
+      eval_tps: traj.evalTps,
+      check: { overall_pass: simple.pass, simple, agent: null },
+    });
+    process.stderr.write(`  supported=${traj.supported} calls=${traj.toolCalls.length} simple=${simple.pass} · ${traj.outTokens} tok @ ${traj.evalTps} tok/s in ${traj.totalDurationS}s\n`);
+    // Release this model before the next loads, so only one is ever resident (no contention).
+    await opts.backend.unload?.(model);
+  }
+
+  // Agent-level check, only for models that passed the structural check. Two modes:
+  //  --verify-live : the verifier calls the server's read-only tools itself to check
+  //                  the answer against LIVE truth (the stronger check; supersedes --judge).
+  //  --judge       : the sandboxed agent judge grades groundedness over the captured trajectory.
+  const eligible = results.filter((r) => r.check.simple.pass);
+  const byModel = new Map(results.map((r) => [r.model, r]));
+  const applyVerdicts = (verdicts: Judgment[]) => {
+    for (const v of verdicts) {
+      const r = byModel.get(v.testId);
+      if (r) {
+        r.check.agent = v;
+        r.check.overall_pass = r.check.simple.pass && v.pass;
+      }
+    }
+  };
+
+  if (eligible.length > 0 && opts.verifyLive) {
+    // The verifier spawns ONLY its named server (read-only, fail-closed); distractor
+    // servers on the model's menu never reach it. Hand it that server's tools only —
+    // filtered by which server each came from — so its deny-list doesn't sprout bogus
+    // rules for tools it can't even see. Fail-closed: only --verify-allow opens tools.
+    const verifyServerName = opts.verifyServerName ?? 'mcp';
+    const verifyServer = opts.servers.find((s) => (s.name ?? 'mcp') === verifyServerName);
+    const toolServer = trajByModel.get(eligible[0].model)?.toolServer ?? {};
+    const verifyToolNames = Array.from(new Set(eligible.flatMap((r) => r.tool_names))).filter((n) => toolServer[n] === verifyServerName);
+    const allowTools = opts.verifyAllow ?? [];
+    if (!verifyServer) {
+      // Misconfigured: verify-live asked, but no server matches the name. Don't fall back
+      // to some other server (could be a distractor) — fail closed.
+      process.stderr.write(`[ERROR] verify-live: no configured server named "${verifyServerName}" — failing closed\n`);
+      applyVerdicts(eligible.map((r) => ({
+        testId: r.model,
+        pass: false,
+        reason: `verify-live could not run: no server named "${verifyServerName}"`,
+        evidenceStatus: 'verifier-unavailable' as const,
+      })));
+    } else {
+      const verifier = new VerifierJudge(
+        { server: verifyServer, serverName: verifyServerName, toolNames: verifyToolNames, allowTools },
+        '',
+      );
+      if (await verifier.isAvailable()) {
+        applyVerdicts(
+          await verifier.verify(eligible.map((r) => ({ testId: r.model, prompt: opts.prompt, answer: trajByModel.get(r.model)!.finalAnswer, toolCalls: r.tool_calls }))),
+        );
+      } else {
+        // Fail closed: a verify-live run whose verifier can't even start has NOT verified anything,
+        // so it must not green-light on the structural check alone. Mark every eligible model FAIL.
+        process.stderr.write('[ERROR] verify-live requested but the verifier agent is unavailable (auth/availability) — failing closed\n');
+        applyVerdicts(eligible.map((r) => ({
+          testId: r.model,
+          pass: false,
+          reason: 'verify-live could not run: verifier agent unavailable (auth/availability)',
+          evidenceStatus: 'verifier-unavailable' as const,
+        })));
+      }
+    }
+  } else if (eligible.length > 0 && opts.judge) {
+    const agentJudge = new AgentJudge();
+    if (await agentJudge.isAvailable()) {
+      applyVerdicts(await agentJudge.judgeResults(eligible.map((r) => toTestResult(trajByModel.get(r.model)!, opts.prompt))));
+    } else {
+      process.stderr.write('[WARN] agent judge not available — simple check only\n');
+    }
+  }
+
+  // "No tool support" is an informational capability verdict, not a harness
+  // failure — only a supported model that failed its check drives a non-zero exit.
+  const failed = results.filter((r) => r.supported && !r.check.overall_pass).length;
+
+  if (opts.output) {
+    const full = results.map((r) => ({ ...r, trajectory: trajByModel.get(r.model) }));
+    writeFileSync(
+      opts.output,
+      JSON.stringify(
+        { timestamp: new Date().toISOString(), backend: opts.backend.name, servers: opts.servers.map((s) => ({ name: s.name ?? 'mcp', command: s.command, args: s.args })), prompt: opts.prompt, judge: judgeLabel(opts), results: full },
+        null,
+        2
+      )
+    );
+    process.stderr.write(`Results written to ${opts.output}\n`);
+  }
+
+  printSummary(opts, results);
+  return failed > 0 ? 1 : 0;
+}
+
+/** Turn an empty evidence cell into a one-glance reason instead of a bare "—" (STORY-010). */
+function evidenceWhy(status: Judgment['evidenceStatus']): string {
+  switch (status) {
+    case 'denied': return '— (tool denied)';
+    case 'not-called': return '— (no tool called)';
+    case 'no-data': return '— (tool returned no data)';
+    case 'verifier-unavailable': return '— (verifier did not run)';
+    default: return '—';
+  }
+}
+
+const tick = (b: boolean): string => (b ? '✅' : '❌');
+/** Peak single-round prompt tokens vs the context window — ⚠️ within 10% of num_ctx
+ *  (a prompt that crosses it is silently truncated). */
+const peakCtx = (peak: number, numCtx: number): string =>
+  peak > 0 ? `${peak > numCtx * 0.9 ? '⚠️ ' : ''}${peak}/${numCtx}` : '—';
+const judgeLabel = (opts: McpTestOptions): string => (opts.verifyLive ? 'verify-live' : opts.judge ? 'dual' : 'simple');
+/** Escape so model/server-controlled text can't break out of the Markdown/<details>/code block. */
+const mdSafe = (s: string): string => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+function printSummary(opts: McpTestOptions, results: McpModelResult[]): void {
+  const supported = results.filter((r) => r.supported);
+  const passed = supported.filter((r) => r.check.overall_pass).length;
+  const failed = supported.length - passed;
+  const sha = process.env.GITHUB_SHA?.slice(0, 8);
+  const out: string[] = [];
+
+  // Banner — a glance tells you the outcome. ⚪ when nothing was actually verified (don't fake a green).
+  const icon = failed > 0 ? '❌' : passed > 0 ? '✅' : '⚪';
+  out.push(`## 🧪 MCP tool-call test — ${icon} ${passed} passed · ${failed} failed`);
+  out.push('');
+  const serverLabel = opts.servers.map((s) => `\`${s.command} ${s.args.join(' ')}\``).join(' + ');
+  out.push(`**Server${opts.servers.length > 1 ? 's' : ''}:** ${serverLabel}`);
+  out.push(`**Prompt:** ${opts.prompt} · **Backend:** ${opts.backend.name} · **Judge:** ${judgeLabel(opts)}${sha ? ` · **Commit:** \`${sha}\`` : ''}`);
+  out.push('');
+
+  // Scannable table — judge stages + cross-check, no raw JSON in the cells.
+  out.push('| Model | Verdict | Tool call(s) | Judge stages (tool·query·content) | Cross-check | Time (s) | Peak in/ctx | Out tok | tok/s |');
+  out.push('|---|---|---|---|---|--:|--:|--:|--:|');
+  for (const r of results) {
+    const verdict = r.check.overall_pass ? '✅ PASS' : r.supported ? '❌ FAIL' : '⚪ NO TOOL SUPPORT';
+    const calls = r.tool_calls.map((c) => c.name).join(', ') || '—';
+    const s = r.check.agent?.stages;
+    const stages = s ? `${tick(s.tool)} · ${tick(s.query)} · ${tick(s.content)}` : '—';
+    const cc = r.check.agent?.crossCheckUnsupported;
+    const cross = cc === undefined ? '—' : cc.length ? `❌ ${cc.join(', ').slice(0, 60)}` : '✅ grounded';
+    out.push(`| ${r.model} | ${verdict} | ${calls} | ${stages} | ${cross} | ${r.total_duration_s || '—'} | ${peakCtx(r.max_prompt_tokens, opts.numCtx)} | ${r.out_tokens || '—'} | ${r.eval_tps || '—'} |`);
+  }
+
+  // Per-model detail (reasoning + raw evidence) tucked behind a toggle — proof without the clutter.
+  for (const r of results) {
+    const reason = (r.check.agent?.reason ?? r.check.simple.reason ?? '').trim();
+    const evidence = r.check.agent?.evidence ?? '';
+    out.push('');
+    out.push(`<details><summary>Judge detail — ${mdSafe(r.model)}</summary>`);
+    out.push('');
+    if (reason) out.push(`**Reasoning:** ${mdSafe(reason.replace(/\n/g, ' '))}`);
+    out.push('');
+    if (evidence) {
+      // HTML-escaped <pre> (not a ``` fence) so a ``` or </details> in the result can't break out.
+      out.push('**Live evidence:**');
+      out.push(`<pre>${mdSafe(evidence.slice(0, 4000))}</pre>`);
+    } else {
+      out.push(`**Live evidence:** ${evidenceWhy(r.check.agent?.evidenceStatus)}`);
+    }
+    out.push('</details>');
+  }
+  process.stdout.write(out.join('\n') + '\n');
+}

--- a/cicd/tests/src/types.ts
+++ b/cicd/tests/src/types.ts
@@ -22,6 +22,10 @@ export interface TestCase {
   steps: TestStep[];
   criteria: string;
   goal?: string;
+  /** Judge style (STORY-003 #125). 'simple' (default) = deterministic checks only —
+   *  fast, free, right for stable tools. 'agent' = ALSO run the ACP agent judge in
+   *  dual mode, for tools whose output isn't deterministic (connect/scan/status). */
+  judge?: 'simple' | 'agent';
 }
 
 export interface PatternMatch {

--- a/cicd/tests/src/types.ts
+++ b/cicd/tests/src/types.ts
@@ -55,6 +55,20 @@ export interface Judgment {
   pass: boolean;
   reason: string;
   evidence?: string;
+  /** Why the evidence cell is what it is — set by the live verifier (VerifierJudge)
+   *  so an empty cell explains itself instead of reading as a silent pass. */
+  evidenceStatus?:
+    | 'captured'
+    | 'denied'
+    | 'not-called'
+    | 'no-data'
+    | 'verifier-unavailable';
+  /** Per-stage rubric flags from the live verifier: did the model pick the right
+   *  tool, call it correctly, and ground its answer in the result? */
+  stages?: { tool: boolean; query: boolean; content: boolean };
+  /** Deterministic cross-check: claims in the answer the live tool result does not
+   *  support (the verifier's PASS cannot stand if this is non-empty). */
+  crossCheckUnsupported?: string[];
 }
 
 export interface StepReportEntry {

--- a/docs/integrations/ci-runner-fork-drift.md
+++ b/docs/integrations/ci-runner-fork-drift.md
@@ -1,0 +1,50 @@
+# CI runner: fork-drift baseline vs `agent-workflows-runner`
+
+Our `cicd/tests` is a fork of the upstream `agent-workflows-runner`. STORY-003 pulls
+upstream's judge tiers (agent-judge, live-MCP verifier) into it. This baseline (issue
+#122) records how far the shared files have drifted, so the ports graft cleanly.
+
+Measured against `/home/jack/src/agent-workflows-runner/cicd/tests/src` on 2026-07-02.
+
+## Shared files — drift
+
+| File | Ours | Upstream | Drift | Note |
+|------|------|----------|-------|------|
+| `judge/index.ts` | 1 | 3 | small | ours exports only `SimpleJudge`; add `AgentJudge` |
+| `judge/simple-judge.ts` | 69 | 80 | small | compatible; keep ours |
+| `config.ts` | 30 | 108 | **large** | ours lacks the `judge` + `mcp` config blocks the ports read |
+| `types.ts` | 110 | 259 | **large** | ours lacks verifier/test-mcp types; `Judgment` shape is compatible |
+| `reporter/json.ts` | 109 | 134 | medium | needs the dual-judge merge (`pass = simple && agent`) + per-judge breakdown |
+| `reporter/console.ts` | 60 | 96 | medium | needs per-judge verdict output |
+| `cli.ts` | 183 | 292 | **large** | ours lacks the `JUDGE_MODE=dual` wiring and the `test-mcp` command |
+| `loader.ts` | 191 | 230 | medium | fork-local (dependency/suite handling); **keep ours** |
+| `executor.ts` | 375 | 357 | **large / rewritten** | ours adds device snapshot/restore — **keep ours**, do not sync |
+
+## Upstream-only files to port
+
+- **#123** `judge/agent-judge.ts` (386) — ACP LLM judge. Imports `{ TestResult, Judgment }`
+  from `../types`, `CONFIG` from `../config`, and `@agentclientprotocol/sdk`.
+- **#124** `judge/verifier-judge.ts` (549) + `mcp/{test-mcp,host,chat-backend,server-config}.ts`
+  (~634) + `mcp/backends/{index,ollama}.ts` — the live-MCP verifier and its model host.
+
+Not part of STORY-003 (test-doc tooling / docker): `audit-bind.ts`, `drift.ts`,
+`port-yaml.ts`, `testdoc.ts`, `log-collector.ts` — **do not port**.
+
+## New dependencies (`cicd/tests/package.json`)
+
+- `@agentclientprotocol/sdk`, `@agentclientprotocol/claude-agent-acp` — the ACP judge.
+- `dotenv` — upstream loads `.env`; useful for `JUDGE_*` / `TEST_SSID_*` (STORY-004).
+
+## Recommendation
+
+- **Graft, don't sync.** Keep our diverged `executor.ts`, `loader.ts`, `config.ts`,
+  `types.ts` — they carry fork-local behavior (snapshot/restore, our SUITES). *Add* the
+  upstream `judge`/`mcp` config blocks and types rather than overwriting.
+- **Land order:** #123 (agent-judge — self-contained, cleanest) → #124 (verifier +
+  test-mcp — heaviest, attaches our MCP server) → #125 (per-test judge style) → #126
+  (CI wiring). #123 proves the ACP path end to end before the heavier verifier.
+- **Runtime auth:** the judge needs an ACP agent (bundled Claude ACP, keyless via
+  `~/.claude` / `CLAUDE_CODE_OAUTH_TOKEN`); the verifier's `test-mcp` needs a model
+  backend (ollama). Where that isn't present, the code must **degrade to the
+  deterministic judge**, not fail — and CI runtime verification is deferred to an
+  environment that has it.


### PR DESCRIPTION
## Summary
Ports the dual-judge CI framework from the upstream `agent-workflows-runner` fork and adapts it to our **HTTP** MCP server:
- **#123** ACP agent judge — dual mode (`simple && agent`), fail-safe degradation when the agent is unavailable. **Verified live.**
- **#124** live-MCP verifier + `test-mcp` — rewired stdio→HTTP (new `mcp/http-server.ts`; verifier attaches our server as `{ type:'http' }`). **Verifier verified live** (agent called the allow-listed `device_list` and graded against ground truth). `test-mcp` model-host path compiles; needs an ollama backend to run.
- **#125** per-test judge style (`judge: agent`) — only opted-in tests pay for the agent.
- **#126** CI wiring — `judge_mode` (ci → smoke → run) + `CLAUDE_CODE_OAUTH_TOKEN`.
- **#122** fork-drift baseline (`docs/integrations/ci-runner-fork-drift.md`).

Reviewed via `/code-review`: fixed a server-orphan leak, evidence provenance + secret redaction, SIGKILL escalation, `JUDGE_MODE` case, and invalid-`judge:` warning (commit 9dc52dd).

Closes #122
Closes #123
Closes #124
Closes #125
Closes #126
Part of STORY-003 · plan #119

## Test plan
- [ ] `JUDGE_MODE=dual` on a test marked `judge: agent` runs the agent judge and merges (verified locally).
- [ ] Verifier: `VerifierJudge.verify()` calls read-only tools over HTTP and grades against ground truth (verified locally).
- [ ] The real exercise: bind test files to scripts and run the suites through the runner in CI.
- [ ] Absent agent auth degrades to deterministic (no mass failure).

Generated with [Claude Code](https://claude.com/claude-code)