### PR TITLE
ci: gated enterprise (EAP-TLS) suite workflow

### DIFF
--- a/.github/workflows/test-enterprise.yml
+++ b/.github/workflows/test-enterprise.yml
@@ -1,0 +1,46 @@
+name: "Test: Enterprise (EAP-TLS)"
+
+# The enterprise suite connects to a real 802.1X (WPA2/3-Enterprise) network via the
+# companion app's WifiNetworkSuggestion, so it needs a lab RADIUS-backed AP + EAP-TLS
+# fixtures AND a one-time manual grant on the runner phone. It is NOT part of the default
+# CI (ci.yml runs smoke); run it explicitly, and it self-skips unless the lab is armed.
+#
+# Lab setup on the self-hosted runner:
+#   - repo variable  ENTERPRISE_LAB = true            (arms this workflow)
+#   - repo secrets   TEST_SSID_ENTERPRISE, TEST_EAP_IDENTITY, TEST_EAP_DOMAIN,
+#                    TEST_EAP_CLIENT_CERT, TEST_EAP_PRIVATE_KEY, TEST_EAP_CA_CERT,
+#                    TEST_DEVICE_SERIAL, CLAUDE_CODE_OAUTH_TOKEN
+#   - phone precondition: the companion app installed and its network-suggestion approval
+#     granted ONCE in the Android UI (CI cannot click it); without it the connect fails.
+# Locally, `make test SUITE=enterprise` (with TEST_EAP_* from .env) stays the first-class
+# path. See the android-wifi-mcp-enterprise-certs skill for the cert anchoring (the CA must
+# be the self-signed server root, not the served fullchain).
+
+on:
+  workflow_dispatch:
+    inputs:
+      judge_mode:
+        description: 'Judge mode (dual runs the agent judge on the connect e2e)'
+        required: false
+        default: 'dual'
+        type: choice
+        options:
+          - dual
+          - simple
+  workflow_call:
+    inputs:
+      judge_mode:
+        required: false
+        default: 'dual'
+        type: string
+
+jobs:
+  test:
+    # Skip cleanly (green, not failed) unless the enterprise lab is armed — no AP/certs/
+    # phone approval → no run.
+    if: ${{ vars.ENTERPRISE_LAB == 'true' }}
+    uses: ./.github/workflows/test-run.yml
+    with:
+      tag: enterprise
+      judge_mode: ${{ inputs.judge_mode || 'dual' }}
+    secrets: inherit

--- a/.github/workflows/test-run.yml
+++ b/.github/workflows/test-run.yml
@@ -45,6 +45,16 @@ jobs:
           TEST_SSID_WPA2_PASSWORD: ${{ secrets.TEST_SSID_WPA2_PASSWORD }}
           TEST_SSID_WPA3: ${{ secrets.TEST_SSID_WPA3 }}
           TEST_SSID_WPA3_PASSWORD: ${{ secrets.TEST_SSID_WPA3_PASSWORD }}
+          # Enterprise EAP-TLS fixtures — the enterprise suite reads these ({{TEST_SSID_ENTERPRISE}}
+          # + $TEST_EAP_* in the jq-built connect args). The certs are multi-line PEMs stored as
+          # secrets. Absent → the enterprise cases skip (requires ssidInRange) or fail cleanly;
+          # other suites ignore them. Locally, .env supplies these instead.
+          TEST_SSID_ENTERPRISE: ${{ secrets.TEST_SSID_ENTERPRISE }}
+          TEST_EAP_IDENTITY: ${{ secrets.TEST_EAP_IDENTITY }}
+          TEST_EAP_DOMAIN: ${{ secrets.TEST_EAP_DOMAIN }}
+          TEST_EAP_CLIENT_CERT: ${{ secrets.TEST_EAP_CLIENT_CERT }}
+          TEST_EAP_PRIVATE_KEY: ${{ secrets.TEST_EAP_PRIVATE_KEY }}
+          TEST_EAP_CA_CERT: ${{ secrets.TEST_EAP_CA_CERT }}
           # Judge mode + agent auth (STORY-003). In 'dual', tests marked `judge: agent`
           # also run the ACP agent judge; if the token/agent is absent it degrades to
           # deterministic verdicts (never a mass failure).


### PR DESCRIPTION
## Summary
Wire the enterprise suite into CI so it *can* run in the pipeline, mirroring `test-wifi.yml`:
- **`test-enterprise.yml`** (new): thin caller → reusable runner with `tag: enterprise`, gated on `vars.ENTERPRISE_LAB` so it **skips cleanly** (green) until the lab is armed.
- **`test-run.yml`**: injects `TEST_SSID_ENTERPRISE` + `TEST_EAP_*` from secrets (absent → enterprise cases skip via `requires` or fail cleanly; other suites ignore them).

Follows STORY-005 — enables CI for the now-reliable enterprise connect (#164).

## Dormant until three manual prerequisites (documented in the workflow header)
This PR is **code only — no secrets published**. To arm it:
1. Repo variable `ENTERPRISE_LAB = true`
2. Repo secrets: `TEST_SSID_ENTERPRISE`, `TEST_EAP_IDENTITY`, `TEST_EAP_DOMAIN`, `TEST_EAP_CLIENT_CERT`, `TEST_EAP_PRIVATE_KEY`, `TEST_EAP_CA_CERT`
3. Companion app's network-suggestion approval granted once on the runner phone (CI can't click it)

## Test plan
- [x] Both workflow YAMLs parse
- [x] Gated (`if: vars.ENTERPRISE_LAB == 'true'`) → no-op until armed; matches the `test-wifi.yml` pattern
- Enterprise cases already verified locally (STORY-005 #169): enterprise 2/2, order-independent with smoke 17/17 + wifi 8/8

Generated with [Claude Code](https://claude.com/claude-code)