### PR TITLE
build(make): add build-app target, fold companion APK into make build

### DIFF
--- a/.claude/skills/android-wifi-mcp-build/SKILL.md
+++ b/.claude/skills/android-wifi-mcp-build/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: android-wifi-mcp-build
+description: |
+  Build the android-wifi-mcp project. Use when the user asks to build the code,
+  compile, or produce a fresh server bundle and/or companion APK. "Build" means
+  BOTH the Node MCP server and the Kotlin companion app unless the user narrows it.
+---
+
+# Build android-wifi-mcp
+
+The repo has **two** build targets. A bare "build" means both.
+
+| Command | Builds | Needs |
+|---|---|---|
+| `make build` | server + companion APK | Node + Android SDK/JDK |
+| `make build-server` | Node MCP server (`tsc` → `dist/`) | Node |
+| `make build-app` | Kotlin companion APK | Android SDK/JDK |
+
+`make build` = `build-server` + `build-app`. The server-only workflows (`make
+test`, `make serve-all`, `make setup`) depend on `build-server`, so they never
+pull in the Android SDK — only a user-facing `make build` builds the APK.
+
+## Steps
+
+1. **Pick scope.** If the user said plain "build", run `make build`. If they
+   named the server or the phone app, run `make build-server` or `make build-app`.
+2. **Run it** from the repo root.
+3. **Report the outputs:**
+   - Server: `dist/index.js`
+   - APK: `companion-app/app/build/outputs/apk/debug/app-debug.apk`
+4. **Don't auto-restart or reinstall.** Rebuilding the server does not restart
+   the running service; rebuilding the APK does not reinstall it on the phone.
+   If the user wants the change live, offer:
+   - Server: `make serve-restart` (stops `:3000`, starts fresh)
+   - APK: `adb install -r companion-app/app/build/outputs/apk/debug/app-debug.apk`
+     (confirm the target device first with `adb devices`).
+
+## Notes
+
+- The `certs/` directory holds real private keys and is gitignored — it is test
+  material, not a build input.
+- CI builds the server with `npm run build` directly (not `make`), so the
+  Makefile's build wiring does not affect CI.

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ cicd/tests/dist/
 
 # Enterprise-WiFi test material — holds a private key, never commit
 lab-certs/
+certs/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: up down restart logs psql migrate migrate-down test test-unit build clean \
+.PHONY: up down restart logs psql migrate migrate-down test test-unit build build-server build-app clean \
         doctor adb devices udev serve serve-stop serve-restart serve-all serve-all-stop \
         setup readme-diagram help
 
@@ -39,7 +39,10 @@ help:
 	@echo "  make up / down / restart / logs / psql / migrate"
 	@echo ""
 	@echo "Build / test:"
-	@echo "  make build / test / test-unit / clean"
+	@echo "  make build          build everything: server (npm) + companion APK (gradle)"
+	@echo "  make build-server   build the Node MCP server only"
+	@echo "  make build-app      build the Kotlin companion APK only"
+	@echo "  make test / test-unit / clean"
 
 # ---- Host setup & server lifecycle -----------------------------------------
 
@@ -98,7 +101,7 @@ serve-restart:
 # Both bind 0.0.0.0 with NO auth, and playwright's host-check is disabled
 # (--allowed-hosts "*") so it answers a remote IP — reachability grants full phone
 # control. Exposure/auth stance: #100.
-serve-all: build
+serve-all: build-server
 	@command -v adb >/dev/null 2>&1 || { echo "adb not found -> make adb"; exit 1; }
 	@mkdir -p $(SERVE_ALL_LOG)
 	@for p in $(PORT) $(PW_PORT); do command -v lsof >/dev/null 2>&1 && lsof -ti:$$p >/dev/null 2>&1 && echo "  warning: :$$p already in use — run 'make serve-all-stop' first if this is a stale bundle" || true; done
@@ -132,7 +135,7 @@ readme-diagram:
 
 setup:
 	@command -v adb >/dev/null 2>&1 || $(MAKE) adb
-	$(MAKE) build
+	$(MAKE) build-server
 	@$(MAKE) doctor
 	@echo ""
 	@echo "Next: make serve   (then reconnect the MCP client)"
@@ -162,13 +165,21 @@ migrate:
 migrate-down:
 	npx node-pg-migrate down
 
-build:
+# `make build` builds everything shippable: the Node MCP server and the Kotlin
+# companion APK. Server-only workflows (test, serve-all, setup) depend on
+# build-server so they don't pull in the Android SDK.
+build: build-server build-app
+
+build-server:
 	npm run build
+
+build-app:
+	cd companion-app && ./gradlew assembleDebug
 
 test-unit:
 	npm run test:unit
 
-test: build
+test: build-server
 	cd cicd/tests && npm test
 
 clean:


### PR DESCRIPTION
## Summary
- Add `build-app` (gradle assembleDebug) and `build-server` (npm run build); `make build` now runs both, so a bare "build" produces the server bundle **and** the companion APK.
- Repoint `test` / `serve-all` / `setup` at `build-server` so those server-only flows don't require the Android SDK.
- Add the `android-wifi-mcp-build` skill documenting the two build targets.
- Gitignore `certs/` — enterprise-WiFi test material that holds private keys.

## Test plan
- [x] `make build-app` → BUILD SUCCESSFUL (Gradle 8.5, SDK android-34); APK at `companion-app/app/build/outputs/apk/debug/app-debug.apk`
- [x] `make test` dry-run runs only `npm run build`, no Gradle
- [x] `certs/`, wrapper JAR, and `local.properties` confirmed gitignored (no secrets/machine paths in the diff)
- [x] CI unaffected — it calls `npm run build` directly, not `make`

Generated with [Claude Code](https://claude.com/claude-code)