### PR TITLE
Adopt requires/setup/teardown so cases are self-contained (#169)

### DIFF
--- a/cicd/tests/src/executor.ts
+++ b/cicd/tests/src/executor.ts
@@ -315,23 +315,30 @@ export class TestExecutor {
 
     // --- requires: precondition gate. Unmet → skip (green), don't fail deep in a step.
     if (testCase.requires?.ssidInRange) {
-      const ssid = this.substituteVariables(testCase.requires.ssidInRange);
-      const inRange = await ensureSsidInRange(ssid);
-      if (!inRange) {
-        this.progress(`    [SKIP] requires: SSID "${ssid}" not in range`);
-        if (snapshot) {
-          await restoreDeviceState(snapshot).catch(() => {});
-        }
+      const skip = (reason: string): TestResult => {
+        this.progress(`    [SKIP] requires: ${reason}`);
         this.currentTestId = null;
         return {
           testCase,
           steps: [],
           totalDuration: Date.now() - startTime,
-          logs: `SKIPPED: requires ssidInRange "${ssid}" not in range`,
+          logs: `SKIPPED: requires ${reason}`,
           logFile: '',
           skipped: true,
-          skipReason: `ssidInRange "${ssid}" not in range`,
+          skipReason: reason,
         };
+      };
+      let ssid: string;
+      try {
+        ssid = this.substituteVariables(testCase.requires.ssidInRange);
+      } catch (e) {
+        // Precondition references an unset fixture — skip (green), don't crash the run.
+        if (snapshot) await restoreDeviceState(snapshot).catch(() => {});
+        return skip((e as Error).message);
+      }
+      if (!(await ensureSsidInRange(ssid))) {
+        if (snapshot) await restoreDeviceState(snapshot).catch(() => {});
+        return skip(`ssidInRange "${ssid}" not in range`);
       }
     }
 

--- a/cicd/tests/testcases/enterprise/TC-ENT-001.yml
+++ b/cicd/tests/testcases/enterprise/TC-ENT-001.yml
@@ -1,0 +1,74 @@
+id: TC-ENT-001
+name: wifi_connect_enterprise (EAP-TLS) associates, then wifi_disconnect_enterprise tears it down
+suite: enterprise
+tags: [enterprise, connect, disconnect]
+priority: 1
+timeout: 180000
+# The connect outcome is non-deterministic (association settles); the agent judge grades
+# "actually associated to the 802.1X SSID" in dual mode. The deterministic checks always run.
+judge: agent
+
+# Only run when the 802.1X AP is actually on the air — otherwise skip (green), don't fail.
+requires:
+  ssidInRange: "{{TEST_SSID_ENTERPRISE}}"
+
+# Self-contained setup: a WifiNetworkSuggestion (how wifi_connect_enterprise connects)
+# ranks BELOW user-saved networks, so an in-range saved competitor makes the device roam
+# off the 802.1X network right after it associates (#164). Forget the test networks that
+# would out-rank it so the suggestion wins. Only the listed (test) SSIDs are touched —
+# personal networks are safe (see clearSavedNetworks' boundary). The wifi suite re-creates
+# these when it runs.
+setup:
+  - name: Clear competing saved test networks so the enterprise suggestion wins auto-join
+    command: npx tsx cicd/tests/src/device-cli.ts clear-networks "{{TEST_SSID_OPEN}}" "{{TEST_SSID_WPA2}}" "{{TEST_SSID_WPA3}}"
+
+steps:
+  - name: Connect to the 802.1X network via EAP-TLS
+    # jq builds the args so the multi-line PEM fixtures escape correctly. The CA is the
+    # self-signed server root (not the served fullchain) — see the enterprise-certs skill.
+    command: |
+      args=$(jq -nc \
+        --arg ssid "$TEST_SSID_ENTERPRISE" \
+        --arg id "$TEST_EAP_IDENTITY" \
+        --arg dom "$TEST_EAP_DOMAIN" \
+        --arg cc "$TEST_EAP_CLIENT_CERT" \
+        --arg pk "$TEST_EAP_PRIVATE_KEY" \
+        --arg ca "$TEST_EAP_CA_CERT" \
+        '{ssid:$ssid, eapMethod:"tls", identity:$id, domainSuffixMatch:$dom, clientCertificate:$cc, privateKey:$pk, caCertificate:$ca, verifyTimeoutMs:45000}')
+      npx tsx cicd/tests/src/mcp-client.ts wifi_connect_enterprise "$args"
+    expectPatterns:
+      - "success.*true"
+      - "Connected to enterprise"
+    rejectPatterns:
+      - "isError"
+      - "Not a CA certificate"
+      - "unknown_ca"
+  - name: Confirm association out of band
+    command: npx tsx cicd/tests/src/mcp-client.ts wifi_status '{}'
+    expectPatterns:
+      - "connected.*true"
+      - "{{TEST_SSID_ENTERPRISE}}"
+    rejectPatterns:
+      - "isError"
+  - name: Disconnect — wifi_disconnect_enterprise removes the suggestion
+    command: |
+      npx tsx cicd/tests/src/mcp-client.ts wifi_disconnect_enterprise "$(jq -nc --arg ssid "$TEST_SSID_ENTERPRISE" '{ssid:$ssid}')"
+    expectPatterns:
+      - "success.*true"
+    rejectPatterns:
+      - "isError"
+
+# Always leave no enterprise suggestion behind, even if a step above failed mid-way.
+teardown:
+  - name: Ensure the enterprise suggestion is removed
+    command: |
+      npx tsx cicd/tests/src/mcp-client.ts wifi_disconnect_enterprise "$(jq -nc --arg ssid "$TEST_SSID_ENTERPRISE" '{ssid:$ssid}')" || true
+
+criteria: |
+  Covers wifi_connect_enterprise AND wifi_disconnect_enterprise end to end, self-contained:
+  EAP-TLS connect actually associates to the 802.1X SSID (confirmed out of band via
+  wifi_status), then disconnect removes the suggestion. `setup` clears the in-range test
+  networks that would otherwise out-rank the suggestion and cause a roam-off (#164);
+  `requires` skips cleanly when the AP is off the air. Preconditions: companion app
+  installed + its suggestion approval granted once, and TEST_SSID_ENTERPRISE / TEST_EAP_*
+  fixtures (see the android-wifi-mcp-enterprise-certs skill).

--- a/cicd/tests/testcases/smoke/TC-SMK-003.yml
+++ b/cicd/tests/testcases/smoke/TC-SMK-003.yml
@@ -6,6 +6,15 @@ priority: 3
 timeout: 30000
 dependencies: []
 
+# Self-contained: establish our own connection rather than assuming the device is already
+# on WiFi (a baseline dependence — STORY-005). Skip cleanly if the open AP isn't on the air.
+requires:
+  ssidInRange: "{{TEST_SSID_OPEN}}"
+
+setup:
+  - name: Connect to the open network so status has a connection to report
+    command: npx tsx cicd/tests/src/mcp-client.ts wifi_connect '{"ssid":"{{TEST_SSID_OPEN}}","security":"open"}'
+
 steps:
   - name: Get current WiFi status
     command: npx tsx cicd/tests/src/mcp-client.ts wifi_status '{}'
@@ -17,8 +26,10 @@ steps:
       - "isError"
 
 criteria: |
-  Verify wifi_status reports the device is on WiFi.
+  Verify wifi_status reports the device is on WiFi — self-contained.
+  - `setup` connects to the open test network so the check doesn't depend on a
+    pre-existing baseline connection (which another suite, e.g. enterprise, may have
+    cleared); `requires` skips cleanly if the AP is off the air.
   - Tool returns successfully without errors
   - enabled is true and connected is true
   - An ssid field is present
-  - Smoke runner expects the test device to already be on a WiFi network

--- a/cicd/tests/testcases/smoke/TC-SMK-006.yml
+++ b/cicd/tests/testcases/smoke/TC-SMK-006.yml
@@ -6,6 +6,15 @@ priority: 6
 timeout: 60000
 dependencies: []
 
+# Self-contained: connect to the open network so there's a live connection to check, rather
+# than assuming a baseline connection (STORY-005). Skip cleanly if the AP is off the air.
+requires:
+  ssidInRange: "{{TEST_SSID_OPEN}}"
+
+setup:
+  - name: Connect to the open network to establish connectivity
+    command: npx tsx cicd/tests/src/mcp-client.ts wifi_connect '{"ssid":"{{TEST_SSID_OPEN}}","security":"open"}'
+
 steps:
   - name: Check internet connectivity
     command: npx tsx cicd/tests/src/mcp-client.ts network_check_internet '{}'

--- a/cicd/tests/testcases/smoke/TC-SMK-007.yml
+++ b/cicd/tests/testcases/smoke/TC-SMK-007.yml
@@ -6,6 +6,15 @@ priority: 7
 timeout: 30000
 dependencies: []
 
+# Self-contained: connect to the open network so there's connectivity to report, rather
+# than assuming a baseline connection (STORY-005). Skip cleanly if the AP is off the air.
+requires:
+  ssidInRange: "{{TEST_SSID_OPEN}}"
+
+setup:
+  - name: Connect to the open network to establish connectivity
+    command: npx tsx cicd/tests/src/mcp-client.ts wifi_connect '{"ssid":"{{TEST_SSID_OPEN}}","security":"open"}'
+
 steps:
   - name: Get WiFi interface info
     command: npx tsx cicd/tests/src/mcp-client.ts network_interface_info '{}'

--- a/cicd/tests/testcases/smoke/TC-SMK-015.yml
+++ b/cicd/tests/testcases/smoke/TC-SMK-015.yml
@@ -6,6 +6,15 @@ priority: 15
 timeout: 30000
 dependencies: []
 
+# Self-contained: connect to the open network so there's connectivity to resolve against,
+# rather than assuming a baseline connection (STORY-005). Skip cleanly if the AP is off the air.
+requires:
+  ssidInRange: "{{TEST_SSID_OPEN}}"
+
+setup:
+  - name: Connect to the open network to establish connectivity
+    command: npx tsx cicd/tests/src/mcp-client.ts wifi_connect '{"ssid":"{{TEST_SSID_OPEN}}","security":"open"}'
+
 steps:
   - name: Resolve a known-resolvable hostname
     command: npx tsx cicd/tests/src/mcp-client.ts network_dns_lookup '{"hostname":"example.com"}'

--- a/cicd/tests/testcases/smoke/TC-SMK-016.yml
+++ b/cicd/tests/testcases/smoke/TC-SMK-016.yml
@@ -6,6 +6,15 @@ priority: 16
 timeout: 30000
 dependencies: []
 
+# Self-contained: connect to the open network so there's connectivity to ping over, rather
+# than assuming a baseline connection (STORY-005). Skip cleanly if the AP is off the air.
+requires:
+  ssidInRange: "{{TEST_SSID_OPEN}}"
+
+setup:
+  - name: Connect to the open network to establish connectivity
+    command: npx tsx cicd/tests/src/mcp-client.ts wifi_connect '{"ssid":"{{TEST_SSID_OPEN}}","security":"open"}'
+
 steps:
   - name: Ping a known-reachable host
     command: npx tsx cicd/tests/src/mcp-client.ts network_ping '{"host":"8.8.8.8","count":3}'

--- a/cicd/tests/testcases/wifi/TC-WIFI-002.yml
+++ b/cicd/tests/testcases/wifi/TC-WIFI-002.yml
@@ -9,6 +9,10 @@ dependencies: []
 # agent judge grade "actually associated to the target SSID" in dual mode.
 judge: agent
 
+# Skip cleanly (green) if the WPA2 AP isn't on the air, instead of failing the connect.
+requires:
+  ssidInRange: "{{TEST_SSID_WPA2}}"
+
 steps:
   - name: Connect to the WPA2 test network
     command: npx tsx cicd/tests/src/mcp-client.ts wifi_connect '{"ssid":"{{TEST_SSID_WPA2}}","security":"wpa2","password":"{{TEST_SSID_WPA2_PASSWORD}}"}'

--- a/cicd/tests/testcases/wifi/TC-WIFI-003.yml
+++ b/cicd/tests/testcases/wifi/TC-WIFI-003.yml
@@ -8,6 +8,10 @@ dependencies: []
 # Connect outcome is non-deterministic; agent judge grades real association in dual mode.
 judge: agent
 
+# Skip cleanly (green) if the open AP isn't on the air, instead of failing the connect.
+requires:
+  ssidInRange: "{{TEST_SSID_OPEN}}"
+
 steps:
   - name: Connect to the open test network
     command: npx tsx cicd/tests/src/mcp-client.ts wifi_connect '{"ssid":"{{TEST_SSID_OPEN}}","security":"open"}'

--- a/cicd/tests/testcases/wifi/TC-WIFI-006.yml
+++ b/cicd/tests/testcases/wifi/TC-WIFI-006.yml
@@ -8,6 +8,10 @@ timeout: 90000
 # agent judge grade "actually associated to the target SSID" in dual mode.
 judge: agent
 
+# Skip cleanly (green) if the WPA3 AP isn't on the air, instead of failing the connect.
+requires:
+  ssidInRange: "{{TEST_SSID_WPA3}}"
+
 steps:
   - name: Connect to the WPA3 (SAE) test network
     command: npx tsx cicd/tests/src/mcp-client.ts wifi_connect '{"ssid":"{{TEST_SSID_WPA3}}","security":"wpa3","password":"{{TEST_SSID_WPA3_PASSWORD}}"}'


### PR DESCRIPTION
## Summary
The payoff of STORY-005 — real cases prepare and clean up their own state, independent of baseline or run order.

- **Enterprise** (`TC-ENT-001`, new, self-contained): covers `wifi_connect_enterprise` + `wifi_disconnect_enterprise`. `setup` clears the in-range test networks that out-rank the suggestion (the #164 roam-off), `requires` skips when the AP is off the air, `teardown` removes the suggestion. Connect now **holds** — reliable back-to-back.
- **Wifi** (TC-WIFI-002/003/006): `requires: ssidInRange` → skip cleanly if the AP is down.
- **Smoke** (TC-SMK-003/006/007/015/016): `requires` + `setup` connect-first, removing the baseline-connection assumption a sibling suite (enterprise) can clear.
- **Executor**: guard the `requires` substitution — an unset fixture skips (green) instead of crashing the run.

Fixes #169 · Part of #165 (STORY-005) · closes the test side of #164

## Test plan
- [x] Order-independent: enterprise (clears baseline, leaves disconnected) → smoke **17/17** → wifi **8/8**
- [x] Enterprise reliable back-to-back (2/2)
- [x] All 33 cases parse; `tsc` clean

## Note
Smoke connectivity tests are no longer strictly zero-config — without the open AP they skip (green). Intended tradeoff of the self-contained approach.

Generated with [Claude Code](https://claude.com/claude-code)