### PR TITLE
Poll for wifi scan results instead of a fixed 2s sleep (#158)

### DIFF
--- a/src/adb/wifi-commands.ts
+++ b/src/adb/wifi-commands.ts
@@ -83,11 +83,24 @@ export class WifiCommands {
   /**
    * Scan for networks (start scan + get results)
    */
-  async scan(): Promise<ScanResult[]> {
+  async scan(timeoutMs = 10000): Promise<ScanResult[]> {
     await this.startScan();
-    // Wait a bit for scan to complete
-    await new Promise(resolve => setTimeout(resolve, 2000));
-    return this.getScanResults();
+    // `cmd wifi start-scan` returns before results land, so a single fixed sleep
+    // false-negatives when the scan hasn't finished — most reliably right after a
+    // radio toggle, which clears the result cache and resets the scan-throttle
+    // window (the empty cache then reads as zero networks). Poll the cached results
+    // until non-empty or the deadline, re-issuing the scan periodically (throttle-
+    // permitting) to nudge fresh results. Poll-don't-sleep, like waitForEnabled (#65).
+    const deadline = Date.now() + timeoutMs;
+    let results = await this.getScanResults();
+    let elapsed = 0;
+    while (results.length === 0 && Date.now() < deadline) {
+      await new Promise(resolve => setTimeout(resolve, 500));
+      elapsed += 500;
+      if (elapsed % 2500 === 0) await this.startScan().catch(() => {});
+      results = await this.getScanResults();
+    }
+    return results;
   }
 
   /**


### PR DESCRIPTION
## Summary
- `WifiCommands.scan()` triggered a scan then slept a fixed **2000ms** and read whatever the framework had cached. `cmd wifi start-scan` returns before results land (and is silently dropped under Android scan throttling — shell exit stays 0), so after a radio toggle cleared the cache + reset the throttle window, 2s elapsed before fresh results arrived → `wifi_scan` returned `count:0`, no `bssid` → `TC-SMK-004` flaked.
- Replace the fixed sleep with a **10s deadline poll**: re-read `list-scan-results` until non-empty, re-issuing `start-scan` periodically to nudge fresh results. Warm cache returns immediately; only the empty case waits. Mirrors the `waitForEnabled`/#65 poll-don't-sleep pattern.

Fixes #158

## Test plan
- [x] Reproduced the flake: radio toggle (clears cache) then `TC-SMK-004` → **3/3 pass** (intermittently failed before)
- [x] `tsc` build clean; sole caller (`server.ts` `wifi_scan`, no-arg) unaffected by the new defaulted param

Generated with [Claude Code](https://claude.com/claude-code)