### PR TITLE
qa: backfill the traceability chain surfaced by #181

### DIFF
--- a/docs/tests/STORY-001/TS-08-proxy-composition.md
+++ b/docs/tests/STORY-001/TS-08-proxy-composition.md
@@ -1,0 +1,40 @@
+---
+id: TS-08
+title: The proxy composes upstream MCP servers into one namespace
+namespace: remote-stack
+story: STORY-001
+plan: 95
+issue: 94
+status: green
+---
+
+# TS-08: The proxy composes upstream MCP servers into one namespace
+
+**Objective:** The unified proxy exposes the *other* MCP servers' tools through one
+namespace — so a remote client reaching `android-wifi` also reaches `android-playwright`
+and `mobile-next` — and can respawn a crashed upstream without losing the composition.
+This is the mechanism behind STORY-001's "reach the whole MCP stack."
+
+## TC-01 — an upstream tool is reachable through the unified namespace
+
+**Script:** cicd/tests/testcases/proxy/TC-PROXY-001.yml
+
+| Action | Expected Result |
+|---|---|
+| Call a mock upstream's tool through the proxy | The proxy routes the call and returns the upstream's result — the tool appears in the unified namespace |
+
+## TC-02 — a real @playwright/mcp tool works through the proxy
+
+**Script:** cicd/tests/testcases/proxy/TC-PROXY-002.yml
+
+| Action | Expected Result |
+|---|---|
+| Invoke `browser_navigate` (from @playwright/mcp) via the proxy against a host browser | The browser navigates — the browser server is driven through the same namespace as `android-wifi` |
+
+## TC-03 — proxy_restart respawns an upstream and re-registers its tools
+
+**Script:** cicd/tests/testcases/proxy/TC-PROXY-003.yml
+
+| Action | Expected Result |
+|---|---|
+| Call an upstream tool, `proxy_restart` it, then call it again | The tool works before and after — restart tears down and respawns the upstream and re-registers its tools cleanly |

--- a/docs/tests/STORY-002/TS-05-no-regression.md
+++ b/docs/tests/STORY-002/TS-05-no-regression.md
@@ -12,14 +12,18 @@ status: green
 **Objective:** Today's WPA2-Enterprise path keeps working unchanged — the new
 verification and validation options don't break the flows that already work.
 
-## TC-01 — existing WPA2-Enterprise connect (to-be)
+## TC-01 — existing WPA2-Enterprise connect
+
+**Script:** cicd/tests/testcases/enterprise/TC-ENT-001.yml
 
 | Action | Expected Result |
 |---|---|
-| Connect to a WPA2-Enterprise SSID via PEAP/TTLS/TLS with a CA and a domain (the current flow) | The device associates as it does today — no new requirement or failure introduced |
+| Connect to a WPA2-Enterprise SSID via EAP-TLS with a CA and a domain (the current flow), then disconnect | The device associates as it does today — no new requirement or failure introduced — and disconnect tears it down cleanly |
 
-## TC-02 — companion-app status check (to-be)
+## TC-02 — companion-app status check
+
+**Script:** cicd/tests/testcases/notifications/TC-NOTIF-005.yml
 
 | Action | Expected Result |
 |---|---|
-| Query the companion-app presence and notification-access status | It reports install + grant state correctly, as before |
+| Query the companion-app presence via `wifi_check_companion_app` | It reports install + grant state correctly, as before |

--- a/docs/tests/STORY-004/TS-01-connect-verify-cleanup.md
+++ b/docs/tests/STORY-004/TS-01-connect-verify-cleanup.md
@@ -14,8 +14,9 @@ status: green
 associated** to the target SSID — confirmed independently, not assumed from "config
 accepted" — and the test leaves the device in its original state.
 
-TC-01 and TC-03 are bound and run green against a lab AP (proven with `TEST_SSID_WPA2`).
-TC-02 (failed connect) and TC-04 (cleanup, a runner mechanism) have no single script yet — **(to-be)**.
+TC-01/03/05/06 are bound and run green against a lab AP (WPA2, open, and WPA3/SAE security
+types). TC-02 (failed connect) and TC-04 (cleanup, a runner mechanism) have no single
+script yet — **(to-be)**.
 
 ## TC-01 — success means associated
 
