### PR TITLE
Don't truncate comma-containing SSIDs in getStatus (#112)

### DIFF
--- a/src/adb/wifi-commands.ts
+++ b/src/adb/wifi-commands.ts
@@ -384,12 +384,14 @@ export class WifiCommands {
 
     const stateConnected = dumpsys.includes('state: COMPLETED') || dumpsys.includes('CONNECTED');
 
-    // Extract SSID. `<unknown ssid>` is the framework's placeholder when
-    // there's no real association (or location-permission gate); treat
-    // it the same as `<none>` and leave status.ssid undefined.
-    const ssidMatch = dumpsys.match(/SSID:\s*["']?([^"',\n]+)["']?/i);
+    // Extract SSID. dumpsys renders a real SSID quoted (`SSID: "Name",`) and the
+    // no-association placeholder unquoted (`SSID: <unknown ssid>,`). The quoted branch
+    // captures everything up to the closing quote so a comma INSIDE the SSID isn't
+    // truncated (#112); the unquoted branch stops at the delimiting comma for the
+    // `<none>`/`<unknown ssid>` placeholders, which we then drop.
+    const ssidMatch = dumpsys.match(/SSID:\s*(?:"([^"\n]+)"|([^",\n]+))/i);
     if (ssidMatch) {
-      const raw = ssidMatch[1].trim();
+      const raw = (ssidMatch[1] ?? ssidMatch[2]).trim();
       if (raw !== '<none>' && raw !== '<unknown ssid>') {
         status.ssid = raw;
       }


### PR DESCRIPTION
## Summary
The SSID regex `/SSID:\s*["']?([^"',\n]+)["']?/` excluded `,` from the capture, so a quoted dumpsys SSID like `SSID: "Corp,Net"` truncated to `Corp` — and `connect()`'s `status.ssid === target` exact-match then never recognized a real association to a comma-containing SSID (false "did not associate").

Fix: match a **quoted branch** (comma allowed up to the closing quote) OR an **unquoted branch** (stops at the delimiting comma, for `<none>`/`<unknown ssid>`):
`/SSID:\s*(?:"([^"\n]+)"|([^",\n]+))/i`, picking `m[1] ?? m[2]`.

Traced live: dumpsys renders a real SSID quoted + comma-delimited (`SSID: "Wednesday", BSSID: …`).

## Test plan
- [x] Regex handles `Wednesday` / `"Corp,Net"` / `<unknown ssid>` / `<none>`
- [x] Live `getStatus()` against a connected device parses the SSID with no regression
- [x] Server `tsc` builds clean
- No unit test — the repo has no unit-test runner; verified empirically (per decision).

Closes #112

Generated with [Claude Code](https://claude.com/claude-code)