### PR TITLE
Anchor TC-WIFI-005 SSID match to the exact saved entry (#155)

### DIFF
--- a/cicd/tests/testcases/wifi/TC-WIFI-005.yml
+++ b/cicd/tests/testcases/wifi/TC-WIFI-005.yml
@@ -16,7 +16,10 @@ steps:
   - name: Find the saved network's id
     command: npx tsx cicd/tests/src/mcp-client.ts wifi_list_networks '{}'
     expectPatterns:
-      - "{{TEST_SSID_WPA2}}"
+      # Anchor to the SSID's surrounding quotes so a saved network that shares this
+      # SSID's prefix can't satisfy the check. Patterns are regex over the double-
+      # encoded payload where quotes render escaped (\"), hence \\" here.
+      - '\\"{{TEST_SSID_WPA2}}\\"'
     rejectPatterns:
       - "isError"
     capture:
@@ -31,10 +34,14 @@ steps:
     command: npx tsx cicd/tests/src/mcp-client.ts wifi_list_networks '{}'
     rejectPatterns:
       - "isError"
-      - "{{TEST_SSID_WPA2}}"
+      # Quote-anchored like the find step (#155): a bare {{TEST_SSID_WPA2}} is a regex
+      # over the saved list, so a saved network sharing this SSID's prefix would
+      # false-fail removal. \\" matches the escaped quote in the double-encoded payload.
+      - '\\"{{TEST_SSID_WPA2}}\\"'
 
 criteria: |
   wifi_forget removes a saved network by id (captured from wifi_list_networks), confirmed
   by the SSID being absent from the saved list afterward. Needs TEST_SSID_WPA2(+_PASSWORD)
   and a real AP. TEST_SSID_WPA2 must not contain a dot or regex metacharacters — the
-  capture path splits on "." and the SSID is used verbatim in patterns.
+  capture path splits on "." and the SSID is used (quote-anchored) in patterns. The
+  quotes anchor to the exact saved entry so a prefix-sharing SSID does not false-match.


### PR DESCRIPTION
## Summary
- `TC-WIFI-005`'s forget-verification matched the bare SSID as a **regex over the double-encoded list-networks payload**, so it false-failed when another saved network shared the SSID's prefix (the test device carries several same-prefix SSIDs).
- Anchor both the presence check and the removal check to the SSID's surrounding (escaped) quotes — `\\"SSID\\"` — so only the exact entry matches. Comments are deployment-agnostic and cite the double-encoding gotcha (`test-yaml-format.md`).

Fixes #155

## Test plan
- [x] `TC-WIFI-005` FAIL → **PASS** with same-prefix networks (`Wednesday` / `- wpa3` / `- 802.1x` / `- SAE`) still saved
- [x] Anchor is exact — a leading/trailing difference breaks the match (spot-checked)
- [x] Depends on the WPA2 fixture now persisted in `.env` (#153)

Generated with [Claude Code](https://claude.com/claude-code)