### PR TITLE
Consolidate 3 shell-quote helpers into one util (#87)

### DIFF
--- a/src/adb/settings-commands.ts
+++ b/src/adb/settings-commands.ts
@@ -1,4 +1,5 @@
 import { AdbClient } from './adb-client.js';
+import { shQuote } from './shell-quote.js';
 
 export type SettingsNamespace = 'system' | 'secure' | 'global';
 
@@ -41,7 +42,7 @@ export class SettingsCommands {
   }
 
   async get(namespace: SettingsNamespace, key: string): Promise<SettingsGetResult> {
-    const result = await this.adb.shell(`settings get ${namespace} ${shellQuote(key)}`);
+    const result = await this.adb.shell(`settings get ${namespace} ${shQuote(key)}`);
     if (!result.success) {
       return {
         namespace,
@@ -58,7 +59,7 @@ export class SettingsCommands {
 
   async put(namespace: SettingsNamespace, key: string, value: string): Promise<SettingsPutResult> {
     const result = await this.adb.shell(
-      `settings put ${namespace} ${shellQuote(key)} ${shellQuote(value)}`
+      `settings put ${namespace} ${shQuote(key)} ${shQuote(value)}`
     );
     if (!result.success) {
       return {
@@ -73,7 +74,7 @@ export class SettingsCommands {
   }
 
   async delete(namespace: SettingsNamespace, key: string): Promise<SettingsDeleteResult> {
-    const result = await this.adb.shell(`settings delete ${namespace} ${shellQuote(key)}`);
+    const result = await this.adb.shell(`settings delete ${namespace} ${shQuote(key)}`);
     if (!result.success) {
       return {
         namespace,
@@ -84,10 +85,4 @@ export class SettingsCommands {
     }
     return { namespace, key, success: true };
   }
-}
-
-function shellQuote(s: string): string {
-  // Single-quote and escape any embedded single quotes. Safe for both host
-  // execFile (no host shell) and the device shell that adb forwards to.
-  return `'${s.replace(/'/g, "'\\''")}'`;
 }

--- a/src/adb/shell-quote.ts
+++ b/src/adb/shell-quote.ts
@@ -1,0 +1,12 @@
+/**
+ * POSIX single-quote a string for safe interpolation into a device-shell command that
+ * `adb shell` forwards. Wraps the value in single quotes and escapes any embedded single
+ * quote as `'\''` (close-quote, escaped-quote, re-open) — the standard shell idiom.
+ *
+ * Extracted so the escape lives in ONE place (#87): it was copy-pasted as `shellQuote`
+ * (settings), `sq` (wifi), and `shQuote` (network) — an escaping bug would have needed
+ * fixing in three files.
+ */
+export function shQuote(s: string): string {
+  return `'${s.replace(/'/g, "'\\''")}'`;
+}

--- a/src/adb/wifi-commands.ts
+++ b/src/adb/wifi-commands.ts
@@ -1,4 +1,5 @@
 import { AdbClient } from './adb-client.js';
+import { shQuote } from './shell-quote.js';
 import { parseRouteGet } from '../network/network-check.js';
 import {
   ScanResult,
@@ -195,10 +196,9 @@ export class WifiCommands {
     // takes the bare SSID; the framework adds wpa_supplicant's on-disk
     // quoting itself. Wrapping with literal `"..."` here would persist
     // those characters as part of the SSID and break association.
-    const sq = (s: string) => `'${s.replace(/'/g, `'\\''`)}'`;
-    let command = `cmd wifi connect-network ${sq(ssid)} ${security}`;
+    let command = `cmd wifi connect-network ${shQuote(ssid)} ${security}`;
     if (password && security !== 'open') {
-      command += ` ${sq(password)}`;
+      command += ` ${shQuote(password)}`;
     }
 
     const result = await this.adb.shell(command);

--- a/src/network/network-check.ts
+++ b/src/network/network-check.ts
@@ -1,4 +1,5 @@
 import { AdbClient } from '../adb/adb-client.js';
+import { shQuote } from '../adb/shell-quote.js';
 import {
   PingResult,
   DnsResult,
@@ -217,13 +218,6 @@ export class NetworkCheck {
   }
 }
 
-/**
- * Single-quote a string for safe interpolation into a device `adb shell`
- * command (the host side uses execFile, but the device runs the string in sh).
- */
-function shQuote(s: string): string {
-  return `'${s.replace(/'/g, "'\\''")}'`;
-}
 
 /**
  * Find the `NetworkAgentInfo` line for the device's Wi-Fi network in


### PR DESCRIPTION
## Summary
The POSIX single-quote escape was copy-pasted 3× (`shellQuote`/`sq`/`shQuote` in settings/wifi/network). Extracted one `shQuote` into `src/adb/shell-quote.ts`; all three import it. Byte-identical logic — pure refactor, no behavior change.

## Test plan
- [x] No dangling refs; `tsc` clean
- [x] All 3 call sites exercised: smoke 17/17 (settings + ping), wifi 8/8 (connect)

Closes #87

Generated with [Claude Code](https://claude.com/claude-code)