### PR TITLE
Add TC-WIFI-006 WPA3 connect test (exercises the WPA3 fixture)

### DIFF
--- a/cicd/tests/testcases/wifi/TC-WIFI-006.yml
+++ b/cicd/tests/testcases/wifi/TC-WIFI-006.yml
@@ -1,0 +1,33 @@
+id: TC-WIFI-006
+name: wifi_connect to WPA3 means associated, not just accepted
+suite: wifi
+tags: [wifi, connect]
+priority: 6
+timeout: 90000
+# Connect outcome is non-deterministic (association may still be settling); let the
+# agent judge grade "actually associated to the target SSID" in dual mode.
+judge: agent
+
+steps:
+  - name: Connect to the WPA3 (SAE) test network
+    command: npx tsx cicd/tests/src/mcp-client.ts wifi_connect '{"ssid":"{{TEST_SSID_WPA3}}","security":"wpa3","password":"{{TEST_SSID_WPA3_PASSWORD}}"}'
+    expectPatterns:
+      - "success.*true"
+      - "{{TEST_SSID_WPA3}}"
+    rejectPatterns:
+      - "isError"
+  - name: Confirm association out of band
+    command: npx tsx cicd/tests/src/mcp-client.ts wifi_status '{}'
+    expectPatterns:
+      - "connected.*true"
+      - "{{TEST_SSID_WPA3}}"
+    rejectPatterns:
+      - "isError"
+
+criteria: |
+  A reported success from wifi_connect (security wpa3 → SAE) means the device is actually
+  associated to the target SSID — confirmed independently via wifi_status (connected true,
+  matching SSID), not assumed from "configuration accepted". The network added here is
+  forgotten by the runner's snapshot/restore after the test. Needs TEST_SSID_WPA3(+_PASSWORD)
+  and a real WPA3 AP. TEST_SSID_* must not contain regex metacharacters or dots (used
+  verbatim in patterns).


### PR DESCRIPTION
## Summary
- Adds `TC-WIFI-006` — a WPA3/SAE connect test mirroring `TC-WIFI-002` (WPA2): `wifi_connect security=wpa3` to `{{TEST_SSID_WPA3}}`, then confirms association out of band via `wifi_status`.
- Closes the orphan-fixture gap: `TEST_SSID_WPA3` was wired into `.env` + CI secrets (#152) but no test used it.

Part of #152

## Test plan
- [x] Local: `TC-WIFI-006` passes; full wifi suite 8/8
- [x] **Real GitHub Actions run on the self-hosted runner: wifi suite 8/8 green** (run 28637370891) — including the new WPA3 test
- [x] Uses the full unique SSID → no prefix-collision (unlike #155)

Generated with [Claude Code](https://claude.com/claude-code)