### PR TITLE
WPA3-Enterprise support via securityType (#72)

### DIFF
--- a/.github/workflows/test-run.yml
+++ b/.github/workflows/test-run.yml
@@ -50,6 +50,7 @@ jobs:
           # secrets. Absent → the enterprise cases skip (requires ssidInRange) or fail cleanly;
           # other suites ignore them. Locally, .env supplies these instead.
           TEST_SSID_ENTERPRISE: ${{ secrets.TEST_SSID_ENTERPRISE }}
+          TEST_SSID_ENTERPRISE_WPA3: ${{ secrets.TEST_SSID_ENTERPRISE_WPA3 }}
           TEST_EAP_IDENTITY: ${{ secrets.TEST_EAP_IDENTITY }}
           TEST_EAP_DOMAIN: ${{ secrets.TEST_EAP_DOMAIN }}
           TEST_EAP_CLIENT_CERT: ${{ secrets.TEST_EAP_CLIENT_CERT }}

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ adb install app/build/outputs/apk/debug/app-debug.apk
 # open the app once; for notification OTPs, tap "Grant Notification Access"
 ```
 
-Then `wifi_connect_enterprise` (PEAP/TTLS/TLS) and `notifications_wait_for_otp` work; `wifi_check_companion_app` reports install + grant status. SMS OTPs (`sms_*`) need no app, but `content://sms/inbox` is locked down on some Samsung/OEM builds — fall back to notification capture there.
+Then `wifi_connect_enterprise` (PEAP/TTLS/TLS; WPA2- or WPA3-Enterprise via `securityType`) and `notifications_wait_for_otp` work; `wifi_check_companion_app` reports install + grant status. SMS OTPs (`sms_*`) need no app, but `content://sms/inbox` is locked down on some Samsung/OEM builds — fall back to notification capture there.
 
 ## Structured logging (optional, Postgres)
 

--- a/cicd/tests/testcases/enterprise/TC-ENT-002.yml
+++ b/cicd/tests/testcases/enterprise/TC-ENT-002.yml
@@ -1,0 +1,66 @@
+id: TC-ENT-002
+name: wifi_connect_enterprise WPA3-Enterprise (securityType wpa3-eap) associates, then disconnects
+suite: enterprise
+tags: [enterprise, connect, disconnect, wpa3]
+priority: 2
+timeout: 180000
+# Non-deterministic association; agent judge grades "actually on the WPA3-Enterprise SSID".
+judge: agent
+
+# Only run when the WPA3-Enterprise AP is on the air — otherwise skip (green).
+requires:
+  ssidInRange: "{{TEST_SSID_ENTERPRISE_WPA3}}"
+
+# Same self-contained setup as TC-ENT-001: forget the in-range saved test networks so the
+# suggestion (which ranks below saved networks, #164) wins auto-join.
+setup:
+  - name: Clear competing saved test networks so the enterprise suggestion wins auto-join
+    command: npx tsx cicd/tests/src/device-cli.ts clear-networks "{{TEST_SSID_OPEN}}" "{{TEST_SSID_WPA2}}" "{{TEST_SSID_WPA3}}"
+
+steps:
+  - name: Connect to the WPA3-Enterprise network via EAP-TLS (securityType wpa3-eap)
+    # Identical to TC-ENT-001 but adds securityType:"wpa3-eap" — the companion selects
+    # WifiNetworkSuggestion.Builder.setWpa3EnterpriseStandardModeConfig (#72).
+    command: |
+      args=$(jq -nc \
+        --arg ssid "$TEST_SSID_ENTERPRISE_WPA3" \
+        --arg id "$TEST_EAP_IDENTITY" \
+        --arg dom "$TEST_EAP_DOMAIN" \
+        --arg cc "$TEST_EAP_CLIENT_CERT" \
+        --arg pk "$TEST_EAP_PRIVATE_KEY" \
+        --arg ca "$TEST_EAP_CA_CERT" \
+        '{ssid:$ssid, securityType:"wpa3-eap", eapMethod:"tls", identity:$id, domainSuffixMatch:$dom, clientCertificate:$cc, privateKey:$pk, caCertificate:$ca, verifyTimeoutMs:45000}')
+      npx tsx cicd/tests/src/mcp-client.ts wifi_connect_enterprise "$args"
+    expectPatterns:
+      - "success.*true"
+      - "Connected to enterprise"
+    rejectPatterns:
+      - "isError"
+      - "Not a CA certificate"
+      - "unknown_ca"
+  - name: Confirm association out of band
+    command: npx tsx cicd/tests/src/mcp-client.ts wifi_status '{}'
+    expectPatterns:
+      - "connected.*true"
+      - "{{TEST_SSID_ENTERPRISE_WPA3}}"
+    rejectPatterns:
+      - "isError"
+  - name: Disconnect — wifi_disconnect_enterprise removes the suggestion
+    command: |
+      npx tsx cicd/tests/src/mcp-client.ts wifi_disconnect_enterprise "$(jq -nc --arg ssid "$TEST_SSID_ENTERPRISE_WPA3" '{ssid:$ssid}')"
+    expectPatterns:
+      - "success.*true"
+    rejectPatterns:
+      - "isError"
+
+teardown:
+  - name: Ensure the enterprise suggestion is removed
+    command: |
+      npx tsx cicd/tests/src/mcp-client.ts wifi_disconnect_enterprise "$(jq -nc --arg ssid "$TEST_SSID_ENTERPRISE_WPA3" '{ssid:$ssid}')" || true
+
+criteria: |
+  Covers WPA3-Enterprise (securityType wpa3-eap) end to end: the EAP-TLS connect actually
+  associates to the WPA3-Enterprise SSID (confirmed out of band via wifi_status), then
+  disconnect removes the suggestion. Same #164 setup-clear and `requires` skip as TC-ENT-001.
+  Preconditions: companion app installed + suggestion approval granted, a WPA3-Enterprise AP,
+  and TEST_SSID_ENTERPRISE_WPA3 / TEST_EAP_* fixtures.

--- a/companion-app/app/build.gradle.kts
+++ b/companion-app/app/build.gradle.kts
@@ -11,8 +11,8 @@ android {
         applicationId = "com.example.wifimcpcompanion"
         minSdk = 30  // Android 11+ required for enterprise WiFi
         targetSdk = 34
-        versionCode = 3
-        versionName = "1.2.0"  // full-chain CA + disconnect/forget; drop non-functional TOFU
+        versionCode = 4
+        versionName = "1.3.0"  // WPA3-Enterprise support (securityType: wpa2-eap/wpa3-eap/wpa3-eap-192)
     }
 
     buildTypes {

--- a/companion-app/app/src/main/kotlin/com/example/wifimcpcompanion/AdbBridgeReceiver.kt
+++ b/companion-app/app/src/main/kotlin/com/example/wifimcpcompanion/AdbBridgeReceiver.kt
@@ -72,6 +72,7 @@ class AdbBridgeReceiver : BroadcastReceiver() {
         val clientCertificate = config.optString("clientCertificate", null)
         val privateKey = config.optString("privateKey", null)
         val privateKeyPassword = config.optString("privateKeyPassword", null)
+        val securityType = config.optString("securityType", "wpa2-eap")
 
         val wifiManager = WifiEnterpriseManager(context)
 
@@ -83,7 +84,8 @@ class AdbBridgeReceiver : BroadcastReceiver() {
                 domain = domainSuffixMatch,
                 caCertPem = caCertificate,
                 anonymousIdentity = anonymousIdentity,
-                phase2Method = wifiManager.getPhase2Method(phase2Method)
+                phase2Method = wifiManager.getPhase2Method(phase2Method),
+                securityType = securityType
             )
             "ttls" -> wifiManager.connectTtls(
                 ssid = ssid,
@@ -92,7 +94,8 @@ class AdbBridgeReceiver : BroadcastReceiver() {
                 domain = domainSuffixMatch,
                 caCertPem = caCertificate,
                 anonymousIdentity = anonymousIdentity,
-                phase2Method = wifiManager.getPhase2Method(phase2Method)
+                phase2Method = wifiManager.getPhase2Method(phase2Method),
+                securityType = securityType
             )
             "tls" -> {
                 if (clientCertificate == null || privateKey == null) {
@@ -111,7 +114,8 @@ class AdbBridgeReceiver : BroadcastReceiver() {
                     clientCertPem = clientCertificate,
                     privateKeyPem = privateKey,
                     privateKeyPassword = privateKeyPassword,
-                    caCertPem = caCertificate
+                    caCertPem = caCertificate,
+                    securityType = securityType
                 )
             }
             else -> {

--- a/companion-app/app/src/main/kotlin/com/example/wifimcpcompanion/WifiEnterpriseManager.kt
+++ b/companion-app/app/src/main/kotlin/com/example/wifimcpcompanion/WifiEnterpriseManager.kt
@@ -45,7 +45,8 @@ class WifiEnterpriseManager(private val context: Context) {
         domain: String,
         caCertPem: String? = null,
         anonymousIdentity: String? = null,
-        phase2Method: Int = WifiEnterpriseConfig.Phase2.MSCHAPV2
+        phase2Method: Int = WifiEnterpriseConfig.Phase2.MSCHAPV2,
+        securityType: String = "wpa2-eap"
     ): ConnectionResult {
         return try {
             val enterpriseConfig = WifiEnterpriseConfig().apply {
@@ -58,7 +59,7 @@ class WifiEnterpriseManager(private val context: Context) {
                 applyServerValidation(domain, caCertPem)
             }
 
-            addNetworkSuggestion(ssid, enterpriseConfig, "peap")
+            addNetworkSuggestion(ssid, enterpriseConfig, "peap", securityType)
         } catch (e: Exception) {
             Log.e(TAG, "PEAP connection failed", e)
             ConnectionResult(
@@ -80,7 +81,8 @@ class WifiEnterpriseManager(private val context: Context) {
         domain: String,
         caCertPem: String? = null,
         anonymousIdentity: String? = null,
-        phase2Method: Int = WifiEnterpriseConfig.Phase2.MSCHAPV2
+        phase2Method: Int = WifiEnterpriseConfig.Phase2.MSCHAPV2,
+        securityType: String = "wpa2-eap"
     ): ConnectionResult {
         return try {
             val enterpriseConfig = WifiEnterpriseConfig().apply {
@@ -93,7 +95,7 @@ class WifiEnterpriseManager(private val context: Context) {
                 applyServerValidation(domain, caCertPem)
             }
 
-            addNetworkSuggestion(ssid, enterpriseConfig, "ttls")
+            addNetworkSuggestion(ssid, enterpriseConfig, "ttls", securityType)
         } catch (e: Exception) {
             Log.e(TAG, "TTLS connection failed", e)
             ConnectionResult(
@@ -115,7 +117,8 @@ class WifiEnterpriseManager(private val context: Context) {
         clientCertPem: String,
         privateKeyPem: String,
         privateKeyPassword: String? = null,
-        caCertPem: String? = null
+        caCertPem: String? = null,
+        securityType: String = "wpa2-eap"
     ): ConnectionResult {
         return try {
             val clientCert = parseCertificate(clientCertPem)
@@ -131,7 +134,7 @@ class WifiEnterpriseManager(private val context: Context) {
                 applyServerValidation(domain, caCertPem)
             }
 
-            addNetworkSuggestion(ssid, enterpriseConfig, "tls")
+            addNetworkSuggestion(ssid, enterpriseConfig, "tls", securityType)
         } catch (e: Exception) {
             Log.e(TAG, "TLS connection failed", e)
             ConnectionResult(
@@ -176,20 +179,36 @@ class WifiEnterpriseManager(private val context: Context) {
     /**
      * Add network suggestion using WifiNetworkSuggestion API
      */
+    // setWpa3EnterpriseConfig is deprecated in API 33; used here only as the API 30-32
+    // fallback for standard WPA3-Enterprise, so suppress the warning for this function.
+    @Suppress("DEPRECATION")
     private fun addNetworkSuggestion(
         ssid: String,
         enterpriseConfig: WifiEnterpriseConfig,
-        eapMethod: String
+        eapMethod: String,
+        securityType: String
     ): ConnectionResult {
         // Clear any prior suggestion first — the app holds one enterprise network
         // at a time, and a stale one would compete during the next auto-join.
         clearAllSuggestions()
 
-        val suggestion = WifiNetworkSuggestion.Builder()
+        // Select the WPA enterprise security suite (#72). Default/unknown → WPA2-Enterprise,
+        // preserving prior behaviour. Standard WPA3-Enterprise uses the API-33 setter, falling
+        // back to the deprecated API-30 one below that; 192-bit / suite-B is API 30 (our minSdk).
+        val builder = WifiNetworkSuggestion.Builder()
             .setSsid(ssid)
-            .setWpa2EnterpriseConfig(enterpriseConfig)
             .setIsAppInteractionRequired(false)
-            .build()
+        when (securityType) {
+            "wpa3-eap" ->
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    builder.setWpa3EnterpriseStandardModeConfig(enterpriseConfig)
+                } else {
+                    builder.setWpa3EnterpriseConfig(enterpriseConfig)
+                }
+            "wpa3-eap-192" -> builder.setWpa3Enterprise192BitModeConfig(enterpriseConfig)
+            else -> builder.setWpa2EnterpriseConfig(enterpriseConfig)
+        }
+        val suggestion = builder.build()
 
         val status = wifiManager.addNetworkSuggestions(listOf(suggestion))
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,7 +5,7 @@ import { NetworkCheck } from './network/network-check.js';
 import { EnterpriseWifiCommands } from './adb/enterprise-wifi.js';
 import { UpstreamProxy } from './mcp/upstream-proxy.js';
 import { runQuery, KNOWN_CLASSIFICATIONS } from './log/query.js';
-import { SecurityType, EapMethod, Phase2Method } from './types.js';
+import { SecurityType, EapMethod, Phase2Method, EapSecurityType } from './types.js';
 
 export interface CreateServerResult {
   server: McpServer;
@@ -541,6 +541,11 @@ export function createMcpServer(
     {
       ssid: z.string().describe('Network SSID'),
       eapMethod: z.enum(['peap', 'ttls', 'tls']).describe('EAP method'),
+      securityType: z
+        .enum(['wpa2-eap', 'wpa3-eap', 'wpa3-eap-192'])
+        .optional()
+        .default('wpa2-eap')
+        .describe('WPA enterprise security: wpa2-eap (default), wpa3-eap (WPA3-Enterprise), or wpa3-eap-192 (WPA3-Enterprise 192-bit / suite-B — requires EAP-TLS).'),
       identity: z.string().describe('Username or email for authentication'),
       domainSuffixMatch: z.string().optional().describe('RADIUS server domain to match (e.g. radius.corp.com). Optional when caCertificate is set.'),
       phase2Method: z
@@ -564,6 +569,7 @@ export function createMcpServer(
       const result = await enterpriseWifi.connectEnterprise({
         ssid: params.ssid,
         eapMethod: params.eapMethod as EapMethod,
+        securityType: params.securityType as EapSecurityType,
         phase2Method: params.phase2Method as Phase2Method,
         identity: params.identity,
         password: params.password,

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,10 +58,14 @@ export interface WifiConnectionResult {
 // EAP Types (for 802.1X enterprise WiFi via companion app)
 export type EapMethod = 'peap' | 'ttls' | 'tls';
 export type Phase2Method = 'mschapv2' | 'pap' | 'gtc' | 'none';
+// WPA enterprise security suite. Default wpa2-eap preserves existing behaviour;
+// wpa3-eap-192 (suite-B) requires EAP-TLS.
+export type EapSecurityType = 'wpa2-eap' | 'wpa3-eap' | 'wpa3-eap-192';
 
 export interface EapConfig {
   ssid: string;
   eapMethod: EapMethod;
+  securityType?: EapSecurityType;    // WPA2-Enterprise (default) / WPA3-Enterprise / WPA3-Ent 192-bit
   phase2Method?: Phase2Method;       // Required for PEAP/TTLS
   identity: string;                  // Username/email
   password?: string;                 // For PEAP/TTLS


### PR DESCRIPTION
## Summary
`wifi_connect_enterprise` hardcoded WPA2-Enterprise, so a WPA3-Enterprise-only SSID wouldn't associate. Add a `securityType` enum (default `wpa2-eap` — preserves every existing caller) threaded schema → `EapConfig` → companion, branching the one hardcoded builder call:
- `wpa2-eap` → `setWpa2EnterpriseConfig` (unchanged)
- `wpa3-eap` → `setWpa3EnterpriseStandardModeConfig` (API 33), else `setWpa3EnterpriseConfig` (API 30)
- `wpa3-eap-192` → `setWpa3Enterprise192BitModeConfig` (suite-B, API 30)

Companion → v1.3.0 (versionCode 4). Added TC-ENT-002 (WPA3-Ent connect+disconnect) + `TEST_SSID_ENTERPRISE_WPA3` fixture (CI secret + test-run.yml) + README note.

## Test plan
- [x] **Live on a real WPA3-Enterprise AP** (`Wednesday - wpa3 802.1x`): EAP-TLS connect → `success:true` "Connected to enterprise WiFi successfully", held (verify poll confirmed the SSID)
- [x] Harness `TC-ENT-002` PASS (WPA3-Ent); WPA2-Ent unchanged (default → same `else` branch, CI-green earlier)
- [x] Server `tsc` + companion Kotlin both build clean

Closes #72

Generated with [Claude Code](https://claude.com/claude-code)