### PR TITLE
Load .env at startup so logging works as documented

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",
+        "dotenv": "^17.4.2",
         "express": "^4.21.0",
         "pg": "^8.20.0",
         "pino": "^10.3.1",
@@ -808,6 +809,18 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "license": "MIT",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.0",
+    "dotenv": "^17.4.2",
     "express": "^4.21.0",
     "pg": "^8.20.0",
     "pino": "^10.3.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config'; // load .env before anything reads process.env (e.g. DATABASE_URL)
 import express from 'express';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { DeviceManager } from './adb/device-manager.js';


### PR DESCRIPTION
## Summary
- The MCP server read `process.env.DATABASE_URL` from the shell only — it never loaded `.env`, so the `.env` workflow `.env.example` advertises silently did nothing and structured logging stayed disabled.
- Add `dotenv` and import `dotenv/config` first in `src/index.ts` so every startup path (`make serve`, `npm start`) honors `.env`.
- Explicit shell vars still win over `.env` (dotenv's default no-override precedence), so `DATABASE_URL=… make serve` is unaffected.

Fixes #148

## Test plan
- [x] `npm run build` succeeds; `dotenv/config` is line 1 of `dist/index.js`
- [x] Server started with a plain `npm start` (no inline var) reads `DATABASE_URL` from `.env`
- [x] `query_log` returns logged calls after such a start (verified live on device)

Generated with [Claude Code](https://claude.com/claude-code)