### PR TITLE
Fix isEnabled() false-positive so wifi_disable confirms (#154)

### DIFF
--- a/src/adb/wifi-commands.ts
+++ b/src/adb/wifi-commands.ts
@@ -23,7 +23,12 @@ export class WifiCommands {
     if (!result.success) {
       throw new Error(`Failed to get WiFi status: ${result.stderr}`);
     }
-    return result.stdout.toLowerCase().includes('wifi is enabled');
+    // Check "disabled" first: when off, the status reads "Wifi is disabled\n
+    // Wifi scanning is only available when wifi is enabled" — that second line
+    // contains "wifi is enabled", so a bare includes() false-positives as on.
+    const out = result.stdout.toLowerCase();
+    if (out.includes('wifi is disabled')) return false;
+    return out.includes('wifi is enabled');
   }
 
   /**
@@ -34,6 +39,22 @@ export class WifiCommands {
     const result = await this.adb.shell(`cmd wifi set-wifi-enabled ${state}`);
     if (!result.success) {
       throw new Error(`Failed to ${enabled ? 'enable' : 'disable'} WiFi: ${result.stderr}`);
+    }
+  }
+
+  /**
+   * Poll until the radio reaches `target`, or the deadline elapses; returns
+   * whether it was confirmed. `cmd wifi set-wifi-enabled` returns before the
+   * radio settles, so a single fixed sleep false-negatives when toggling an
+   * active connection (Android disconnects, then flips the radio — >1s). Same
+   * poll-don't-sleep fix as the connect verify (#65).
+   */
+  async waitForEnabled(target: boolean, timeoutMs = 8000): Promise<boolean> {
+    const deadline = Date.now() + timeoutMs;
+    while (true) {
+      if ((await this.isEnabled()) === target) return true;
+      if (Date.now() >= deadline) return false;
+      await new Promise(resolve => setTimeout(resolve, 300));
     }
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -449,8 +449,7 @@ export function createMcpServer(
       const wifi = deviceManager.getWifiCommands();
       await wifi.setEnabled(true);
 
-      await new Promise(resolve => setTimeout(resolve, 1000));
-      const enabled = await wifi.isEnabled();
+      const enabled = await wifi.waitForEnabled(true);
 
       return {
         content: [
@@ -472,14 +471,13 @@ export function createMcpServer(
       const wifi = deviceManager.getWifiCommands();
       await wifi.setEnabled(false);
 
-      await new Promise(resolve => setTimeout(resolve, 1000));
-      const enabled = await wifi.isEnabled();
+      const disabled = await wifi.waitForEnabled(false);
 
       return {
         content: [
           {
             type: 'text',
-            text: !enabled ? 'WiFi disabled successfully' : 'WiFi disable command sent (verify with wifi_status)',
+            text: disabled ? 'WiFi disabled successfully' : 'WiFi disable command sent (verify with wifi_status)',
           },
         ],
       };


### PR DESCRIPTION
## Summary
- `isEnabled()` did a bare `stdout.includes('wifi is enabled')` on the full `cmd wifi status` output. When the radio is **off**, that output includes the line *"Wifi scanning is only available when wifi is enabled"* — so it false-positived as **on**, and `wifi_disable` could never confirm (returned `"command sent"`, failing `TC-WIFI-001`). Now checks `"wifi is disabled"` first.
- Replace the fixed 1s post-toggle sleep with a `waitForEnabled()` poll (same poll-don't-sleep fix as #65) so toggling an **active** connection (which takes >1s to settle) still confirms.

Fixes #154

## Test plan
- [x] `TC-WIFI-001` FAIL → **PASS** (disable confirms in ~3.5s, was timing out at 8s)
- [x] Verified enabled-state output contains no "disabled" (negative guard is safe)

Generated with [Claude Code](https://claude.com/claude-code)