### PR TITLE
ci: drop the WIFI_LAB/ENTERPRISE_LAB job gates

### DIFF
--- a/.claude/rules/workflow-patterns.md
+++ b/.claude/rules/workflow-patterns.md
@@ -33,9 +33,11 @@ NOT apply to a bare `workflow_dispatch`, so forward with a fallback:
 exposes a `simple`/`dual` choice and passes it through (`ci.yml` → `test-<suite>.yml` →
 `test-run.yml`). In `dual`, only cases marked `judge: agent` pay for the agent judge.
 
-**Lab gating:** suites that need real hardware (e.g. `wifi`) must not run on a runner
-that lacks it. Gate the job on a repo variable — `if: ${{ vars.WIFI_LAB == 'true' }}` —
-so it **skips cleanly** (green, not failed) until the lab is armed. See `test-wifi.yml`.
+**Lab suites:** suites that need real hardware (e.g. `wifi`, `enterprise`) are manual
+(`workflow_dispatch`) — you run them only on a runner that has the lab. No job-level
+gate: individual cases self-skip (green) via `requires: ssidInRange` when their AP or
+fixture is absent (STORY-005), which is finer-grained than an all-or-nothing job gate
+and avoids a whole-suite silent-skip. See `test-wifi.yml`.
 
 ## Environment (repository Variables / Secrets → Actions)
 

--- a/.github/workflows/test-enterprise.yml
+++ b/.github/workflows/test-enterprise.yml
@@ -3,10 +3,10 @@ name: "Test: Enterprise (EAP-TLS)"
 # The enterprise suite connects to a real 802.1X (WPA2/3-Enterprise) network via the
 # companion app's WifiNetworkSuggestion, so it needs a lab RADIUS-backed AP + EAP-TLS
 # fixtures AND a one-time manual grant on the runner phone. It is NOT part of the default
-# CI (ci.yml runs smoke); run it explicitly, and it self-skips unless the lab is armed.
+# CI; run it explicitly on a runner that has the lab. The single case self-skips (green)
+# when its AP or fixtures are absent (requires: ssidInRange), so no job-level gate is needed.
 #
 # Lab setup on the self-hosted runner:
-#   - repo variable  ENTERPRISE_LAB = true            (arms this workflow)
 #   - repo secrets   TEST_SSID_ENTERPRISE, TEST_EAP_IDENTITY, TEST_EAP_DOMAIN,
 #                    TEST_EAP_CLIENT_CERT, TEST_EAP_PRIVATE_KEY, TEST_EAP_CA_CERT,
 #                    TEST_DEVICE_SERIAL, CLAUDE_CODE_OAUTH_TOKEN
@@ -36,9 +36,6 @@ on:
 
 jobs:
   test:
-    # Skip cleanly (green, not failed) unless the enterprise lab is armed — no AP/certs/
-    # phone approval → no run.
-    if: ${{ vars.ENTERPRISE_LAB == 'true' }}
     uses: ./.github/workflows/test-run.yml
     with:
       tag: enterprise

--- a/.github/workflows/test-wifi.yml
+++ b/.github/workflows/test-wifi.yml
@@ -1,11 +1,11 @@
 name: "Test: WiFi"
 
 # The wifi suite mutates the radio and connects to real networks, so it needs a lab
-# access point + credentials. It is NOT part of the default CI (ci.yml runs smoke); run
-# it explicitly, and it self-skips unless the lab is marked ready.
+# access point + credentials. It is NOT part of the default CI; run it explicitly on a
+# runner that has the lab. Individual cases self-skip (green) when their AP or fixture is
+# absent (requires: ssidInRange), so no job-level gate is needed.
 #
 # Lab setup on the self-hosted runner:
-#   - repo variable  WIFI_LAB = true                 (arms this workflow)
 #   - repo secrets   TEST_SSID_OPEN, TEST_SSID_WPA2 / _PASSWORD, TEST_SSID_WPA3 / _PASSWORD,
 #                    TEST_DEVICE_SERIAL, CLAUDE_CODE_OAUTH_TOKEN   (test data + agent-judge auth)
 # Locally, `make test SUITE=wifi` (with TEST_SSID_* exported) stays the first-class path.
@@ -30,8 +30,6 @@ on:
 
 jobs:
   test:
-    # Skip cleanly (green, not failed) unless the lab is armed — no device/secrets → no run.
-    if: ${{ vars.WIFI_LAB == 'true' }}
     uses: ./.github/workflows/test-run.yml
     with:
       tag: wifi


### PR DESCRIPTION
Manual workflows + STORY-005 per-case `requires` make the job-level lab gate redundant (and it silently skipped a whole suite green). Remove both `if: vars.*_LAB` gates; cases self-skip individually via `requires: ssidInRange`. Doc updated. Retiring the `WIFI_LAB` variable after merge.

Generated with [Claude Code](https://claude.com/claude-code)