@@ -44,3 +45,19 @@ TC-02 (failed connect) and TC-04 (cleanup, a runner mechanism) have no single sc
 | Action | Expected Result |
 |---|---|
 | After the test completes (pass or fail) | The network added during the test is forgotten and the prior WiFi enabled-state is restored — no residue for the next test |
+
+## TC-05 — an open network connect means associated
+
+**Script:** cicd/tests/testcases/wifi/TC-WIFI-003.yml
+
+| Action | Expected Result |
+|---|---|
+| Connect to an open (no-password) SSID | The result reports the device **associated** to that SSID, confirmed out of band via `wifi_status` |
+
+## TC-06 — a WPA3 (SAE) connect means associated
+
+**Script:** cicd/tests/testcases/wifi/TC-WIFI-006.yml
+
+| Action | Expected Result |
+|---|---|
+| Connect to a WPA3/SAE SSID with the correct password | The result reports the device **associated** (SAE), confirmed out of band — not merely "configuration accepted" |

--- a/docs/tests/STORY-004/TS-03-network-diagnostics.md
+++ b/docs/tests/STORY-004/TS-03-network-diagnostics.md
@@ -10,13 +10,13 @@ status: green
 
 # TS-03: Network diagnostics reach a real host
 
-**Objective:** The diagnostic tools (`network_dns_lookup`, `network_ping`) return a
-real result for a real target — a resolved address, a reachable host — not just a
-well-shaped empty response.
+**Objective:** The network tools (`network_dns_lookup`, `network_ping`,
+`network_check_internet`, `network_interface_info`, `network_check_captive`) return a
+real result for real conditions — a resolved address, a reachable host, a live IP, a
+truthful internet/captive verdict — not just a well-shaped empty response.
 
-TC-01 and TC-03 ship as `TC-SMK-015`/`TC-SMK-016` in the smoke suite and run wherever
-the device has internet (targets are hardcoded public hosts — `example.com`, `8.8.8.8`).
-TC-02 is **(to-be)** — no binding yet.
+TC-01/03/04/05/06 are bound and run wherever the device has connectivity. TC-02 is
+**(to-be)** — no binding yet.
 
 ## TC-01 — dns lookup resolves a hostname
 
@@ -39,3 +39,27 @@ TC-02 is **(to-be)** — no binding yet.
 | Action | Expected Result |
 |---|---|
 | Ping a known-reachable host | The result reports the host reachable (`alive` true) |
+
+## TC-04 — internet check reports a truthful verdict
+
+**Script:** cicd/tests/testcases/smoke/TC-SMK-006.yml
+
+| Action | Expected Result |
+|---|---|
+| Check internet connectivity while online | `network_check_internet` reports `hasInternet: true` |
+
+## TC-05 — interface info returns a live IP
+
+**Script:** cicd/tests/testcases/smoke/TC-SMK-007.yml
+
+| Action | Expected Result |
+|---|---|
+| Read the WiFi interface info while connected | `network_interface_info` returns a real (non-empty) IP address |
+
+## TC-06 — captive check returns an Android-sourced verdict
+
+**Script:** cicd/tests/testcases/smoke/TC-SMK-014.yml
+
+| Action | Expected Result |
+|---|---|
+| Check captive-portal status | `network_check_captive` returns a tri-state verdict (`open`/`captive`/`unknown`) from Android's own connectivity check |

