### PR TITLE
Add setup/teardown/requires to the test-case schema + loader (#166)

### DIFF
--- a/.claude/rules/test-yaml-format.md
+++ b/.claude/rules/test-yaml-format.md
@@ -20,6 +20,13 @@ dependencies: [TC-WIFI-002]        # tests that must run first (topo-sorted)
 judge: simple                      # optional: 'simple' (default) or 'agent' (see below)
 goal: One-line objective for the agent judge (optional)
 
+requires:                          # optional precondition — case SKIPS if unmet
+  ssidInRange: "{{TEST_SSID_WPA2}}"  #   the SSID must be scan-confirmed in range
+
+setup:                             # optional — steps run BEFORE `steps` (same shape)
+  - name: Bring device to a known-clean state
+    command: ...
+
 steps:
   - name: Step description
     command: shell command to execute       # usually mcp-client.ts <tool> '<json>'
@@ -31,9 +38,30 @@ steps:
     capture:                       # extract values from the tool's JSON output
       varName: "field[key=value].subfield"
 
+teardown:                          # optional — steps run AFTER `steps`, ALWAYS (even on failure)
+  - name: Remove what this case created
+    command: ...
+
 criteria: |
   Human-readable pass criteria (also the agent judge's rubric context).
 ```
+
+## Lifecycle phases (STORY-005)
+
+A case runs as `requires → setup → steps → teardown → (framework restore)`:
+
+- `requires` — a precondition checked before anything runs. `ssidInRange: "<SSID>"`
+  makes the runner scan and confirm the SSID is present; if it isn't, the case is
+  **skipped** (green) rather than failing deep in a step.
+- `setup` — step-array run before `steps` to bring the device to a known-clean starting
+  state (so a case doesn't inherit baseline or another case's residue).
+- `teardown` — step-array run after `steps`, **always** — even when a step failed — to
+  remove exactly what the case created and return the device to its pre-test state.
+
+`setup`/`teardown` are the same shape as `steps` and get `{{VAR}}` substitution. Use them
+so each case is **self-contained**: it prepares its own state and cleans up after itself,
+independent of run order or baseline. (Framework `snapshot`/`restore` still runs around
+every case as a backstop; the phases are the case's own explicit control.)
 
 ## Judge style (STORY-003)
 

--- a/cicd/tests/src/loader.ts
+++ b/cicd/tests/src/loader.ts
@@ -7,7 +7,7 @@ import { readFileSync } from 'fs';
 import { glob } from 'glob';
 import yaml from 'js-yaml';
 import path from 'path';
-import { TestCase, TestStep } from './types.js';
+import { TestCase, TestStep, TestRequires } from './types.js';
 import { SUITES, CONFIG } from './config.js';
 
 /** Normalize a testcase's `judge` field. 'agent' opts into the agent judge; 'simple'
@@ -165,25 +165,35 @@ export class TestLoader {
       return null;
     }
 
-    const steps: TestStep[] = [];
-    for (const step of raw.steps) {
-      if (!step.name || typeof step.name !== 'string') {
-        console.error(`${filePath}: step missing 'name' field`);
-        return null;
-      }
-      if (!step.command || typeof step.command !== 'string') {
-        console.error(`${filePath}: step '${step.name}' missing 'command' field`);
-        return null;
-      }
+    // `steps` (required, non-empty) plus optional `setup`/`teardown` phases — all
+    // step-arrays, validated the same way so setup/teardown behave exactly like steps.
+    const steps = this.normalizeSteps(raw.steps, filePath, 'steps');
+    if (!steps) return null;
 
-      steps.push({
-        name: step.name,
-        command: step.command,
-        timeout: typeof step.timeout === 'number' ? step.timeout : undefined,
-        expectPatterns: Array.isArray(step.expectPatterns) ? step.expectPatterns : undefined,
-        rejectPatterns: Array.isArray(step.rejectPatterns) ? step.rejectPatterns : undefined,
-        capture: typeof step.capture === 'object' && step.capture !== null ? step.capture : undefined,
-      });
+    let setup: TestStep[] | undefined;
+    if (raw.setup !== undefined) {
+      const parsed = this.normalizeSteps(raw.setup, filePath, 'setup');
+      if (!parsed) return null;
+      setup = parsed;
+    }
+
+    let teardown: TestStep[] | undefined;
+    if (raw.teardown !== undefined) {
+      const parsed = this.normalizeSteps(raw.teardown, filePath, 'teardown');
+      if (!parsed) return null;
+      teardown = parsed;
+    }
+
+    let requires: TestRequires | undefined;
+    if (raw.requires !== undefined) {
+      if (typeof raw.requires !== 'object' || raw.requires === null || Array.isArray(raw.requires)) {
+        console.error(`${filePath}: 'requires' must be an object`);
+        return null;
+      }
+      const r = raw.requires as Record<string, unknown>;
+      requires = {
+        ssidInRange: typeof r.ssidInRange === 'string' ? r.ssidInRange : undefined,
+      };
     }
 
     return {
@@ -194,9 +204,47 @@ export class TestLoader {
       priority: typeof raw.priority === 'number' ? raw.priority : 1,
       timeout: typeof raw.timeout === 'number' ? raw.timeout : CONFIG.defaultTimeout,
       dependencies: Array.isArray(raw.dependencies) ? raw.dependencies : [],
+      requires,
+      setup,
       steps,
+      teardown,
       criteria: typeof raw.criteria === 'string' ? raw.criteria : '',
+      goal: typeof raw.goal === 'string' ? raw.goal : undefined,
       judge: normalizeJudge(raw.judge),
     };
+  }
+
+  /** Validate + normalize a step-array (used for `steps`, `setup`, and `teardown`).
+   *  Returns null on the first invalid step so the caller can bail. `label` names the
+   *  phase in error messages. */
+  private normalizeSteps(
+    raw: unknown,
+    filePath: string,
+    label: string
+  ): TestStep[] | null {
+    if (!Array.isArray(raw)) {
+      console.error(`${filePath}: '${label}' must be an array`);
+      return null;
+    }
+    const steps: TestStep[] = [];
+    for (const step of raw as Array<Record<string, unknown>>) {
+      if (!step.name || typeof step.name !== 'string') {
+        console.error(`${filePath}: ${label} step missing 'name' field`);
+        return null;
+      }
+      if (!step.command || typeof step.command !== 'string') {
+        console.error(`${filePath}: ${label} step '${step.name}' missing 'command' field`);
+        return null;
+      }
+      steps.push({
+        name: step.name,
+        command: step.command,
+        timeout: typeof step.timeout === 'number' ? step.timeout : undefined,
+        expectPatterns: Array.isArray(step.expectPatterns) ? (step.expectPatterns as string[]) : undefined,
+        rejectPatterns: Array.isArray(step.rejectPatterns) ? (step.rejectPatterns as string[]) : undefined,
+        capture: typeof step.capture === 'object' && step.capture !== null ? (step.capture as Record<string, string>) : undefined,
+      });
+    }
+    return steps;
   }
 }

--- a/cicd/tests/src/types.ts
+++ b/cicd/tests/src/types.ts
@@ -11,6 +11,13 @@ export interface TestStep {
   capture?: Record<string, string>;
 }
 
+/** A precondition a case needs before it runs. Checked before setup; when unmet the
+ *  case skips (green) rather than failing deep in a step. Extend as new kinds appear. */
+export interface TestRequires {
+  /** SSID that must be in range (scan-confirmed) before the case runs. */
+  ssidInRange?: string;
+}
+
 export interface TestCase {
   id: string;
   name: string;
@@ -19,7 +26,15 @@ export interface TestCase {
   priority: number;
   timeout: number;
   dependencies: string[];
+  /** Precondition checked before `setup` — unmet → the case is skipped. */
+  requires?: TestRequires;
+  /** Steps run before `steps` to bring the device to a known-clean starting state.
+   *  Same shape as `steps`, run through the same substitute→execute path. */
+  setup?: TestStep[];
   steps: TestStep[];
+  /** Steps run after `steps` — ALWAYS, even after a failed step — to remove what the
+   *  case created and return the device to its pre-test state. */
+  teardown?: TestStep[];
   criteria: string;
   goal?: string;
   /** Judge style (STORY-003 #125). 'simple' (default) = deterministic checks only —


### PR DESCRIPTION
## Summary
- Add lifecycle vocabulary to a test case: `setup` / `teardown` (step-arrays, same shape as `steps`) and `requires` (a precondition, `ssidInRange`).
- Wire them into **both** `TestCase` (`types.ts`) and the loader's `validateAndNormalize` (`loader.ts`) via a shared `normalizeSteps` helper, so setup/teardown validate exactly like steps.
- Fix the flagged pre-existing `goal` drop (typed but silently dropped by the loader) — behavior-safe: no case uses `goal:`, and the agent judge falls back to `name`.
- Document the `requires → setup → steps → teardown` lifecycle in `test-yaml-format.md`.

The executor that *runs* these phases is #167; this is schema + loader + docs only (additive, inert until then).

Fixes #166 · Part of #165 (STORY-005)

## Test plan
- [x] Valid case with all three phases parses (requires/setup/teardown captured); malformed `requires` rejected with a clear message
- [x] `tsc --noEmit` clean
- [x] All 32 cases still parse; smoke 17/17, wifi 8/8 green (no regression)

Generated with [Claude Code](https://claude.com/claude-code)