### PR TITLE
ci(wifi): wire the wifi suite into CI, gated on the lab (#133)

### DIFF
--- a/.github/workflows/test-wifi.yml
+++ b/.github/workflows/test-wifi.yml
@@ -1,0 +1,39 @@
+name: "Test: WiFi"
+
+# The wifi suite mutates the radio and connects to real networks, so it needs a lab
+# access point + credentials. It is NOT part of the default CI (ci.yml runs smoke); run
+# it explicitly, and it self-skips unless the lab is marked ready.
+#
+# Lab setup on the self-hosted runner:
+#   - repo variable  WIFI_LAB = true                 (arms this workflow)
+#   - repo secrets   TEST_SSID_WPA2 / _PASSWORD, TEST_SSID_OPEN, TEST_DEVICE_SERIAL,
+#                    CLAUDE_CODE_OAUTH_TOKEN         (test data + agent-judge auth)
+# Locally, `make test SUITE=wifi` (with TEST_SSID_* exported) stays the first-class path.
+
+on:
+  workflow_dispatch:
+    inputs:
+      judge_mode:
+        description: 'Judge mode (dual runs the agent judge on connect e2e)'
+        required: false
+        default: 'dual'
+        type: choice
+        options:
+          - dual
+          - simple
+  workflow_call:
+    inputs:
+      judge_mode:
+        required: false
+        default: 'dual'
+        type: string
+
+jobs:
+  test:
+    # Skip cleanly (green, not failed) unless the lab is armed — no device/secrets → no run.
+    if: ${{ vars.WIFI_LAB == 'true' }}
+    uses: ./.github/workflows/test-run.yml
+    with:
+      tag: wifi
+      judge_mode: ${{ inputs.judge_mode || 'dual' }}
+    secrets: inherit

--- a/cicd/tests/testcases/wifi/TC-WIFI-002.yml
+++ b/cicd/tests/testcases/wifi/TC-WIFI-002.yml
@@ -5,6 +5,9 @@ tags: [wifi, connect]
 priority: 2
 timeout: 90000
 dependencies: []
+# Connect outcome is non-deterministic (association may still be settling); let the
+# agent judge grade "actually associated to the target SSID" in dual mode.
+judge: agent
 
 steps:
   - name: Connect to the WPA2 test network

--- a/cicd/tests/testcases/wifi/TC-WIFI-003.yml
+++ b/cicd/tests/testcases/wifi/TC-WIFI-003.yml
@@ -5,6 +5,8 @@ tags: [wifi, connect]
 priority: 3
 timeout: 90000
 dependencies: []
+# Connect outcome is non-deterministic; agent judge grades real association in dual mode.
+judge: agent
 
 steps:
   - name: Connect to the open test network


### PR DESCRIPTION
## Summary
- `test-wifi.yml` — runs the `wifi` suite (tag `wifi`, `judge_mode: dual`, `secrets: inherit`); self-skips via `if: vars.WIFI_LAB == 'true'` so it never runs without a lab device/secrets.
- TC-WIFI-002/003 marked `judge: agent` — connect "means associated" verified by the STORY-003 agent judge in dual mode.
- Local `make test SUITE=wifi` stays first-class.

Proven live this session: the full wifi suite ran green against a real WPA2 AP (WhenWiredCry), TC-WIFI-002 passing via the agent judge (independent `wifi_status` confirmation).

Closes #133
Part of STORY-004 · plan #120

Generated with [Claude Code](https://claude.com/claude-code)