--- a/docs/tests/STORY-004/TS-04-inspection-and-management-tools.md
+++ b/docs/tests/STORY-004/TS-04-inspection-and-management-tools.md
@@ -1,0 +1,92 @@
+---
+id: TS-04
+title: Inspection and management tools return real results
+namespace: device
+story: STORY-004
+plan: 120
+issue: 128
+status: green
+---
+
+# TS-04: Inspection and management tools return real results
+
+**Objective:** The read/inspect/manage tools on the device surface (`device_list`,
+`device_settings_*`, `device_push_file`/`device_pull_file`, `device_screenshot`,
+`device_event_log`, `device_select`, `wifi_status`, `wifi_scan`) return a **real
+result reflecting real device state** — a listed device, a round-tripped setting, a
+byte-equal file, a saved PNG — not a well-shaped empty response, and their failure
+paths surface clean structured errors.
+
+All cases are bound and run green in the smoke suite against an attached device.
+
+## TC-01 — device_list returns the attached device
+
+**Script:** cicd/tests/testcases/smoke/TC-SMK-001.yml
+
+| Action | Expected Result |
+|---|---|
+| List attached devices | The result contains the connected Android device (serial present) |
+
+## TC-02 — wifi_status reflects real radio + connection state
+
+**Script:** cicd/tests/testcases/smoke/TC-SMK-003.yml
+
+| Action | Expected Result |
+|---|---|
+| Read WiFi status while connected | Reports the radio **enabled** and **connected** to the current SSID |
+
+## TC-03 — wifi_scan returns real networks
+
+**Script:** cicd/tests/testcases/smoke/TC-SMK-004.yml
+
+| Action | Expected Result |
+|---|---|
+| Scan for WiFi networks | The result contains **at least one** network from the surrounding environment |
+
+## TC-04 — device_settings put/get/delete round-trips
+
+**Script:** cicd/tests/testcases/smoke/TC-SMK-009.yml
+
+| Action | Expected Result |
+|---|---|
+| Put a sentinel key, get it, delete it, get again | Put succeeds and the value reads back; after delete it reads null — a real state change, then cleaned up |
+
+## TC-05 — push/pull preserves file bytes
+
+**Script:** cicd/tests/testcases/smoke/TC-SMK-010.yml
+
+| Action | Expected Result |
+|---|---|
+| Push a host file to the device, pull it back | The round-tripped file is **byte-equal** to the original |
+
+## TC-06 — device_screenshot writes a real PNG
+
+**Script:** cicd/tests/testcases/smoke/TC-SMK-011.yml
+
+| Action | Expected Result |
+|---|---|
+| Capture a screenshot to a host path | The file exists, is non-empty, and is a valid PNG |
+
+## TC-07 — push/pull failure paths surface clean errors
+
+**Script:** cicd/tests/testcases/smoke/TC-SMK-012.yml
+
+| Action | Expected Result |
+|---|---|
+| Push/pull with a bad path | Each call returns `success: false` with `isError: true` — a clean structured error, not a throw or hang |
+
+## TC-08 — device_event_log returns the attach/detach ring
+
+**Script:** cicd/tests/testcases/smoke/TC-SMK-017.yml
+
+| Action | Expected Result |
+|---|---|
+| Read the device event log | The result is the attach/detach transition ring for the device |
+
+## TC-09 — device_select selects a device by serial
+
+**Script:** cicd/tests/testcases/smoke/TC-SMK-018.yml
+
+| Action | Expected Result |
+|---|---|
+| Select a device by its serial | The named device becomes the active target for subsequent tool calls |

--- a/docs/tests/STORY-004/TS-04-inspection-and-management-tools.md
+++ b/docs/tests/STORY-004/TS-04-inspection-and-management-tools.md
@@ -90,3 +90,9 @@ All cases are bound and run green in the smoke suite against an attached device.
 | Action | Expected Result |
 |---|---|
 | Select a device by its serial | The named device becomes the active target for subsequent tool calls |
+
+## TC-10 — device_info reports the device's real Android version (to-be)
+
+| Action | Expected Result |
+|---|---|
+| Read device info | Reports a real SDK / Android version for the connected device (SDK ≥ 30) — verified against the actual device, not just field presence. The prior shape-only test was removed; a meaningful assertion is still to write. |

--- a/docs/tests/STORY-004/TS-05-logging.md
+++ b/docs/tests/STORY-004/TS-05-logging.md
@@ -1,0 +1,23 @@
+---
+id: TS-05
+title: query_log returns the tool-call audit trail
+namespace: logging
+story: STORY-004
+plan: 120
+issue: 128
+status: green
+---
+
+# TS-05: query_log returns the tool-call audit trail
+
+**Objective:** `query_log` returns the structured record of tool calls the server made —
+a real audit trail, not a well-shaped empty response — so a run can be inspected after
+the fact.
+
+## TC-01 — query_log returns structured tool-call rows
+
+**Script:** cicd/tests/testcases/logging/TC-LOG-001.yml
+
+| Action | Expected Result |
+|---|---|
+| After some tool calls, query the log | The result contains structured rows for the calls made (tool name, timing) — the audit trail reflects real activity |

