### PR TITLE
clearSavedNetworks with a shared/dedicated boundary + device-cli (#168)

### DIFF
--- a/cicd/tests/src/device-cli.ts
+++ b/cicd/tests/src/device-cli.ts
@@ -1,0 +1,27 @@
+#!/usr/bin/env npx tsx
+/**
+ * Small device CLI for a case's `setup`/`teardown` steps. Those steps are shell
+ * commands, so they can't call device-state helpers directly — this exposes them.
+ *
+ *   npx tsx cicd/tests/src/device-cli.ts clear-networks [--all] [SSID ...]
+ *
+ * `clear-networks` forgets saved networks. With SSIDs it forgets only those (safe on a
+ * shared phone); with `--all` it wipes every saved network but requires
+ * TEST_DEVICE_SERIAL's phone to be declared dedicated (TEST_DEDICATED_DEVICE=true).
+ */
+import { clearSavedNetworks } from './device-state.js';
+
+const [command, ...rest] = process.argv.slice(2);
+
+if (command === 'clear-networks') {
+  const all = rest.includes('--all');
+  const ssids = rest.filter((a) => !a.startsWith('--'));
+  const n = await clearSavedNetworks({ all, ssids });
+  const what = all ? 'all' : ssids.length ? `matching: ${ssids.join(', ')}` : 'none listed';
+  console.log(`cleared ${n} saved network(s) (${what})`);
+} else {
+  console.error(
+    `Unknown command: ${command || '(none)'}\nUsage: device-cli.ts clear-networks [--all] [SSID ...]`
+  );
+  process.exit(1);
+}

--- a/cicd/tests/src/device-state.ts
+++ b/cicd/tests/src/device-state.ts
@@ -52,6 +52,67 @@ export async function ensureSsidInRange(ssid: string, settleMs = 4000): Promise<
   }
 }
 
+/**
+ * Forget saved networks — the "clear config" primitive for a case's `setup`/`teardown`.
+ * Boundary so a shared phone is never wiped: `all` requires `TEST_DEDICATED_DEVICE=true`;
+ * otherwise only networks whose SSID is in `ssids` (the caller's explicit allowlist) are
+ * forgotten — an unlisted (personal) network is never touched. Returns how many were
+ * forgotten.
+ */
+export async function clearSavedNetworks(opts: { ssids?: string[]; all?: boolean }): Promise<number> {
+  const dedicated = /^(1|true|yes)$/i.test(process.env.TEST_DEDICATED_DEVICE || '');
+  const saved = await listSavedNetworks();
+
+  let targets: Array<{ id: number; ssid: string }>;
+  if (opts.all) {
+    if (!dedicated) {
+      throw new Error(
+        'clearSavedNetworks({ all: true }) refused: set TEST_DEDICATED_DEVICE=true to wipe all saved networks (guards a shared phone).'
+      );
+    }
+    targets = saved;
+  } else {
+    const allow = new Set(opts.ssids ?? []);
+    targets = saved.filter((n) => allow.has(n.ssid));
+  }
+
+  const forgotten = new Set<number>();
+  for (const n of targets) {
+    if (forgotten.has(n.id)) continue;
+    try {
+      await adbShell(`cmd wifi forget-network ${n.id}`);
+      forgotten.add(n.id);
+    } catch {
+      // best-effort — a missing id is not fatal
+    }
+  }
+  return forgotten.size;
+}
+
+/** Saved networks as {id, ssid}. Parses `cmd wifi list-networks` where the SSID column
+ *  may contain spaces (id is the first token, security the last, SSID everything between);
+ *  dedupes the per-security-param duplicate rows by id. */
+async function listSavedNetworks(): Promise<Array<{ id: number; ssid: string }>> {
+  try {
+    const output = await adbShell('cmd wifi list-networks');
+    const nets: Array<{ id: number; ssid: string }> = [];
+    const seen = new Set<number>();
+    for (const line of output.split('\n')) {
+      const t = line.trim();
+      if (!t || t.startsWith('Network Id')) continue;
+      const m = t.match(/^(\d+)\s+(.+?)\s+\S+$/);
+      if (!m) continue;
+      const id = parseInt(m[1], 10);
+      if (seen.has(id)) continue;
+      seen.add(id);
+      nets.push({ id, ssid: m[2].trim() });
+    }
+    return nets;
+  } catch {
+    return [];
+  }
+}
+
 export async function snapshotDeviceState(): Promise<DeviceSnapshot> {
   const statusOut = await adbShell('cmd wifi status');
   const wifiEnabled = /wifi is enabled/i.test(statusOut);


### PR DESCRIPTION
## Summary
- `clearSavedNetworks({ssids | all})` in device-state — the "clear config" primitive for `setup`/`teardown`. Boundary so a shared phone is never wiped: `all` requires `TEST_DEDICATED_DEVICE=true`; otherwise only networks whose SSID is in the explicit allowlist are forgotten (an unlisted/personal network is never touched).
- `device-cli.ts` (`clear-networks [--all] [SSID …]`) so a case's setup/teardown shell step can invoke it (steps are shell commands).
- Parses `list-networks` handling SSIDs-with-spaces + dedupes per-security rows.

`ensureSsidInRange` already landed with #167. Adopting these in real cases is #169.

Fixes #168 · Part of #165 (STORY-005)

## Test plan
- [x] Allowlist: `clear-networks "open-test"` forgot only open-test — personal `home`/`WhenWiredCry` untouched
- [x] `--all` without `TEST_DEDICATED_DEVICE` → refused with a clear error, nothing wiped
- [x] Purely additive (snapshot/restore unchanged); smoke 17/17; `tsc` clean

Generated with [Claude Code](https://claude.com/claude-code)