### PR TITLE
Fix empty-ADB_PATH server crash + wire WiFi CI fixtures from secrets

### DIFF
--- a/.github/workflows/test-run.yml
+++ b/.github/workflows/test-run.yml
@@ -36,6 +36,15 @@ jobs:
         env:
           TEST_DEVICE_SERIAL: ${{ secrets.TEST_DEVICE_SERIAL }}
           ADB_PATH: ${{ secrets.ADB_PATH }}
+          # WiFi lab fixtures — the wifi suite reads these as {{TEST_SSID_*}}. On a
+          # self-hosted-runner checkout there is no .env, so the fixtures must come from
+          # repo secrets here. Unset secrets are empty (harmless for suites that don't
+          # use them, e.g. smoke). Locally, .env supplies these instead.
+          TEST_SSID_OPEN: ${{ secrets.TEST_SSID_OPEN }}
+          TEST_SSID_WPA2: ${{ secrets.TEST_SSID_WPA2 }}
+          TEST_SSID_WPA2_PASSWORD: ${{ secrets.TEST_SSID_WPA2_PASSWORD }}
+          TEST_SSID_WPA3: ${{ secrets.TEST_SSID_WPA3 }}
+          TEST_SSID_WPA3_PASSWORD: ${{ secrets.TEST_SSID_WPA3_PASSWORD }}
           # Judge mode + agent auth (STORY-003). In 'dual', tests marked `judge: agent`
           # also run the ACP agent judge; if the token/agent is absent it degrades to
           # deterministic verdicts (never a mass failure).

--- a/.github/workflows/test-wifi.yml
+++ b/.github/workflows/test-wifi.yml
@@ -6,8 +6,8 @@ name: "Test: WiFi"
 #
 # Lab setup on the self-hosted runner:
 #   - repo variable  WIFI_LAB = true                 (arms this workflow)
-#   - repo secrets   TEST_SSID_WPA2 / _PASSWORD, TEST_SSID_OPEN, TEST_DEVICE_SERIAL,
-#                    CLAUDE_CODE_OAUTH_TOKEN         (test data + agent-judge auth)
+#   - repo secrets   TEST_SSID_OPEN, TEST_SSID_WPA2 / _PASSWORD, TEST_SSID_WPA3 / _PASSWORD,
+#                    TEST_DEVICE_SERIAL, CLAUDE_CODE_OAUTH_TOKEN   (test data + agent-judge auth)
 # Locally, `make test SUITE=wifi` (with TEST_SSID_* exported) stays the first-class path.
 
 on:

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,8 +12,13 @@ import { closePool } from './db/pool.js';
 
 const log = logger.child({ component: 'server' });
 
-const deviceManager = new DeviceManager();
-const deviceObserver = new DeviceObserver(process.env.ADB_PATH);
+// Empty string (e.g. an unset CI secret injected as ADB_PATH="") must fall back to
+// the default 'adb': a default parameter only applies to `undefined`, and spawn("")
+// throws "argument 'file' cannot be empty", crashing the server on startup. Apply the
+// resolved path to both the observer and tool calls so ADB_PATH is honored consistently.
+const adbPath = process.env.ADB_PATH || undefined;
+const deviceManager = new DeviceManager(adbPath);
+const deviceObserver = new DeviceObserver(adbPath);
 deviceManager.setObserver(deviceObserver);
 const upstreamProxy = new UpstreamProxy();
 const { server: mcpServer, nativeToolNames } = createMcpServer(deviceManager, upstreamProxy);


### PR DESCRIPTION
## Summary
- **fix(server) #161:** `new DeviceObserver(process.env.ADB_PATH)` crashed the server at startup when `ADB_PATH` was an **empty string** — a default param only defaults `undefined`, so `spawn("")` threw *"argument 'file' cannot be empty"*. Resolve `ADB_PATH || undefined` and apply it to both the `DeviceManager` and the observer (so `ADB_PATH` is honored consistently). This is what an unset `ADB_PATH` secret (injected as `""`) did to the self-hosted runner — every tool call failed (0/7).
- **ci(wifi) #152:** `test-run.yml` now injects `TEST_SSID_OPEN`/`WPA2`(+pw)/`WPA3`(+pw) from repo secrets into the test env (previously only `TEST_DEVICE_SERIAL`/`ADB_PATH`), so the wifi suite gets its fixtures on a fresh runner checkout (no `.env`). `test-wifi.yml`'s documented secrets list updated.

Fixes #161
Part of #152 (code half; the lab-owner steps — repo secrets set, open/OWE permanence — remain)

## Test plan
- [x] `ADB_PATH="" mcp-client wifi_status` → crash before, valid status after
- [x] **Real GitHub Actions run on the self-hosted runner: wifi suite 7/7 green** (run 28634718814)
- [x] Local wifi suite 7/7; `.env` value stays gitignored

Generated with [Claude Code](https://claude.com/claude-code)