--- a/docs/tests/STORY-004/TS-06-message-capture.md
+++ b/docs/tests/STORY-004/TS-06-message-capture.md
@@ -1,0 +1,44 @@
+---
+id: TS-06
+title: Message-capture tools read the inbox and wait for OTPs
+namespace: messaging
+story: STORY-004
+plan: 120
+issue: 128
+status: green
+---
+
+# TS-06: Message-capture tools read the inbox and wait for OTPs
+
+**Objective:** The message-capture tools (`sms_read_recent`, `sms_wait_for_otp`,
+`notifications_list_recent`, `notifications_wait_for_otp`) — used to grab a one-time code
+during an auth flow — behave correctly: the wait tools return cleanly on a bounded timeout
+when no code arrives, and the read tools return real inbox/notification state.
+
+## TC-01 — sms_wait_for_otp times out cleanly
+
+**Script:** cicd/tests/testcases/sms/TC-SMS-003.yml
+
+| Action | Expected Result |
+|---|---|
+| Wait for an OTP with a short timeout when no message arrives | The call returns cleanly at the timeout — no hang, no crash — reporting no code found |
+
+## TC-02 — notifications_wait_for_otp times out cleanly
+
+**Script:** cicd/tests/testcases/notifications/TC-NOTIF-002.yml
+
+| Action | Expected Result |
+|---|---|
+| Wait for an OTP notification with a short timeout when none arrives | The call returns cleanly at the timeout — no hang, no crash |
+
+## TC-03 — sms_read_recent returns a real inbox message (to-be)
+
+| Action | Expected Result |
+|---|---|
+| Read recent SMS on a device with a known message present | The result contains that message — verified against a real inbox, not just the response shape. Needs a message fixture; until then `sms_read_recent` has no meaningful test. |
+
+## TC-04 — notifications_list_recent returns a real notification (to-be)
+
+| Action | Expected Result |
+|---|---|
+| List recent notifications with a known notification posted | The result contains that notification — verified against real state, not just the shape. Needs a notification fixture; until then `notifications_list_recent` has no meaningful test. |


### PR DESCRIPTION
## Summary
Follow-up to #181 — close the chain gaps the new derived `qw-drift` surfaced, by **binding every behavior test to the story that owns its need** (no new stories, no coverage file):

- **STORY-004/TS-01** +TC-05/06 → open + WPA3/SAE connects (TC-WIFI-003/006)
- **STORY-004/TS-03** +TC-04/05/06 → internet / interface-IP / captive (TC-SMK-006/007/014)
- **STORY-004/TS-04** (new) → device + read tools: list/settings/push-pull/screenshot/event-log/select/wifi-status/wifi-scan (TC-SMK-001/003/004/009/010/011/012/017/018); +TC-10 `device_info` (to-be)
- **STORY-004/TS-05** (new) → `query_log` audit trail (TC-LOG-001)
- **STORY-004/TS-06** (new) → message-capture: sms/notif wait-for-otp timeout (TC-SMS-003, TC-NOTIF-002); `sms_read_recent` / `notifications_list_recent` as (to-be)
- **STORY-002/TS-05** → bind TC-01 → TC-ENT-001 (WPA2-Ent), TC-02 → TC-NOTIF-005 (companion)
- **STORY-001/TS-08** (new) → the proxy composes upstream MCP servers (TC-PROXY-001/002/003)

## Result
`drift`: **26 → 4 gaps, 0 orphan** (audit-bind 31 bound, 0 unbound). The last 4 are genuine infra/fixture work, not binding:
- 3 read/info tools (`device_info`, `sms_read_recent`, `notifications_list_recent`) with no meaningful test without a fixture — homed as (to-be)
- the `logging` suite's CI Postgres wiring (`test-logging.yml`) — TC-LOG-001's own "(to-be) until wired into CI with a database"

Related to #181

Generated with [Claude Code](https://claude.com/claude-code)