### PR TITLE
Load repo-root .env in the test harness so fixtures persist

### DIFF
--- a/cicd/tests/src/cli.ts
+++ b/cicd/tests/src/cli.ts
@@ -7,6 +7,7 @@
  *   npx tsx src/cli.ts list [options]
  */
 
+import './load-env.js'; // must be first: loads repo-root .env before config.js reads process.env
 import { Command } from 'commander';
 import path from 'path';
 import { mkdirSync, existsSync } from 'fs';

--- a/cicd/tests/src/load-env.ts
+++ b/cicd/tests/src/load-env.ts
@@ -1,0 +1,17 @@
+/**
+ * Load the repo-root `.env` into process.env before anything reads it.
+ *
+ * Import this FIRST in the CLI entrypoint — ESM evaluates imports in source
+ * order, so config.js (which builds CONFIG from process.env at import time) and
+ * every {{TEST_SSID_*}} / TEST_DEVICE_SERIAL / DATABASE_URL lookup then see the
+ * persisted fixtures. Uses the same root `.env` the MCP server loads, so the
+ * harness and the server share one source of truth. dotenv does not override
+ * vars already set in the environment (e.g. a self-hosted runner's secrets win).
+ */
+import { config } from 'dotenv';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+// cicd/tests/src -> repo root is three levels up.
+config({ path: path.resolve(here, '..', '..', '..', '.env') });


### PR DESCRIPTION
## Summary
- The test harness read `TEST_SSID_*` / `TEST_DEVICE_SERIAL` / `DATABASE_URL` from `process.env` only — nothing loaded `.env` — so wifi connect tests failed on empty `{{TEST_SSID_*}}` unless every var was exported by hand each run.
- Add `dotenv` + a `load-env` module imported **first** in `cli.ts` (before `config.js` reads `process.env`), pointing at the **same repo-root `.env`** the MCP server loads. One source of truth; a self-hosted runner's injected secrets still win (dotenv doesn't override set vars).

Part of #144 (item 4: full-suite green run). Fixture provisioning tracked in #152.

## Test plan
- [x] Harness loads root `.env` — verified `TEST_SSID_OPEN`/`TEST_DEVICE_SERIAL`/`DATABASE_URL` populate from the file with no inline env
- [x] `TC-WIFI-003` went FAIL (empty SSID) → **PASS** using only the persisted `.env`
- [x] `.env` stays gitignored (holds AP passwords) — not in this diff

Generated with [Claude Code](https://claude.com/claude-code)