### PR TITLE
TC-PROXY-002: target Wikipedia + detect a real page feature; configurable browser

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,3 +50,9 @@
 # TEST_PORTAL_SSID=
 # TEST_PORTAL_USERNAME=
 # TEST_PORTAL_PASSWORD=
+
+# ============ Playwright proxy test (TC-PROXY-002) ============
+# Extra args appended to the @playwright/mcp upstream so it launches a browser that
+# exists on the host. Leave unset if Google Chrome is installed (the default channel).
+# Example for a host using Playwright/system Chromium instead of Chrome:
+# PW_BROWSER_ARGS=--browser chromium --executable-path /usr/bin/chromium-browser --no-sandbox

--- a/cicd/tests/testcases/proxy/TC-PROXY-002.yml
+++ b/cicd/tests/testcases/proxy/TC-PROXY-002.yml
@@ -1,5 +1,5 @@
 id: TC-PROXY-002
-name: Proxy exposes @playwright/mcp browser_navigate via host Chromium
+name: Proxy exposes @playwright/mcp browser_navigate via a host browser
 suite: proxy
 tags: [proxy, playwright]
 priority: 2
@@ -7,22 +7,28 @@ timeout: 180000
 dependencies: []
 
 steps:
-  - name: browser_navigate to https://example.com via the proxied playwright server
+  - name: browser_navigate to a well-known page via the proxied playwright server
+    # ${PW_BROWSER_ARGS} (from .env) points the upstream at a browser the host has —
+    # empty when Google Chrome is installed (@playwright/mcp's default channel).
     command: |
-      UPSTREAM_MCP='playwright=npx -y @playwright/mcp@latest --headless' \
-        npx tsx cicd/tests/src/mcp-client.ts browser_navigate '{"url":"https://example.com"}'
+      UPSTREAM_MCP="playwright=npx -y @playwright/mcp@latest --headless ${PW_BROWSER_ARGS}" \
+        npx tsx cicd/tests/src/mcp-client.ts browser_navigate '{"url":"https://en.wikipedia.org"}'
     timeout: 150000
     expectPatterns:
       - "Page URL"
-      - "example.com"
-      - "Example Domain"
+      - "wikipedia.org"          # reached the real site (URL)
+      - "free encyclopedia"      # distinctive page feature: the Wikipedia title
     rejectPatterns:
       - "isError"
       - "Unknown tool"
 
 criteria: |
   Verify the proxy works with a real upstream MCP (@playwright/mcp).
-  - First run downloads @playwright/mcp + browsers if not cached (longer timeout)
-  - Our server spawns it as an upstream and registers all 21 browser_* tools
-  - browser_navigate to https://example.com returns Page URL and Page Title
-  - This validates the canonical use case: device + WiFi + browser via one MCP endpoint
+  - Our server spawns @playwright/mcp as an upstream and registers its browser_* tools.
+  - browser_navigate to a well-known, bot-friendly page (Wikipedia) returns its real
+    Page URL (wikipedia.org) and a distinctive title feature ("...the free encyclopedia")
+    — not just a 200. google.com is deliberately avoided: it serves an anti-bot
+    interstitial to automated browsers, which would make this flaky.
+  - PW_BROWSER_ARGS (from .env) selects a browser present on the host; leave it unset
+    when Google Chrome is installed. See .env.example.
+  - Validates the canonical use case: device + WiFi + browser via one MCP endpoint.


### PR DESCRIPTION
## Summary
- Retarget `TC-PROXY-002` from `example.com` to **`en.wikipedia.org`** and assert on a **distinctive page feature** — the `free encyclopedia` title + `wikipedia.org` URL — so the proxy test proves a real page rendered, not just a 200.
- **Avoid google.com**: it serves an anti-bot interstitial (`/sorry/…`) to automated browsers (reproduced live), which would be flaky.
- Make the upstream browser configurable via **`${PW_BROWSER_ARGS}`** (loaded from `.env`), so the host-specific browser path stays out of the portable YAML — unset on a host with Google Chrome (`@playwright/mcp`'s default channel). Documented in `.env.example`.

Part of #144 (item 4 — full-suite green).

## Test plan
- [x] `TC-PROXY-002` FAIL (no host Chrome) → **PASS** — proxy spawns `@playwright/mcp`, navigates Wikipedia, returns `Page URL` + `wikipedia.org` + `free encyclopedia`
- [x] Browser driven by `.env` `PW_BROWSER_ARGS` (EPEL chromium on this Rocky host); empty-fallback keeps the default channel for Chrome hosts
- [x] `.env` (with the path) stays gitignored; only the commented template is in the diff

Generated with [Claude Code](https://claude.com/claude-code)